### PR TITLE
Remove warnings-related compiler options from CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,6 @@ set(SDBUSCPP_SRCS ${SDBUSCPP_CPP_SRCS} ${SDBUSCPP_HDR_SRCS} ${SDBUSCPP_PUBLIC_HD
 #-------------------------------
 
 set(CMAKE_CXX_STANDARD 17)
-add_compile_options(-W -Wextra -Wall -Werror -pedantic)
 include_directories("${CMAKE_SOURCE_DIR}/include")
 include_directories("${CMAKE_SOURCE_DIR}/src")
 


### PR DESCRIPTION
These options:

* shall rather come from the user instead of being hard-coded in the project build system,
* if kept hard-coded, they may cause unnecessary compilation errors, like in #28 , due to new (and not always useful, cf. discussion at https://github.com/boostorg/mpl/issues/31#issuecomment-368998776) warnings introduced by new versions of compilers.

Fixes #28 , as the warning (turned to error) there is issued by gcc 8 on a completely valid code.