### PR TITLE
sdbus-c++-xml2cpp: fixed file existence condition

### DIFF
--- a/tools/xml2cpp-codegen/xml2cpp.cpp
+++ b/tools/xml2cpp-codegen/xml2cpp.cpp
@@ -149,7 +149,7 @@ int main(int argc, char **argv)
 
             std::ifstream input(xmlFile);
 
-            if (input.bad())
+            if (input.fail())
             {
                 std::cerr << "Unable to open file " << xmlFile << endl;
                 return 1;


### PR DESCRIPTION
fixes issue: https://github.com/Kistler-Group/sdbus-cpp/issues/83