### PR TITLE
Fix #88: Timeout handling.

### DIFF
--- a/src/Connection.h
+++ b/src/Connection.h
@@ -123,10 +123,14 @@ namespace sdbus::internal {
         void joinWithEventLoop();
         static std::vector</*const */char*> to_strv(const std::vector<std::string>& strings);
 
-        struct LoopExitEventFd
+        struct LoopEventFd
         {
-            LoopExitEventFd();
-            ~LoopExitEventFd();
+            explicit LoopEventFd(int flag);
+            ~LoopEventFd();
+
+            void set();
+            void clear();
+
             int fd;
         };
 
@@ -136,7 +140,8 @@ namespace sdbus::internal {
         std::thread asyncLoopThread_;
         std::atomic<std::thread::id> loopThreadId_;
         std::mutex loopMutex_;
-        LoopExitEventFd loopExitFd_;
+        LoopEventFd loopExitFd_;
+        LoopEventFd loopNotifyFd_;
     };
 
 }

--- a/src/SdBus.h
+++ b/src/SdBus.h
@@ -75,8 +75,12 @@ public:
     virtual int sd_bus_flush(sd_bus *bus) override;
     virtual sd_bus *sd_bus_flush_close_unref(sd_bus *bus) override;
 
+    void set_loop_notify(void(*)(void* userdata), void* userdata);
+
 private:
     std::recursive_mutex sdbusMutex_;
+    void (*notify_)(void*);
+    void* userData_;
 };
 
 }

--- a/tests/integrationtests/AdaptorAndProxy_test.cpp
+++ b/tests/integrationtests/AdaptorAndProxy_test.cpp
@@ -48,6 +48,7 @@
 using ::testing::Eq;
 using ::testing::DoubleEq;
 using ::testing::Gt;
+using ::testing::Le;
 using ::testing::AnyOf;
 using ::testing::ElementsAre;
 using ::testing::SizeIs;
@@ -242,15 +243,18 @@ TEST_F(SdbusTestObject, CallsMethodWithCustomTimeoutSuccessfully)
 
 TEST_F(SdbusTestObject, ThrowsTimeoutErrorWhenMethodTimesOut)
 {
+    auto start = std::chrono::steady_clock::now();
     try
     {
-        m_proxy->doOperationWith500msTimeout(1000); // The operation will take 1s, but the timeout is 500ms, so we should time out
+        m_proxy->doOperationWith500msTimeout(2000); // The operation will take 2s, but the timeout is 500ms, so we should time out
         FAIL() << "Expected sdbus::Error exception";
     }
     catch (const sdbus::Error& e)
     {
         ASSERT_THAT(e.getName(), AnyOf("org.freedesktop.DBus.Error.Timeout", "org.freedesktop.DBus.Error.NoReply"));
         ASSERT_THAT(e.getMessage(), AnyOf("Connection timed out", "Method call timed out"));
+        auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start);
+        ASSERT_THAT(ms.count(), Le(1000));
     }
     catch(...)
     {

--- a/tests/integrationtests/proxy-glue.h
+++ b/tests/integrationtests/proxy-glue.h
@@ -145,7 +145,7 @@ public:
     {
         using namespace std::chrono_literals;
         uint32_t result;
-        object_.callMethod("doOperation").onInterface(INTERFACE_NAME).withTimeout(500000us).withArguments(param).storeResultsTo(result);
+        object_.callMethod("doOperation").onInterface(INTERFACE_NAME).withTimeout(500ms).withArguments(param).storeResultsTo(result);
         return result;
     }
 


### PR DESCRIPTION
* Despite what is documented in sd_bus_get_timeout(3), the timeout
  returned is actually an absolute time point of Linux's CLOCK_MONOTONIC
  clock. Hence, we first have to subtract the current time from the
  timeout in order to get a relative time that can be passed to poll.

* For async call timeouts to reliably work, we need a way to notify the
  event loop of a connection that is currently blocked waiting in poll.
  I.e. assume the event loop thread entered poll with a timeout set to
  T1. Afterwards, the main thread starts an async call C with a timeout
  T2 < T1. In order for C to be canceled after its timeout T1 has
  elapsed, we have to be able to notify the event loop so that it can
  update its poll data.