### PR TITLE
Feaure request: Make async call cancellable.

### DIFF
--- a/include/sdbus-c++/ConvenienceApiClasses.h
+++ b/include/sdbus-c++/ConvenienceApiClasses.h
@@ -193,7 +193,7 @@ namespace sdbus {
         template <typename _Rep, typename _Period>
         AsyncMethodInvoker& withTimeout(const std::chrono::duration<_Rep, _Period>& timeout);
         template <typename... _Args> AsyncMethodInvoker& withArguments(_Args&&... args);
-        template <typename _Function> void uponReplyInvoke(_Function&& callback);
+        template <typename _Function> PendingCall uponReplyInvoke(_Function&& callback);
 
     private:
         IProxy& proxy_;

--- a/include/sdbus-c++/ConvenienceApiClasses.inl
+++ b/include/sdbus-c++/ConvenienceApiClasses.inl
@@ -576,7 +576,7 @@ namespace sdbus {
     }
 
     template <typename _Function>
-    void AsyncMethodInvoker::uponReplyInvoke(_Function&& callback)
+    PendingCall AsyncMethodInvoker::uponReplyInvoke(_Function&& callback)
     {
         assert(method_.isValid()); // onInterface() must be placed/called prior to this function
 
@@ -594,7 +594,7 @@ namespace sdbus {
             sdbus::apply(callback, error, args);
         };
 
-        proxy_.callMethod(method_, std::move(asyncReplyHandler), timeout_);
+        return proxy_.callMethod(method_, std::move(asyncReplyHandler), timeout_);
     }
 
     /*** ---------------- ***/

--- a/include/sdbus-c++/IProxy.h
+++ b/include/sdbus-c++/IProxy.h
@@ -38,6 +38,7 @@ namespace sdbus {
     class MethodCall;
     class MethodReply;
     class IConnection;
+    class PendingCall;
 }
 
 namespace sdbus {
@@ -117,7 +118,7 @@ namespace sdbus {
          *
          * @throws sdbus::Error in case of failure
          */
-        virtual void callMethod(const MethodCall& message, async_reply_handler asyncReplyCallback, uint64_t timeout = 0) = 0;
+        virtual PendingCall callMethod(const MethodCall& message, async_reply_handler asyncReplyCallback, uint64_t timeout = 0) = 0;
 
         /*!
          * @copydoc IProxy::callMethod(const MethodCall&,async_reply_handler,uint64_t)

--- a/include/sdbus-c++/Message.h
+++ b/include/sdbus-c++/Message.h
@@ -58,6 +58,26 @@ namespace sdbus {
     inline constexpr adopt_message_t adopt_message{};
 
     /********************************************//**
+     * @class PendingCall
+     *
+     * A simple handle type for canceling the result delivery of an asynchronous call.
+     ***********************************************/
+    class PendingCall
+    {
+    public:
+        PendingCall(std::weak_ptr<void>, void(*cancelFunc)(void*));
+        //! Returns whether or not the delivery of the call result is still pending.
+        bool isPending() const;
+        //! Cancels delivery if it is still pending. Otherwise, the call has no effect and returns false.
+        //! \return Whether or not delivery was canceled.
+        bool cancel();
+    private:
+        std::weak_ptr<void> ptr_;
+        void (*cancel_)(void*);
+    };
+
+
+    /********************************************//**
      * @class Message
      *
      * Message represents a D-Bus message, which can be either method call message,

--- a/src/Message.cpp
+++ b/src/Message.cpp
@@ -36,6 +36,26 @@
 
 namespace sdbus {
 
+PendingCall::PendingCall(std::weak_ptr<void> p, void(*cancelFunc)(void*))
+    : ptr_(std::move(p))
+    , cancel_(cancelFunc)
+{
+}
+
+bool PendingCall::cancel()
+{
+    if (auto ptr = ptr_.lock(); ptr && cancel_)
+    {
+        cancel_(ptr.get());
+        return true;
+    }
+    return false;
+}
+bool PendingCall::isPending() const
+{
+    return !ptr_.expired();
+}
+
 Message::Message(internal::ISdBus* sdbus) noexcept
     : sdbus_(sdbus)
 {

--- a/tests/integrationtests/proxy-glue.h
+++ b/tests/integrationtests/proxy-glue.h
@@ -156,9 +156,9 @@ public:
         return result;
     }
 
-    void doOperationClientSideAsync(uint32_t param)
+    sdbus::PendingCall doOperationClientSideAsync(uint32_t param)
     {
-        object_.callMethodAsync("doOperation")
+        return object_.callMethodAsync("doOperation")
                .onInterface(INTERFACE_NAME)
                .withArguments(param)
                .uponReplyInvoke([this](const sdbus::Error* error, uint32_t returnValue)


### PR DESCRIPTION
Clients sometimes need to be able to cancel the delivery of the result of an asynchronous call. 

This PR adds support for this use case by extending the existing AsyncCalls logic of Proxy.
In particular, IProxy's async callMethod now returns a PendingCall object representing a handle that can be used to cancel the invocation of a given reply callback.

**NOTE:** The current design does not allow for cancelling from within the user's reply callback as I don't think that this is a sensible thing to do. However, adding support for this would be relatively easy (e.g. by replacing the lock flag with a thread-id and a CAS loop).

Please let me know whether you think this is useful and/or if you see better ways to implement this.