### PR TITLE
Added ability to integrate with foreign event loops

### DIFF
--- a/include/sdbus-c++/IConnection.h
+++ b/include/sdbus-c++/IConnection.h
@@ -46,6 +46,13 @@ namespace sdbus {
     class IConnection
     {
     public:
+        struct PollData
+        {
+            int fd;
+            short int events;
+            uint64_t timeout_usec;
+        };
+
         virtual ~IConnection() = default;
 
         /*!
@@ -103,6 +110,41 @@ namespace sdbus {
          * @throws sdbus::Error in case of failure
          */
         virtual void addObjectManager(const std::string& objectPath) = 0;
+
+        /*!
+         * @brief Returns parameters you can pass to poll
+         *
+         * To integrate sdbus with your app's own custom event handling system
+         * (without the requirement of an extra thread), you can use this
+         * method to query which file descriptors, poll events and timeouts you
+         * should add to your app's poll call in your main event loop. If these
+         * file descriptors signal, then you should call processPendingRequest
+         * to process the event. This means that all of sdbus's callbacks will
+         * arrive on your app's main event thread (opposed to on a thread created
+         * by sdbus-c++). If you are unsure what this all means then use
+         * enterProcessingLoop() or enterProcessingLoopAsync() instead.
+         *
+         * To integrate sdbus-c++ into a gtk app, pass the file descriptor returned
+         * by this method to g_main_context_add_poll.
+         *
+         * @throws sdbus::Error in case of failure
+         */
+        virtual PollData getProcessLoopPollData() = 0;
+
+        /*!
+         * @brief Process a pending request
+         *
+         * Processes a single dbus event. All of sdbus-c++'s callbacks will be called
+         * from within this method. This method should ONLY be used in conjuction
+         * with getProcessLoopPollData(). enterProcessingLoop() and
+         * enterProcessingLoopAsync() will call this method for you, so there is no
+         * need to call it when using these. If you are unsure what this all means then
+         * don't use this method.
+         *
+         * @returns true if an event was processed
+         * @throws sdbus::Error in case of failure
+         */
+        virtual bool processPendingRequest() = 0;
     };
 
     /*!

--- a/src/Connection.h
+++ b/src/Connection.h
@@ -57,6 +57,8 @@ namespace sdbus { namespace internal {
         void enterProcessingLoop() override;
         void enterProcessingLoopAsync() override;
         void leaveProcessingLoop() override;
+        bool processPendingRequest() override;
+        sdbus::IConnection::PollData getProcessLoopPollData() override;
 
         void addObjectManager(const std::string& objectPath) override;
         SlotPtr addObjectManager(const std::string& objectPath, void* /*dummy*/) override;
@@ -99,7 +101,6 @@ namespace sdbus { namespace internal {
         void finishHandshake(sd_bus* bus);
         static int createProcessingLoopExitDescriptor();
         static void closeProcessingLoopExitDescriptor(int fd);
-        bool processPendingRequest();
         bool waitForNextRequest();
         static std::string composeSignalMatchFilter( const std::string& objectPath
                                                    , const std::string& interfaceName


### PR DESCRIPTION
Currently, sdbus-c++ cannot be integrated into foreign event loops, like gtk's or KDE's event loop - and therefore it's impossible to use sdbus-c++ in gtk/kde apps without sdbus-c++ creating an additional thread.

To solve this, sdbus-c++ needs to expose the sdbus' function `sd_bus_get_poll_data`. The result can then be polled for in the user's app or added as an event source to the event loop system the user is using (for example by using the gtk method `g_main_context_add_poll` in gtk apps).

This PR exposes this function and allows the user to process a single sdbus event (whenever the file descriptor signals).