### PR TITLE
Fix proposal for clang compilation issue

### DIFF
--- a/include/sdbus-c++/Types.h
+++ b/include/sdbus-c++/Types.h
@@ -97,6 +97,9 @@ namespace sdbus {
     public:
         using std::tuple<_ValueTypes...>::tuple;
 
+        Struct(const std::tuple<_ValueTypes...>& t)
+            : std::tuple<_ValueTypes...>(t) {}
+
         template <std::size_t _I>
         auto& get()
         {

--- a/test/unittests/Types_test.cpp
+++ b/test/unittests/Types_test.cpp
@@ -203,3 +203,12 @@ TEST(CopiesOfVariant, SerializeToAndDeserializeFromMessageSuccessfully)
     ASSERT_THAT(receivedVariant2.get<decltype(value)>(), Eq(value));
     ASSERT_THAT(receivedVariant3.get<decltype(value)>(), Eq(value));
 }
+
+TEST(AStruct, CreatesStructFromTuple)
+{
+    std::tuple<int32_t, std::string> value{1234, "abcd"};
+    sdbus::Struct<int32_t, std::string> valueStruct{value};
+
+    ASSERT_THAT(std::get<0>(valueStruct), Eq(std::get<0>(value)));
+    ASSERT_THAT(std::get<1>(valueStruct), Eq(std::get<1>(value)));
+}


### PR DESCRIPTION
Added a test example where sdbus::Struct fails to compile with clang (tested with clang 4 & 5):

```
| ../../git/test/unittests/Types_test.cpp:210:41: error: no matching constructor for initialization of 'sdbus::Struct<int32_t, std::string>' (aka 'Struct<int, basic_string<char> >')
|     sdbus::Struct<int32_t, std::string> valueStruct{value};
|                                         ^          ~~~~~~~
| ../../git/include/sdbus-c++/Types.h:94:11: note: candidate constructor (the implicit move constructor) not viable: no known conversion from 'std::tuple<int32_t, std::string>' (aka 'tuple<int, basic_string<char> >') to 'sdbus::Struct<int, std::__cxx11::basic_string<char> >' for 1st argument
|     class Struct
|           ^
| ../../git/include/sdbus-c++/Types.h:94:11: note: candidate constructor (the implicit copy constructor) not viable: no known conversion from 'std::tuple<int32_t, std::string>' (aka 'tuple<int, basic_string<char> >') to 'const sdbus::Struct<int, std::__cxx11::basic_string<char> >' for 1st argument
| /home/kistler/work/skybase-build-clang/yocto/yocto-build/tmp/work/cortexa8hf-neon-poky-linux-gnueabi/sdbus-c++/0.2.3-r3/recipe-sysroot/usr/lib//arm-poky-linux-gnueabi/6.3.0/../../../include/c++/6.3.0/tuple:959:28: note: candidate template ignored: requirement '!_TMC::template _ImplicitlyConvertibleTuple<int, std::__cxx11::basic_string<char> >()' was not satisfied [with _U1 = int, _U2 = std::__cxx11::basic_string<char>]
|         explicit constexpr tuple(const tuple<_U1, _U2>& __in)
|                            ^
| /home/kistler/work/skybase-build-clang/yocto/yocto-build/tmp/work/cortexa8hf-neon-poky-linux-gnueabi/sdbus-c++/0.2.3-r3/recipe-sysroot/usr/lib//arm-poky-linux-gnueabi/6.3.0/../../../include/c++/6.3.0/tuple:1014:28: note: candidate template ignored: could not match 'pair' against 'tuple'
|         explicit constexpr tuple(pair<_U1, _U2>&& __in)
|                            ^
| /home/kistler/work/skybase-build-clang/yocto/yocto-build/tmp/work/cortexa8hf-neon-poky-linux-gnueabi/sdbus-c++/0.2.3-r3/recipe-sysroot/usr/lib//arm-poky-linux-gnueabi/6.3.0/../../../include/c++/6.3.0/tuple:977:28: note: candidate template ignored: requirement '!_TMC::template _ImplicitlyMoveConvertibleTuple<int, std::__cxx11::basic_string<char> >()' was not satisfied [with _U1 = int, _U2 = std::__cxx11::basic_string<char>]
|         explicit constexpr tuple(tuple<_U1, _U2>&& __in)
|                            ^
| /home/kistler/work/skybase-build-clang/yocto/yocto-build/tmp/work/cortexa8hf-neon-poky-linux-gnueabi/sdbus-c++/0.2.3-r3/recipe-sysroot/usr/lib//arm-poky-linux-gnueabi/6.3.0/../../../include/c++/6.3.0/tuple:986:19: note: candidate template ignored: could not match 'pair' against 'tuple'
|         constexpr tuple(const pair<_U1, _U2>& __in)
|                   ^
| /home/kistler/work/skybase-build-clang/yocto/yocto-build/tmp/work/cortexa8hf-neon-poky-linux-gnueabi/sdbus-c++/0.2.3-r3/recipe-sysroot/usr/lib//arm-poky-linux-gnueabi/6.3.0/../../../include/c++/6.3.0/tuple:995:28: note: candidate template ignored: could not match 'pair' against 'tuple'
|         explicit constexpr tuple(const pair<_U1, _U2>& __in)
|                            ^
| /home/kistler/work/skybase-build-clang/yocto/yocto-build/tmp/work/cortexa8hf-neon-poky-linux-gnueabi/sdbus-c++/0.2.3-r3/recipe-sysroot/usr/lib//arm-poky-linux-gnueabi/6.3.0/../../../include/c++/6.3.0/tuple:1004:19: note: candidate template ignored: could not match 'pair' against 'tuple'
|         constexpr tuple(pair<_U1, _U2>&& __in)
|                   ^
| /home/kistler/work/skybase-build-clang/yocto/yocto-build/tmp/work/cortexa8hf-neon-poky-linux-gnueabi/sdbus-c++/0.2.3-r3/recipe-sysroot/usr/lib//arm-poky-linux-gnueabi/6.3.0/../../../include/c++/6.3.0/tuple:906:19: note: candidate inherited constructor template not viable: requires 2 arguments, but 1 was provided
|         constexpr tuple(const _T1& __a1, const _T2& __a2)
|                   ^
| ../../git/include/sdbus-c++/Types.h:98:43: note: constructor from base class 'tuple<int, std::__cxx11::basic_string<char> >' inherited here
|         using std::tuple<_ValueTypes...>::tuple;
|                                           ^
| /home/kistler/work/skybase-build-clang/yocto/yocto-build/tmp/work/cortexa8hf-neon-poky-linux-gnueabi/sdbus-c++/0.2.3-r3/recipe-sysroot/usr/lib//arm-poky-linux-gnueabi/6.3.0/../../../include/c++/6.3.0/tuple:915:28: note: candidate inherited constructor template not viable: requires 2 arguments, but 1 was provided
|         explicit constexpr tuple(const _T1& __a1, const _T2& __a2)
|                            ^
| ../../git/include/sdbus-c++/Types.h:98:43: note: constructor from base class 'tuple<int, std::__cxx11::basic_string<char> >' inherited here
|         using std::tuple<_ValueTypes...>::tuple;
|                                           ^
| /home/kistler/work/skybase-build-clang/yocto/yocto-build/tmp/work/cortexa8hf-neon-poky-linux-gnueabi/sdbus-c++/0.2.3-r3/recipe-sysroot/usr/lib//arm-poky-linux-gnueabi/6.3.0/../../../include/c++/6.3.0/tuple:928:19: note: candidate inherited constructor template not viable: requires 2 arguments, but 1 was provided
|         constexpr tuple(_U1&& __a1, _U2&& __a2)
|                   ^
| ../../git/include/sdbus-c++/Types.h:98:43: note: constructor from base class 'tuple<int, std::__cxx11::basic_string<char> >' inherited here
|         using std::tuple<_ValueTypes...>::tuple;
|                                           ^
| /home/kistler/work/skybase-build-clang/yocto/yocto-build/tmp/work/cortexa8hf-neon-poky-linux-gnueabi/sdbus-c++/0.2.3-r3/recipe-sysroot/usr/lib//arm-poky-linux-gnueabi/6.3.0/../../../include/c++/6.3.0/tuple:937:28: note: candidate inherited constructor template not viable: requires 2 arguments, but 1 was provided
|         explicit constexpr tuple(_U1&& __a1, _U2&& __a2)
|                            ^
| ../../git/include/sdbus-c++/Types.h:98:43: note: constructor from base class 'tuple<int, std::__cxx11::basic_string<char> >' inherited here
|         using std::tuple<_ValueTypes...>::tuple;
|                                           ^
| /home/kistler/work/skybase-build-clang/yocto/yocto-build/tmp/work/cortexa8hf-neon-poky-linux-gnueabi/sdbus-c++/0.2.3-r3/recipe-sysroot/usr/lib//arm-poky-linux-gnueabi/6.3.0/../../../include/c++/6.3.0/tuple:1032:2: note: candidate inherited constructor template not viable: requires 4 arguments, but 1 was provided
|         tuple(allocator_arg_t __tag, const _Alloc& __a,
|         ^
| ../../git/include/sdbus-c++/Types.h:98:43: note: constructor from base class 'tuple<int, std::__cxx11::basic_string<char> >' inherited here
|         using std::tuple<_ValueTypes...>::tuple;
|                                           ^
| /home/kistler/work/skybase-build-clang/yocto/yocto-build/tmp/work/cortexa8hf-neon-poky-linux-gnueabi/sdbus-c++/0.2.3-r3/recipe-sysroot/usr/lib//arm-poky-linux-gnueabi/6.3.0/../../../include/c++/6.3.0/tuple:878:17: note: candidate inherited constructor template not viable: requires 0 arguments, but 1 was provided
|       constexpr tuple()
|                 ^
| ../../git/include/sdbus-c++/Types.h:98:43: note: constructor from base class 'tuple<int, std::__cxx11::basic_string<char> >' inherited here
|         using std::tuple<_ValueTypes...>::tuple;
|                                           ^
| /home/kistler/work/skybase-build-clang/yocto/yocto-build/tmp/work/cortexa8hf-neon-poky-linux-gnueabi/sdbus-c++/0.2.3-r3/recipe-sysroot/usr/lib//arm-poky-linux-gnueabi/6.3.0/../../../include/c++/6.3.0/tuple:1021:2: note: candidate inherited constructor template not viable: requires 2 arguments, but 1 was provided
|         tuple(allocator_arg_t __tag, const _Alloc& __a)
|         ^
| ../../git/include/sdbus-c++/Types.h:98:43: note: constructor from base class 'tuple<int, std::__cxx11::basic_string<char> >' inherited here
|         using std::tuple<_ValueTypes...>::tuple;
|                                           ^
| /home/kistler/work/skybase-build-clang/yocto/yocto-build/tmp/work/cortexa8hf-neon-poky-linux-gnueabi/sdbus-c++/0.2.3-r3/recipe-sysroot/usr/lib//arm-poky-linux-gnueabi/6.3.0/../../../include/c++/6.3.0/tuple:1095:11: note: candidate inherited constructor template not viable: requires 3 arguments, but 1 was provided
|         explicit tuple(allocator_arg_t __tag, const _Alloc& __a,
|                  ^
| ../../git/include/sdbus-c++/Types.h:98:43: note: constructor from base class 'tuple<int, std::__cxx11::basic_string<char> >' inherited here
|         using std::tuple<_ValueTypes...>::tuple;
|                                           ^
| /home/kistler/work/skybase-build-clang/yocto/yocto-build/tmp/work/cortexa8hf-neon-poky-linux-gnueabi/sdbus-c++/0.2.3-r3/recipe-sysroot/usr/lib//arm-poky-linux-gnueabi/6.3.0/../../../include/c++/6.3.0/tuple:892:26: note: candidate inherited constructor template not viable: requires 0 arguments, but 1 was provided
|       explicit constexpr tuple()
|                          ^
| ../../git/include/sdbus-c++/Types.h:98:43: note: constructor from base class 'tuple<int, std::__cxx11::basic_string<char> >' inherited here
|         using std::tuple<_ValueTypes...>::tuple;
|                                           ^
| /home/kistler/work/skybase-build-clang/yocto/yocto-build/tmp/work/cortexa8hf-neon-poky-linux-gnueabi/sdbus-c++/0.2.3-r3/recipe-sysroot/usr/lib//arm-poky-linux-gnueabi/6.3.0/../../../include/c++/6.3.0/tuple:1044:11: note: candidate inherited constructor template not viable: requires 4 arguments, but 1 was provided
|         explicit tuple(allocator_arg_t __tag, const _Alloc& __a,
|                  ^
| ../../git/include/sdbus-c++/Types.h:98:43: note: constructor from base class 'tuple<int, std::__cxx11::basic_string<char> >' inherited here
|         using std::tuple<_ValueTypes...>::tuple;
|                                           ^
| /home/kistler/work/skybase-build-clang/yocto/yocto-build/tmp/work/cortexa8hf-neon-poky-linux-gnueabi/sdbus-c++/0.2.3-r3/recipe-sysroot/usr/lib//arm-poky-linux-gnueabi/6.3.0/../../../include/c++/6.3.0/tuple:arm-poky-linux-gnueabi-clang++ -march=armv7-a -mfpu=neon -mfloat-abi=hard -mcpu=cortex-a8 -mlittle-endian -D__extern_always_inline=inline -no-integrated-as -Wno-error=unused-command-line-argument -Qunused-arguments --sysroot=/home/kistler/work/skybase-build-clang/yocto/yocto-build/tmp/work/cortexa8hf-neon-poky-linux-gnueabi/sdbus-c++/0.2.3-r3/recipe-sysroot -DHAVE_CONFIG_H -I. -I../../git/test -I..  -I../../git/include -I../../git/src  -W -Wall -Werror -pedantic -pipe -std=c++14 -O2 -pipe -g -feliminate-unused-debug-types -fdebug-prefix-map=/home/kistler/work/skybase-build-clang/yocto/yocto-build/tmp/work/cortexa8hf-neon-poky-linux-gnueabi/sdbus-c++/0.2.3-r3=/usr/src/debug/sdbus-c++/0.2.3-r3 -fdebug-prefix-map=/home/kistler/work/skybase-build-clang/yocto/yocto-build/tmp/work/cortexa8hf-neon-poky-linux-gnueabi/sdbus-c++/0.2.3-r3/recipe-sysroot-native= -fdebug-prefix-map=/home/kistler/work/skybase-build-clang/yocto/yocto-build/tmp/work/cortexa8hf-neon-poky-linux-gnueabi/sdbus-c++/0.2.3-r3/recipe-sysroot=  -fvisibility-inlines-hidden -c -o integrationtests/libsdbus-c++_integrationtests.o ../../git/test/integrationtests/libsdbus-c++_integrationtests.cpp
| 1054:2: note: candidate inherited constructor template not viable: requires 4 arguments, but 1 was provided
|         tuple(allocator_arg_t __tag, const _Alloc& __a, _U1&& __a1, _U2&& __a2)
|         ^
| ../../git/include/sdbus-c++/Types.h:98:43: note: constructor from base class 'tuple<int, std::__cxx11::basic_string<char> >' inherited here
|         using std::tuple<_ValueTypes...>::tuple;
|                                           ^
| /home/kistler/work/skybase-build-clang/yocto/yocto-build/tmp/work/cortexa8hf-neon-poky-linux-gnueabi/sdbus-c++/0.2.3-r3/recipe-sysroot/usr/lib//arm-poky-linux-gnueabi/6.3.0/../../../include/c++/6.3.0/tuple:1064:11: note: candidate inherited constructor template not viable: requires 4 arguments, but 1 was provided
|         explicit tuple(allocator_arg_t __tag, const _Alloc& __a,
|                  ^
| ../../git/include/sdbus-c++/Types.h:98:43: note: constructor from base class 'tuple<int, std::__cxx11::basic_string<char> >' inherited here
|         using std::tuple<_ValueTypes...>::tuple;
|                                           ^
| /home/kistler/work/skybase-build-clang/yocto/yocto-build/tmp/work/cortexa8hf-neon-poky-linux-gnueabi/sdbus-c++/0.2.3-r3/recipe-sysroot/usr/lib//arm-poky-linux-gnueabi/6.3.0/../../../include/c++/6.3.0/tuple:1070:2: note: candidate inherited constructor template not viable: requires 3 arguments, but 1 was provided
|         tuple(allocator_arg_t __tag, const _Alloc& __a, const tuple& __in)
|         ^
| ../../git/include/sdbus-c++/Types.h:98:43: note: constructor from base class 'tuple<int, std::__cxx11::basic_string<char> >' inherited here
|         using std::tuple<_ValueTypes...>::tuple;
|                                           ^
| /home/kistler/work/skybase-build-clang/yocto/yocto-build/tmp/work/cortexa8hf-neon-poky-linux-gnueabi/sdbus-c++/0.2.3-r3/recipe-sysroot/usr/lib//arm-poky-linux-gnueabi/6.3.0/../../../include/c++/6.3.0/tuple:1074:2: note: candidate inherited constructor template not viable: requires 3 arguments, but 1 was provided
|         tuple(allocator_arg_t __tag, const _Alloc& __a, tuple&& __in)
|         ^
| ../../git/include/sdbus-c++/Types.h:98:43: note: constructor from base class 'tuple<int, std::__cxx11::basic_string<char> >' inherited here
|         using std::tuple<_ValueTypes...>::tuple;
|                                           ^
| /home/kistler/work/skybase-build-clang/yocto/yocto-build/tmp/work/cortexa8hf-neon-poky-linux-gnueabi/sdbus-c++/0.2.3-r3/recipe-sysroot/usr/lib//arm-poky-linux-gnueabi/6.3.0/../../../include/c++/6.3.0/tuple:1083:2: note: candidate inherited constructor template not viable: requires 3 arguments, but 1 was provided
|         tuple(allocator_arg_t __tag, const _Alloc& __a,
|         ^
| ../../git/include/sdbus-c++/Types.h:98:43: note: constructor from base class 'tuple<int, std::__cxx11::basic_string<char> >' inherited here
|         using std::tuple<_ValueTypes...>::tuple;
|                                           ^
| /home/kistler/work/skybase-build-clang/yocto/yocto-build/tmp/work/cortexa8hf-neon-poky-linux-gnueabi/sdbus-c++/0.2.3-r3/recipe-sysroot/usr/lib//arm-poky-linux-gnueabi/6.3.0/../../../include/c++/6.3.0/tuple:1107:2: note: candidate inherited constructor template not viable: requires 3 arguments, but 1 was provided
|         tuple(allocator_arg_t __tag, const _Alloc& __a, tuple<_U1, _U2>&& __in)
|         ^
| ../../git/include/sdbus-c++/Types.h:98:43: note: constructor from base class 'tuple<int, std::__cxx11::basic_string<char> >' inherited here
|         using std::tuple<_ValueTypes...>::tuple;
|                                           ^
| /home/kistler/work/skybase-build-clang/yocto/yocto-build/tmp/work/cortexa8hf-neon-poky-linux-gnueabi/sdbus-c++/0.2.3-r3/recipe-sysroot/usr/lib//arm-poky-linux-gnueabi/6.3.0/../../../include/c++/6.3.0/tuple:1117:11: note: candidate inherited constructor template not viable: requires 3 arguments, but 1 was provided
|         explicit tuple(allocator_arg_t __tag, const _Alloc& __a,
|                  ^
| ../../git/include/sdbus-c++/Types.h:98:43: note: constructor from base class 'tuple<int, std::__cxx11::basic_string<char> >' inherited here
|         using std::tuple<_ValueTypes...>::tuple;
|                                           ^
| /home/kistler/work/skybase-build-clang/yocto/yocto-build/tmp/work/cortexa8hf-neon-poky-linux-gnueabi/sdbus-c++/0.2.3-r3/recipe-sysroot/usr/lib//arm-poky-linux-gnueabi/6.3.0/../../../include/c++/6.3.0/tuple:1128:9: note: candidate inherited constructor template not viable: requires 3 arguments, but 1 was provided
|         tuple(allocator_arg_t __tag, const _Alloc& __a,
|         ^
| ../../git/include/sdbus-c++/Types.h:98:43: note: constructor from base class 'tuple<int, std::__cxx11::basic_string<char> >' inherited here
|         using std::tuple<_ValueTypes...>::tuple;
|                                           ^
| /home/kistler/work/skybase-build-clang/yocto/yocto-build/tmp/work/cortexa8hf-neon-poky-linux-gnueabi/sdbus-c++/0.2.3-r3/recipe-sysroot/usr/lib//arm-poky-linux-gnueabi/6.3.0/../../../include/c++/6.3.0/tuple:1138:18: note: candidate inherited constructor template not viable: requires 3 arguments, but 1 was provided
|         explicit tuple(allocator_arg_t __tag, const _Alloc& __a,
|                  ^
| ../../git/include/sdbus-c++/Types.h:98:43: note: constructor from base class 'tuple<int, std::__cxx11::basic_string<char> >' inherited here
|         using std::tuple<_ValueTypes...>::tuple;
|                                           ^
| /home/kistler/work/skybase-build-clang/yocto/yocto-build/tmp/work/cortexa8hf-neon-poky-linux-gnueabi/sdbus-c++/0.2.3-r3/recipe-sysroot/usr/lib//arm-poky-linux-gnueabi/6.3.0/../../../include/c++/6.3.0/tuple:1148:9: note: candidate inherited constructor template not viable: requires 3 arguments, but 1 was provided
|         tuple(allocator_arg_t __tag, const _Alloc& __a, pair<_U1, _U2>&& __in)
|         ^
| ../../git/include/sdbus-c++/Types.h:98:43: note: constructor from base class 'tuple<int, std::__cxx11::basic_string<char> >' inherited here
|         using std::tuple<_ValueTypes...>::tuple;
|                                           ^
| /home/kistler/work/skybase-build-clang/yocto/yocto-build/tmp/work/cortexa8hf-neon-poky-linux-gnueabi/sdbus-c++/0.2.3-r3/recipe-sysroot/usr/lib//arm-poky-linux-gnueabi/6.3.0/../../../include/c++/6.3.0/tuple:1158:18: note: candidate inherited constructor template not viable: requires 3 arguments, but 1 was provided
|         explicit tuple(allocator_arg_t __tag, const _Alloc& __a,
|                  ^
| ../../git/include/sdbus-c++/Types.h:98:43: note: constructor from base class 'tuple<int, std::__cxx11::basic_string<char> >' inherited here
|         using std::tuple<_ValueTypes...>::tuple;
|                                           ^
| /home/kistler/work/skybase-build-clang/yocto/yocto-build/tmp/work/cortexa8hf-neon-poky-linux-gnueabi/sdbus-c++/0.2.3-r3/recipe-sysroot/usr/lib//arm-poky-linux-gnueabi/6.3.0/../../../include/c++/6.3.0/tuple:950:19: note: candidate template ignored: inherited constructor cannot be used to copy object
|         constexpr tuple(const tuple<_U1, _U2>& __in)
|                   ^
| ../../git/include/sdbus-c++/Types.h:98:43: note: constructor from base class 'tuple<int, std::__cxx11::basic_string<char> >' inherited here
|         using std::tuple<_ValueTypes...>::tuple;
|                                           ^
| /home/kistler/work/skybase-build-clang/yocto/yocto-build/tmp/work/cortexa8hf-neon-poky-linux-gnueabi/sdbus-c++/0.2.3-r3/recipe-sysroot/usr/lib//arm-poky-linux-gnueabi/6.3.0/../../../include/c++/6.3.0/tuple:968:19: note: candidate template ignored: inherited constructor cannot be used to move object
|         constexpr tuple(tuple<_U1, _U2>&& __in)
|                   ^
| ../../git/include/sdbus-c++/Types.h:98:43: note: constructor from base class 'tuple<int, std::__cxx11::basic_string<char> >' inherited here
|         using std::tuple<_ValueTypes...>::tuple;
|                                           ^
| ../../git/include/sdbus-c++/Types.h:94:11: note: candidate constructor (the implicit default constructor) not viable: requires 0 arguments, but 1 was provided
|     class Struct
|           ^
| 1 error generated.
```
