### PR TITLE
Fix build with gcc8.3

### DIFF
--- a/include/sdbus-c++/Types.h
+++ b/include/sdbus-c++/Types.h
@@ -154,6 +154,7 @@ namespace sdbus {
     public:
         using std::string::string;
         ObjectPath() = default; // Fixes gcc 6.3 error (default c-tor is not imported in above using declaration)
+        ObjectPath(const ObjectPath&) = default; // Fixes gcc 8.3 error (deleted copy constructor)
         ObjectPath(std::string path)
             : std::string(std::move(path))
         {}
@@ -171,6 +172,7 @@ namespace sdbus {
     public:
         using std::string::string;
         Signature() = default; // Fixes gcc 6.3 error (default c-tor is not imported in above using declaration)
+        Signature(const Signature&) = default; // Fixes gcc 8.3 error (deleted copy constructor)
         Signature(std::string path)
             : std::string(std::move(path))
         {}


### PR DESCRIPTION
sdbus::ObjectPath and sdbus::Signature copy constructors are implicitly
declared as deleted when compiling with Linaro's ARM toolchain [1] gcc8.3.
Explicitly listing the copy constructors for affected classes fixes the problem.

[1] https://www.linaro.org/

Here is the failure (for simplified code)
```cpp
const sdbus::ObjectPath foo("/path/to/somewhere");
const sdbus::ObjectPath bar(foo);
```
```  
/cesnet/build-clearfog/build/velia-custom/src/inputs/DbusSystemdInput.cpp: In member function ‘void velia::DbusSystemdInput::registerSystemdUnit(sdbus::IConnection&, const string&, const sdbus::ObjectPath&)’:
/cesnet/build-clearfog/build/velia-custom/src/inputs/DbusSystemdInput.cpp:77:36: error: use of deleted function ‘sdbus::ObjectPath::ObjectPath(const sdbus::ObjectPath&)’
     const sdbus::ObjectPath bar(foo);
                                    ^
In file included from /cesnet/build-clearfog/per-package/velia/host/arm-buildroot-linux-gnueabihf/sysroot/usr/include/sdbus-c++/ConvenienceApiClasses.inl:34,
                 from /cesnet/build-clearfog/per-package/velia/host/arm-buildroot-linux-gnueabihf/sysroot/usr/include/sdbus-c++/IObject.h:494,
                 from /cesnet/build-clearfog/per-package/velia/host/arm-buildroot-linux-gnueabihf/sysroot/usr/include/sdbus-c++/sdbus-c++.h:28,
                 from /cesnet/build-clearfog/build/velia-custom/src/inputs/DbusSystemdInput.h:10,
                 from /cesnet/build-clearfog/build/velia-custom/src/inputs/DbusSystemdInput.cpp:7:
/cesnet/build-clearfog/per-package/velia/host/arm-buildroot-linux-gnueabihf/sysroot/usr/include/sdbus-c++/Types.h:152:11: note: ‘sdbus::ObjectPath::ObjectPath(const sdbus::ObjectPath&)’ is implicitly declared as deleted because ‘sdbus::ObjectPath’ declares a move constructor or move assignment operator
     class ObjectPath : public std::string
           ^~~~~~~~~~
```