### PR TITLE
Add ability to declare property behavior on PropertyChanged signal

### DIFF
--- a/include/sdbus-c++/ConvenienceClasses.h
+++ b/include/sdbus-c++/ConvenienceClasses.h
@@ -74,6 +74,13 @@ namespace sdbus {
         int exceptions_{}; // Number of active exceptions when SignalRegistrator is constructed
     };
 
+    enum class PropertyUpdateBehavior {
+        Default,
+        EmitsChange,
+        EmitsInvalidation,
+        Constant
+    };
+
     class PropertyRegistrator
     {
     public:
@@ -82,6 +89,7 @@ namespace sdbus {
         PropertyRegistrator& operator=(PropertyRegistrator&& other) = default;
         ~PropertyRegistrator() noexcept(false);
         PropertyRegistrator& onInterface(const std::string& interfaceName);
+        PropertyRegistrator& withUpdateBehavior(PropertyUpdateBehavior behavior);
         template <typename _Function> PropertyRegistrator& withGetter(_Function&& callback);
         template <typename _Function> PropertyRegistrator& withSetter(_Function&& callback);
 
@@ -92,7 +100,9 @@ namespace sdbus {
         std::string propertySignature_;
         property_get_callback getter_;
         property_set_callback setter_;
+        PropertyUpdateBehavior behavior_;
         int exceptions_{}; // Number of active exceptions when PropertyRegistrator is constructed
+
     };
 
     class SignalEmitter

--- a/include/sdbus-c++/ConvenienceClasses.inl
+++ b/include/sdbus-c++/ConvenienceClasses.inl
@@ -191,6 +191,13 @@ namespace sdbus {
         return *this;
     }
 
+    inline PropertyRegistrator& PropertyRegistrator::withUpdateBehavior(PropertyUpdateBehavior policy)
+    {
+        behavior_ = policy;
+
+        return *this;
+    }
+
     template <typename _Function>
     inline PropertyRegistrator& PropertyRegistrator::withGetter(_Function&& callback)
     {

--- a/include/sdbus-c++/IObject.h
+++ b/include/sdbus-c++/IObject.h
@@ -138,6 +138,25 @@ namespace sdbus {
                                      , property_set_callback setCallback ) = 0;
 
         /*!
+        * @brief Registers read/write property that the object will provide on D-Bus
+        *
+        * @param[in] interfaceName Name of an interface that the property will fall under
+        * @param[in] propertyName Name of the property
+        * @param[in] signature D-Bus signature of property parameters
+        * @param[in] getCallback Callback that implements the body of the property getter
+        * @param[in] setCallback Callback that implements the body of the property setter
+        * @param[in] policy Property update behavior
+        *
+        * @throws sdbus::Error in case of failure
+        */
+        virtual void registerProperty(  const std::string& interfaceName
+                                      , const std::string& propertyName
+                                      , const std::string& signature
+                                      , property_get_callback getCallback
+                                      , property_set_callback setCallback
+                                      , PropertyUpdateBehavior policy) = 0;
+
+        /*!
         * @brief Finishes the registration and exports object API on D-Bus
         *
         * The method exports all up to now registered methods, signals and properties on D-Bus.

--- a/src/ConvenienceClasses.cpp
+++ b/src/ConvenienceClasses.cpp
@@ -62,6 +62,7 @@ SignalRegistrator::~SignalRegistrator() noexcept(false) // since C++11, destruct
 PropertyRegistrator::PropertyRegistrator(IObject& object, const std::string& propertyName)
     : object_(object)
     , propertyName_(propertyName)
+    , behavior_(PropertyUpdateBehavior::Default)
     , exceptions_(std::uncaught_exceptions())
 {
 }
@@ -87,7 +88,8 @@ PropertyRegistrator::~PropertyRegistrator() noexcept(false) // since C++11, dest
                             , std::move(propertyName_)
                             , std::move(propertySignature_)
                             , std::move(getter_)
-                            , std::move(setter_) );
+                            , std::move(setter_)
+                            , behavior_);
 }
 
 

--- a/src/Object.h
+++ b/src/Object.h
@@ -72,6 +72,13 @@ namespace internal {
                              , property_get_callback getCallback
                              , property_set_callback setCallback ) override;
 
+        void registerProperty( const std::string& interfaceName
+                             , const std::string& propertyName
+                             , const std::string& signature
+                             , property_get_callback getCallback
+                             , property_set_callback setCallback
+                             , PropertyUpdateBehavior policy) override;
+
         void finishRegistration() override;
 
         sdbus::Signal createSignal(const std::string& interfaceName, const std::string& signalName) override;
@@ -103,6 +110,7 @@ namespace internal {
                 std::string signature_;
                 property_get_callback getCallback_;
                 property_set_callback setCallback_;
+                PropertyUpdateBehavior behavior_;
             };
             std::map<PropertyName, PropertyData> properties_;
             std::vector<sd_bus_vtable> vtable_;

--- a/src/VTableUtils.c
+++ b/src/VTableUtils.c
@@ -50,18 +50,36 @@ sd_bus_vtable createVTableSignalItem( const char *member
 
 sd_bus_vtable createVTablePropertyItem( const char *member
                                       , const char *signature
-                                      , sd_bus_property_get_t getter )
+                                      , sd_bus_property_get_t getter
+                                      , bool isConst)
 {
-    struct sd_bus_vtable vtableItem = SD_BUS_PROPERTY(member, signature, getter, 0, 0);
+    unsigned long long sdbusFlags = 0ULL;
+
+    if (isConst)
+        sdbusFlags |= SD_BUS_VTABLE_PROPERTY_CONST;
+
+    struct sd_bus_vtable vtableItem = SD_BUS_PROPERTY(member, signature, getter, 0, sdbusFlags);
     return vtableItem;
 }
 
 sd_bus_vtable createVTableWritablePropertyItem( const char *member
                                               , const char *signature
                                               , sd_bus_property_get_t getter
-                                              , sd_bus_property_set_t setter )
+                                              , sd_bus_property_set_t setter
+                                              , bool emitsChange
+                                              , bool emitsInvalidation)
 {
-    struct sd_bus_vtable vtableItem = SD_BUS_WRITABLE_PROPERTY(member, signature, getter, setter, 0, 0);
+    unsigned long long sdbusFlags = 0ULL;
+
+    if (emitsChange) {
+        sdbusFlags |= SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE;
+    } else {
+        if (emitsInvalidation) {
+            sdbusFlags |= SD_BUS_VTABLE_PROPERTY_EMITS_INVALIDATION;
+        }
+    }
+
+    struct sd_bus_vtable vtableItem = SD_BUS_WRITABLE_PROPERTY(member, signature, getter, setter, 0, sdbusFlags);
     return vtableItem;
 }
 

--- a/src/VTableUtils.h
+++ b/src/VTableUtils.h
@@ -27,6 +27,7 @@
 #define SDBUS_CXX_INTERNAL_VTABLEUTILS_H_
 
 #include <systemd/sd-bus.h>
+#include <stdbool.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,11 +42,14 @@ sd_bus_vtable createVTableSignalItem( const char *member
                                     , const char *signature );
 sd_bus_vtable createVTablePropertyItem( const char *member
                                       , const char *signature
-                                      , sd_bus_property_get_t getter );
+                                      , sd_bus_property_get_t getter
+                                      , bool isConst);
 sd_bus_vtable createVTableWritablePropertyItem( const char *member
                                               , const char *signature
                                               , sd_bus_property_get_t getter
-                                              , sd_bus_property_set_t setter );
+                                              , sd_bus_property_set_t setter
+                                              , bool emitsChange
+                                              , bool emitsInvalidation);
 sd_bus_vtable createVTableEndItem();
 
 #ifdef __cplusplus


### PR DESCRIPTION
Systemd library has ability to declare behavior on properties with annotations like:
`<annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false|true|const"/>`
This patch adds ability to explicitly specify what behavior do we declare on our property. New functionality related only to object introspection, user still has to emit `org.freedesktop.DBus.Property.PropertiesChanged` signal on his/her own.

