### PR TITLE
Fix CPU hog on async methods

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -25,8 +25,8 @@ AC_PROG_INSTALL
 # enable pkg-config
 PKG_PROG_PKG_CONFIG
 
-PKG_CHECK_MODULES(SYSTEMD, [libsystemd >= 0.10.1],,
-    AC_MSG_ERROR([You need the libsystemd library (version 0.10.1 or better)]
+PKG_CHECK_MODULES(SYSTEMD, [libsystemd >= 236],,
+    AC_MSG_ERROR([You need the libsystemd library (version 236 or newer)]
     [https://www.freedesktop.org/wiki/Software/systemd/])
 )
 

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -29,7 +29,7 @@ unittests/TypeTraits_test.cpp \
 unittests/Types_test.cpp \
 unittests/Message_test.cpp
 
-libsdbus_c___unittests_LDFLAGS = -L$(top_builddir)/src
+libsdbus_c___unittests_LDFLAGS = -L$(top_builddir)/src -pthread
 
 libsdbus_c___unittests_LDADD = \
 	-lsdbus-c++ \
@@ -45,14 +45,13 @@ integrationtests/libsdbus-c++_integrationtests.cpp \
 integrationtests/Connection_test.cpp \
 integrationtests/AdaptorAndProxy_test.cpp
 
-libsdbus_c___integrationtests_LDFLAGS = -L$(top_builddir)/src
+libsdbus_c___integrationtests_LDFLAGS = -L$(top_builddir)/src -pthread
 
 libsdbus_c___integrationtests_LDADD = \
 	-lsdbus-c++ \
 	@libsdbus_cpp_LIBS@  \
 	@SYSTEMD_LIBS@ \
-	-lgmock \
-	-lpthread
+	-lgmock
 
 TESTS += libsdbus-c++_integrationtests
 

--- a/test/integrationtests/TestingAdaptor.h
+++ b/test/integrationtests/TestingAdaptor.h
@@ -107,12 +107,20 @@ protected:
 
     void doOperationAsync(uint32_t param, sdbus::Result<uint32_t> result)
     {
-        // The same as doOperationSync, just written as an asynchronous method callback
-        std::thread([param, result = std::move(result)]()
+        if (param == 0)
         {
-            std::this_thread::sleep_for(std::chrono::milliseconds(param));
+            // Don't sleep and return the result from this thread
             result.returnResults(param);
-        }).detach();
+        }
+        else
+        {
+            // Process asynchronously in another thread and return the result from there
+            std::thread([param, result = std::move(result)]()
+            {
+                std::this_thread::sleep_for(std::chrono::milliseconds(param));
+                result.returnResults(param);
+            }).detach();
+        }
     }
 
     sdbus::Signature getSignature() const { return SIGNATURE_VALUE; }


### PR DESCRIPTION
The eventfd descriptor was forgotten to be read from by the consumer, causing poll to always signal readiness for reading.