### PR TITLE
Fixed integration tests for libsystemd older than 242

### DIFF
--- a/tests/integrationtests/adaptor-glue.h
+++ b/tests/integrationtests/adaptor-glue.h
@@ -251,17 +251,33 @@ R"delimiter(<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspectio
    <arg type="a{t(a{ya(obva{is})}gs)}" direction="out"/>
    <annotation name="org.freedesktop.DBus.Deprecated" value="true"/>
   </method>
-  <method name="getInt">
-   <arg type="i" name="anInt" direction="out"/>
+  <method name="getInt">)delimiter"
+#if LIBSYSTEMD_VERSION>=242
+R"delimiter(
+   <arg type="i" name="anInt" direction="out"/>)delimiter"
+#else
+R"delimiter(
+   <arg type="i" direction="out"/>)delimiter"
+#endif
+R"delimiter(
   </method>
   <method name="getInts16FromStruct">
    <arg type="(yndsan)" direction="in"/>
    <arg type="an" direction="out"/>
   </method>
-  <method name="getMapOfVariants">
+  <method name="getMapOfVariants">)delimiter"
+#if LIBSYSTEMD_VERSION>=242
+R"delimiter(
    <arg type="ai" name="x" direction="in"/>
    <arg type="(vv)" name="y" direction="in"/>
-   <arg type="a{iv}" name="aMapOfVariants" direction="out"/>
+   <arg type="a{iv}" name="aMapOfVariants" direction="out"/>)delimiter"
+#else
+R"delimiter(
+   <arg type="ai" direction="in"/>
+   <arg type="(vv)" direction="in"/>
+   <arg type="a{iv}" direction="out"/>)delimiter"
+#endif
+R"delimiter(
   </method>
   <method name="getObjectPath">
    <arg type="o" direction="out"/>
@@ -279,10 +295,19 @@ R"delimiter(<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspectio
   <method name="getUnixFd">
    <arg type="h" direction="out"/>
   </method>
-  <method name="multiply">
+  <method name="multiply">)delimiter"
+#if LIBSYSTEMD_VERSION>=242
+R"delimiter(
    <arg type="x" name="a" direction="in"/>
    <arg type="d" name="b" direction="in"/>
-   <arg type="d" name="result" direction="out"/>
+   <arg type="d" name="result" direction="out"/>)delimiter"
+#else
+R"delimiter(
+   <arg type="x" direction="in"/>
+   <arg type="d" direction="in"/>
+   <arg type="d" direction="out"/>)delimiter"
+#endif
+R"delimiter(
   </method>
   <method name="multiplyWithNoReply">
    <arg type="x" direction="in"/>


### PR DESCRIPTION
Recently, a support for method and signal parameter names in introspection was added to the library, but it requires `libsystemd` version 242+ to support it. So that, vtable is set up depending on its version:
https://github.com/Kistler-Group/sdbus-cpp/blob/master/src/VTableUtils.c#L73

However, we are running `libsystemd` 239 and our integration tests are failing, as they expect output with parameter names. Here is a patch that fixes `SdbusTestObject.AnswersXmlApiDescriptionViaIntrospectableInterface` test case to behave correctly depending on `libsystemd` version.