### PR TITLE
Add a method to retrieve the unique name of a connection

### DIFF
--- a/include/sdbus-c++/IConnection.h
+++ b/include/sdbus-c++/IConnection.h
@@ -75,6 +75,13 @@ namespace sdbus {
         virtual void releaseName(const std::string& name) = 0;
 
         /*!
+         * @brief Retrieve the unique name of a connection. E.g. ":1.xx"
+         *
+         * @throws sdbus::Error in case of failure
+         */
+        virtual std::string getUniqueName() = 0;
+
+        /*!
          * @brief Enters the D-Bus processing loop
          *
          * The incoming D-Bus messages are processed in the loop. The method

--- a/src/Connection.cpp
+++ b/src/Connection.cpp
@@ -76,6 +76,14 @@ void Connection::releaseName(const std::string& name)
     SDBUS_THROW_ERROR_IF(r < 0, "Failed to release bus name", -r);
 }
 
+std::string Connection::getUniqueName()
+{
+    const char* unique = nullptr;
+    auto r = iface_->sd_bus_get_unique_name(bus_.get(), &unique);
+    SDBUS_THROW_ERROR_IF(r < 0 || unique == nullptr, "Failed to get unique bus name", -r);
+    return unique;
+}
+
 void Connection::enterProcessingLoop()
 {
     while (true)

--- a/src/Connection.h
+++ b/src/Connection.h
@@ -57,6 +57,7 @@ namespace sdbus { namespace internal {
 
         void requestName(const std::string& name) override;
         void releaseName(const std::string& name) override;
+        std::string getUniqueName() override;
         void enterProcessingLoop() override;
         void enterProcessingLoopAsync() override;
         void leaveProcessingLoop() override;

--- a/src/ISdBus.h
+++ b/src/ISdBus.h
@@ -70,6 +70,7 @@ namespace sdbus { namespace internal {
         virtual int sd_bus_open_system_remote(sd_bus **ret, const char* host) = 0;
         virtual int sd_bus_request_name(sd_bus *bus, const char *name, uint64_t flags) = 0;
         virtual int sd_bus_release_name(sd_bus *bus, const char *name) = 0;
+        virtual int sd_bus_get_unique_name(sd_bus *bus, const char **name) = 0;
         virtual int sd_bus_add_object_vtable(sd_bus *bus, sd_bus_slot **slot, const char *path, const char *interface, const sd_bus_vtable *vtable, void *userdata) = 0;
         virtual int sd_bus_add_object_manager(sd_bus *bus, sd_bus_slot **slot, const char *path) = 0;
         virtual int sd_bus_add_match(sd_bus *bus, sd_bus_slot **slot, const char *match, sd_bus_message_handler_t callback, void *userdata) = 0;

--- a/src/SdBus.cpp
+++ b/src/SdBus.cpp
@@ -183,6 +183,12 @@ int SdBus::sd_bus_release_name(sd_bus *bus, const char *name)
     return ::sd_bus_release_name(bus, name);
 }
 
+int SdBus::sd_bus_get_unique_name(sd_bus *bus, const char **name)
+{
+    std::unique_lock<std::recursive_mutex> lock(sdbusMutex_);
+    return ::sd_bus_get_unique_name(bus, name);
+}
+
 int SdBus::sd_bus_add_object_vtable(sd_bus *bus, sd_bus_slot **slot, const char *path, const char *interface, const sd_bus_vtable *vtable, void *userdata)
 {
     std::unique_lock<std::recursive_mutex> lock(sdbusMutex_);

--- a/src/SdBus.h
+++ b/src/SdBus.h
@@ -62,6 +62,7 @@ public:
     virtual int sd_bus_open_system_remote(sd_bus **ret, const char* hsot) override;
     virtual int sd_bus_request_name(sd_bus *bus, const char *name, uint64_t flags) override;
     virtual int sd_bus_release_name(sd_bus *bus, const char *name) override;
+    virtual int sd_bus_get_unique_name(sd_bus *bus, const char **name) override;
     virtual int sd_bus_add_object_vtable(sd_bus *bus, sd_bus_slot **slot, const char *path, const char *interface, const sd_bus_vtable *vtable, void *userdata) override;
     virtual int sd_bus_add_object_manager(sd_bus *bus, sd_bus_slot **slot, const char *path) override;
     virtual int sd_bus_add_match(sd_bus *bus, sd_bus_slot **slot, const char *match, sd_bus_message_handler_t callback, void *userdata) override;


### PR DESCRIPTION
Hello!
I added this method to get the unique name of a connection.  It is useful to access remote adapters on unnamed connection.
