### PR TITLE
Fix build with clang 9.0.1 and libcxx

### DIFF
--- a/src/Proxy.cpp
+++ b/src/Proxy.cpp
@@ -99,7 +99,7 @@ PendingAsyncCall Proxy::callMethod(const MethodCall& message, async_reply_handle
 
     auto callback = (void*)&Proxy::sdbus_async_reply_handler;
     auto callData = std::make_shared<AsyncCalls::CallData>(AsyncCalls::CallData{*this, std::move(asyncReplyCallback), {}});
-    auto weakData = std::weak_ptr{callData};
+    auto weakData = std::weak_ptr<AsyncCalls::CallData>{callData};
 
     callData->slot = message.send(callback, callData.get(), timeout);
 


### PR DESCRIPTION
This should not be required in C++17 because there is an appropriate [class template deduction rule](https://en.cppreference.com/w/cpp/memory/weak_ptr/deduction_guides) which infers that it's going to be a `weak_ptr<T>` when constructing from a `shared_ptr<T>`. However, in clang/LLVM's libcxx C++ STL implementation this [only got implemented in May 2020](https://reviews.llvm.org/D69603).

Here's the failure (Fedora 31, clang 9.0.1):
```
[8/19] Building CXX object CMakeFiles/sdbus-c++-objlib.dir/src/Proxy.cpp.o
FAILED: CMakeFiles/sdbus-c++-objlib.dir/src/Proxy.cpp.o
/usr/bin/clang++  -DBUILD_LIB=1 -DLIBSYSTEMD_VERSION=243 -I/home/ci/src/cesnet-gerrit-czechlight/CzechLight/dependencies/sdbus-cpp/include -I/home/ci/src/cesnet-gerrit-czechlight/CzechLight/dependencies/sdbus-cpp/src -fsanitize=address,undefined -stdlib=libc++ -g -fPIC   -std=gnu++17 -MD -MT CMakeFiles/sdbus-c++-objlib.dir/src/Proxy.cpp.o -MF CMakeFiles/sdbus-c++-objlib.dir/src/Proxy.cpp.o.d -o CMakeFiles/sdbus-c++-objlib.dir/src/Proxy.cpp.o -c /home/ci/src/cesnet-gerrit-czechlight/CzechLight/dependencies/sdbus-cpp/src/Proxy.cpp
/home/ci/src/cesnet-gerrit-czechlight/CzechLight/dependencies/sdbus-cpp/src/Proxy.cpp:102:21: error: no viable constructor or deduction guide for deduction of template arguments of 'weak_ptr'
    auto weakData = std::weak_ptr{callData};
                    ^
/usr/bin/../include/c++/v1/memory:4883:51: note: candidate template ignored: couldn't infer template argument '_Tp'
    template<class _Yp> _LIBCPP_INLINE_VISIBILITY weak_ptr(shared_ptr<_Yp> const& __r,
                                                  ^
/usr/bin/../include/c++/v1/memory:4872:28: note: candidate template ignored: could not match 'weak_ptr' against 'shared_ptr'
class _LIBCPP_TEMPLATE_VIS weak_ptr
                           ^
/usr/bin/../include/c++/v1/memory:4887:5: note: candidate template ignored: could not match 'weak_ptr' against 'shared_ptr'
    weak_ptr(weak_ptr const& __r) _NOEXCEPT;
    ^
/usr/bin/../include/c++/v1/memory:4888:51: note: candidate template ignored: could not match 'weak_ptr' against 'shared_ptr'
    template<class _Yp> _LIBCPP_INLINE_VISIBILITY weak_ptr(weak_ptr<_Yp> const& __r,
                                                  ^
/usr/bin/../include/c++/v1/memory:4894:5: note: candidate template ignored: could not match 'weak_ptr' against 'shared_ptr'
    weak_ptr(weak_ptr&& __r) _NOEXCEPT;
    ^
/usr/bin/../include/c++/v1/memory:4895:51: note: candidate template ignored: could not match 'weak_ptr' against 'shared_ptr'
    template<class _Yp> _LIBCPP_INLINE_VISIBILITY weak_ptr(weak_ptr<_Yp>&& __r,
                                                  ^
/usr/bin/../include/c++/v1/memory:4882:23: note: candidate function template not viable: requires 0 arguments, but 1 was provided
    _LIBCPP_CONSTEXPR weak_ptr() _NOEXCEPT;
                      ^
1 error generated.
```

Cc: @peckato1