### PR TITLE
Fix potential data race in Proxy's condition variable

### DIFF
--- a/src/Proxy.cpp
+++ b/src/Proxy.cpp
@@ -127,8 +127,8 @@ MethodReply Proxy::sendMethodCallMessageAndWaitForReply(const MethodCall& messag
 
 void Proxy::SyncCallReplyData::sendMethodReplyToWaitingThread(MethodReply& reply, const Error* error)
 {
-    SCOPE_EXIT{ cond_.notify_one(); };
     std::unique_lock lock{mutex_};
+    SCOPE_EXIT{ cond_.notify_one(); }; // This must happen before unlocking the mutex to avoid potential data race on spurious wakeup in the waiting thread
     SCOPE_EXIT{ arrived_ = true; };
 
     //error_ = nullptr; // Necessary if SyncCallReplyData instance is thread_local


### PR DESCRIPTION
This fixes a data race that could potentially occur: a spurious wakeup after mutex unlock but before notify would result in notify called on a destroyed condition variable object. Hence, the notification must occur under the locked mutex to achieve precise scheduling of events.

Fixes #108 