### PR TITLE
[WIP][RFC] Add owning types for unix file descriptors

### DIFF
--- a/include/sdbus-c++/Message.h
+++ b/include/sdbus-c++/Message.h
@@ -44,7 +44,9 @@ namespace sdbus {
     class ObjectPath;
     class Signature;
     template <typename... _ValueTypes> class Struct;
-    struct UnixFd;
+    struct UnixFdRef;
+    struct UniqueUnixFd;
+    struct AnyUnixFd;
     class MethodReply;
     namespace internal {
         class ISdBus;
@@ -92,7 +94,9 @@ namespace sdbus {
         Message& operator<<(const Variant &item);
         Message& operator<<(const ObjectPath &item);
         Message& operator<<(const Signature &item);
-        Message& operator<<(const UnixFd &item);
+        Message& operator<<(const AnyUnixFd &item);
+        Message& operator<<(const UnixFdRef &item);
+        Message& operator<<(const UniqueUnixFd &item);
 
         Message& operator>>(bool& item);
         Message& operator>>(int16_t& item);
@@ -108,7 +112,8 @@ namespace sdbus {
         Message& operator>>(Variant &item);
         Message& operator>>(ObjectPath &item);
         Message& operator>>(Signature &item);
-        Message& operator>>(UnixFd &item);
+        Message& operator>>(UnixFdRef &item);
+        Message& operator>>(UniqueUnixFd &item);
 
         Message& openContainer(const std::string& signature);
         Message& closeContainer();

--- a/include/sdbus-c++/TypeTraits.h
+++ b/include/sdbus-c++/TypeTraits.h
@@ -34,6 +34,7 @@
 #include <cstdint>
 #include <functional>
 #include <tuple>
+#include <variant>
 
 // Forward declarations
 namespace sdbus {
@@ -41,7 +42,9 @@ namespace sdbus {
     template <typename... _ValueTypes> class Struct;
     class ObjectPath;
     class Signature;
-    struct UnixFd;
+    struct UnixFdRef;
+    struct UniqueUnixFd;
+    struct AnyUnixFd;
     class MethodCall;
     class MethodReply;
     class Signal;
@@ -289,7 +292,29 @@ namespace sdbus {
     };
 
     template <>
-    struct signature_of<UnixFd>
+    struct signature_of<AnyUnixFd>
+    {
+        static constexpr bool is_valid = true;
+
+        static const std::string str()
+        {
+            return "h";
+        }
+    };
+
+    template <>
+    struct signature_of<UnixFdRef>
+    {
+        static constexpr bool is_valid = true;
+
+        static const std::string str()
+        {
+            return "h";
+        }
+    };
+
+    template <>
+    struct signature_of<UniqueUnixFd>
     {
         static constexpr bool is_valid = true;
 

--- a/tools/xml2cpp-codegen/BaseGenerator.cpp
+++ b/tools/xml2cpp-codegen/BaseGenerator.cpp
@@ -105,7 +105,7 @@ std::tuple<unsigned, std::string> BaseGenerator::generateNamespaces(const std::s
 }
 
 
-std::tuple<std::string, std::string, std::string> BaseGenerator::argsToNamesAndTypes(const Nodes& args, bool async) const
+std::tuple<std::string, std::string, std::string> BaseGenerator::argsToNamesAndTypes(const Nodes& args, bool incoming, bool async) const
 {
     std::ostringstream argSS, argTypeSS, typeSS;
 
@@ -124,7 +124,7 @@ std::tuple<std::string, std::string, std::string> BaseGenerator::argsToNamesAndT
         {
             argName = "arg" + std::to_string(i);
         }
-        auto type = signature_to_type(arg->get("type"));
+        auto type = signature_to_type(arg->get("type"), incoming);
         if (!async)
         {
             argSS << argName;
@@ -144,7 +144,7 @@ std::tuple<std::string, std::string, std::string> BaseGenerator::argsToNamesAndT
 /**
  *
  */
-std::string BaseGenerator::outArgsToType(const Nodes& args, bool bareList) const
+std::string BaseGenerator::outArgsToType(const Nodes& args, const StubType& stubType, bool bareList) const
 {
     std::ostringstream retTypeSS;
 
@@ -158,7 +158,7 @@ std::string BaseGenerator::outArgsToType(const Nodes& args, bool bareList) const
     else if (args.size() == 1)
     {
         const auto& arg = *args.begin();
-        retTypeSS << signature_to_type(arg->get("type"));
+        retTypeSS << signature_to_type(arg->get("type"), stubType != StubType::ADAPTOR);
     }
     else if (args.size() >= 2)
     {
@@ -169,7 +169,7 @@ std::string BaseGenerator::outArgsToType(const Nodes& args, bool bareList) const
         for (const auto& arg : args)
         {
             if (firstArg) firstArg = false; else retTypeSS << ", ";
-            retTypeSS << signature_to_type(arg->get("type"));
+            retTypeSS << signature_to_type(arg->get("type"), stubType != StubType::ADAPTOR);
         }
 
         if (!bareList)

--- a/tools/xml2cpp-codegen/BaseGenerator.h
+++ b/tools/xml2cpp-codegen/BaseGenerator.h
@@ -88,14 +88,14 @@ protected:
      * @param args
      * @return tuple: argument names, argument types and names, argument types
      */
-    std::tuple<std::string, std::string, std::string> argsToNamesAndTypes(const sdbuscpp::xml::Nodes& args, bool async = false) const;
+    std::tuple<std::string, std::string, std::string> argsToNamesAndTypes(const sdbuscpp::xml::Nodes& args, bool incoming, bool async = false) const;
 
     /**
      * Output arguments to return type
      * @param args
      * @return return type
      */
-    std::string outArgsToType(const sdbuscpp::xml::Nodes& args, bool bareList = false) const;
+    std::string outArgsToType(const sdbuscpp::xml::Nodes& args, const StubType& stubType, bool bareList = false) const;
 
 };
 

--- a/tools/xml2cpp-codegen/generator_utils.h
+++ b/tools/xml2cpp-codegen/generator_utils.h
@@ -9,11 +9,11 @@
 #include <sstream>
 #include <iomanip>
 
-const char *atomic_type_to_string(char t);
+const char *atomic_type_to_string(char t, bool incoming);
 
 std::string stub_name(const std::string& name);
 
-std::string signature_to_type(const std::string& signature);
+std::string signature_to_type(const std::string& signature, bool incoming);
 
 std::string underscorize(const std::string& str);
 


### PR DESCRIPTION
Rename current UnixFd to UnixFdRef, add UniqueUnixFd as owning unix file
descriptor, and AnyUnixFd to hold any of the previous two.

Change stub generator to use AnyUnixFd for outgoing file descriptor and
UnixFdRef for incoming file descriptors (they are owned by the message).

Fix #63.

--------

This is not ready yet. I sent the PR so the design could be discussed and to get help to fix issues.

I tested passing fds with this patch, it worked for passing fds from client to server, but not for passing them from server to client through methods or properties (but it worked with signals). Any idea what I did wrong?

About the design, I am not sure about the use of unique_ptr for holding file descriptor, it kind of do everything needed, but it feels like abusing to make file descriptor pointers that cannot be dereferenced.

UniqueUnixFd and AnyUnixFd use inheritance instead of aliases so they can be forward declared and have operator int. But I think it would be cleaner if they could be aliases. Conversion operator are not that important : UniqueUnixFd::operator int is the same thing as unique_ptr::get, and AnyUnixFd::operator int should only be used in operator<<, so std::visit could be called directly there.