### PR TITLE
- Rewind Message prior to access for peekValueType.

### DIFF
--- a/src/Types.cpp
+++ b/src/Types.cpp
@@ -51,6 +51,7 @@ void Variant::deserializeFrom(Message& msg)
 
 std::string Variant::peekValueType() const
 {
+    msg_.rewind(false);
     std::string type;
     std::string contents;
     msg_.peekType(type, contents);


### PR DESCRIPTION
Fixes #8

(cherry picked from commit f8bed4b0faa2c0a2bc7037f3a55105060d56dbdb)