### PR TITLE
Added support for opening a connection to a remote system bus using ssh

### DIFF
--- a/include/sdbus-c++/IConnection.h
+++ b/include/sdbus-c++/IConnection.h
@@ -204,6 +204,15 @@ namespace sdbus {
      */
     std::unique_ptr<sdbus::IConnection> createSessionBusConnection(const std::string& name);
 
+    /*!
+     * @brief Creates/opens D-Bus system connection on a remote host using ssh
+     *
+     * @param[in] host Name of the host to connect
+     * @return Connection instance
+     *
+     * @throws sdbus::Error in case of failure
+     */
+    std::unique_ptr<sdbus::IConnection> createRemoteSystemBusConnection(const std::string& host);
 }
 
 #endif /* SDBUS_CXX_ICONNECTION_H_ */

--- a/src/Connection.h
+++ b/src/Connection.h
@@ -46,10 +46,12 @@ namespace sdbus { namespace internal {
         enum class BusType
         {
             eSystem,
-            eSession
+            eSession,
+            eRemoteSystem,
         };
 
         Connection(BusType type, std::unique_ptr<ISdBus>&& interface);
+        Connection(const std::string& host, std::unique_ptr<ISdBus>&& interface);
         ~Connection() override;
 
         void requestName(const std::string& name) override;
@@ -119,6 +121,7 @@ namespace sdbus { namespace internal {
 
         std::thread asyncLoopThread_;
         int loopExitFd_{-1};
+        std::string host_;
     };
 
 }}

--- a/src/ISdBus.h
+++ b/src/ISdBus.h
@@ -62,6 +62,7 @@ namespace sdbus { namespace internal {
 
         virtual int sd_bus_open_user(sd_bus **ret) = 0;
         virtual int sd_bus_open_system(sd_bus **ret) = 0;
+        virtual int sd_bus_open_system_remote(sd_bus **ret, const char* host) = 0;
         virtual int sd_bus_request_name(sd_bus *bus, const char *name, uint64_t flags) = 0;
         virtual int sd_bus_release_name(sd_bus *bus, const char *name) = 0;
         virtual int sd_bus_add_object_vtable(sd_bus *bus, sd_bus_slot **slot, const char *path, const char *interface, const sd_bus_vtable *vtable, void *userdata) = 0;

--- a/src/SdBus.cpp
+++ b/src/SdBus.cpp
@@ -137,6 +137,11 @@ int SdBus::sd_bus_open_system(sd_bus **ret)
     return ::sd_bus_open_system(ret);
 }
 
+int SdBus::sd_bus_open_system_remote(sd_bus **ret, const char *host)
+{
+    return ::sd_bus_open_system_remote(ret, host);
+}
+
 int SdBus::sd_bus_request_name(sd_bus *bus, const char *name, uint64_t flags)
 {
     std::unique_lock<std::recursive_mutex> lock(sdbusMutex_);

--- a/src/SdBus.h
+++ b/src/SdBus.h
@@ -56,6 +56,7 @@ public:
 
     virtual int sd_bus_open_user(sd_bus **ret) override;
     virtual int sd_bus_open_system(sd_bus **ret) override;
+    virtual int sd_bus_open_system_remote(sd_bus **ret, const char* hsot) override;
     virtual int sd_bus_request_name(sd_bus *bus, const char *name, uint64_t flags) override;
     virtual int sd_bus_release_name(sd_bus *bus, const char *name) override;
     virtual int sd_bus_add_object_vtable(sd_bus *bus, sd_bus_slot **slot, const char *path, const char *interface, const sd_bus_vtable *vtable, void *userdata) override;


### PR DESCRIPTION
The sd_bus C library provides the ability to open a connection to the system bus on a remote device using ssh. This type of connection is created using the `sd_bus_open_system_remote()` function. This PR adds the necessary plumbing to use this functionality in sdbus-cpp. A new connection creation method was added, `createRemoteSystemBusConnection()` which takes a single argument, the name of the host you'd like to connect to (ex. "user@192.168.1.1").