### PR TITLE
xml2cpp-codegen: make destructor virtual

### DIFF
--- a/tools/xml2cpp-codegen/AdaptorGenerator.cpp
+++ b/tools/xml2cpp-codegen/AdaptorGenerator.cpp
@@ -131,7 +131,7 @@ std::string AdaptorGenerator::processInterface(Node& interface) const
                        << propertyRegistration
          << tab << "}" << endl << endl;
 
-    body << tab << "~" << className << "() = default;" << endl << endl;
+    body << tab << "virtual ~" << className << "() = default;" << endl << endl;
 
     if (!signalMethods.empty())
     {

--- a/tools/xml2cpp-codegen/ProxyGenerator.cpp
+++ b/tools/xml2cpp-codegen/ProxyGenerator.cpp
@@ -96,7 +96,7 @@ std::string ProxyGenerator::processInterface(Node& interface) const
             << registration
             << tab << "}" << endl << endl;
 
-    body << tab << "~" << className << "() = default;" << endl << endl;
+    body << tab << "virtual ~" << className << "() = default;" << endl << endl;
 
     if (!declaration.empty())
         body << declaration << endl;


### PR DESCRIPTION
Even though this is most probably a false warning, you will get
get GCC warning like:
base class ‘class sdbus::ProxyInterfaces<YourProxyHere_proxy>’ has accessible non-virtual destructor [-Wnon-virtual-dtor]
this commit should fix this.

Signed-off-by: Matthias Schoepfer <matthias.schoepfer@ithinx.io>