### PR TITLE
Close file descriptor of event loop's semaphore on exec

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ References/documentation
 Contributing
 ------------
 
-Contributions that increase the library quality, functionality, or fix issues are very welcome. To introduce a change, please submit a merge request with a description.
+Contributions that increase the library quality, functionality, or fix issues are very welcome. To introduce a change, please submit a pull request with a description.
 
 Contact
 -------

--- a/src/Connection.cpp
+++ b/src/Connection.cpp
@@ -59,7 +59,7 @@ Connection::Connection(Connection::BusType type)
     if (r < 0)
         SDBUS_THROW_ERROR("Failed to flush system bus on opening", -r);
 
-    r = eventfd(0, EFD_SEMAPHORE);
+    r = eventfd(0, EFD_SEMAPHORE | EFD_CLOEXEC);
     SDBUS_THROW_ERROR_IF(r < 0, "Failed to create event object", -errno);
     runFd_ = r;
 }


### PR DESCRIPTION
File descriptor belonging to event loop's semaphore need to be closed on exec, else the loaded program might use it inadvertently - when forking, the child process might interfere with the event loop.