### PR TITLE
Fix #93: Get signals working for multiple proxies.

### DIFF
--- a/src/Proxy.cpp
+++ b/src/Proxy.cpp
@@ -238,7 +238,7 @@ int Proxy::sdbus_signal_handler(sd_bus_message *sdbusMessage, void *userData, sd
 
     callback(message);
 
-    return 1;
+    return 0;
 }
 
 }

--- a/tests/integrationtests/AdaptorAndProxy_test.cpp
+++ b/tests/integrationtests/AdaptorAndProxy_test.cpp
@@ -455,6 +455,18 @@ TEST_F(SdbusTestObject, EmitsSimpleSignalSuccesfully)
     ASSERT_TRUE(waitUntil(m_proxy->m_gotSimpleSignal));
 }
 
+TEST_F(SdbusTestObject, EmitsSimpleSignalToMultipleProxiesSuccesfully)
+{
+    auto proxy1 = std::make_unique<TestingProxy>(*s_connection, INTERFACE_NAME, OBJECT_PATH);
+    auto proxy2 = std::make_unique<TestingProxy>(*s_connection, INTERFACE_NAME, OBJECT_PATH);
+
+    m_adaptor->emitSimpleSignal();
+
+    ASSERT_TRUE(waitUntil(m_proxy->m_gotSimpleSignal));
+    ASSERT_TRUE(waitUntil(proxy1->m_gotSimpleSignal));
+    ASSERT_TRUE(waitUntil(proxy2->m_gotSimpleSignal));
+}
+
 TEST_F(SdbusTestObject, EmitsSignalWithMapSuccesfully)
 {
     m_adaptor->emitSignalWithMap({{0, "zero"}, {1, "one"}});

--- a/tests/integrationtests/TestingProxy.h
+++ b/tests/integrationtests/TestingProxy.h
@@ -43,6 +43,12 @@ public:
         registerProxy();
     }
 
+    TestingProxy(sdbus::IConnection& connection, std::string destination, std::string objectPath)
+        : ProxyInterfaces(connection, std::move(destination), std::move(objectPath))
+    {
+        registerProxy();
+    }
+
     ~TestingProxy()
     {
         unregisterProxy();


### PR DESCRIPTION
* Proxy::sdbus_signal_handler() needs to return 0 instead of 1 in
  order to allow multiple proxies listening to a signal all being
  triggered.
* Add test for emitting a signal to multiple proxies on same
  connection.