### PR TITLE
Introduce CI workflow based on GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         mkdir build
         cd build
         #cmake -DCMAKE_BUILD_TYPE=Debug -BUILD_TESTS=ON -DBUILD_PERF_TESTS=ON -DBUILD_STRESS_TESTS=ON -DBUILD_LIBSYSTEMD=ON -DLIBSYSTEMD_VERSION=242 ..
-        cmake -DCMAKE_BUILD_TYPE=Debug -BUILD_TESTS=ON -DBUILD_PERF_TESTS=ON -DBUILD_STRESS_TESTS=ON ..
+        cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS=ON -DBUILD_PERF_TESTS=ON -DBUILD_STRESS_TESTS=ON ..
     - name: make
       run: make -j
     - name: verify

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
       run: |
         mkdir build
         cd build
+        export CC=${{ matrix.compiler }}
         export CXX=${{ matrix.compiler }}
         #cmake -DCMAKE_BUILD_TYPE=Debug -BUILD_TESTS=ON -DBUILD_PERF_TESTS=ON -DBUILD_STRESS_TESTS=ON -DBUILD_LIBSYSTEMD=${{ matrix.embedded_systemd }} -DLIBSYSTEMD_VERSION=$(systemctl --version | grep systemd | cut -d' ' -f2) ..
         cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS=ON -DENABLE_PERF_TESTS=ON -DENABLE_STRESS_TESTS=ON ..

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04, ubuntu-20.04]
-        compiler: [g++, clang]
+        #os: [ubuntu-18.04, ubuntu-20.04]
+        os: [ubuntu-20.04]
+        compiler: [g++]
+        #compiler: [g++, clang]
+        strategy: [default, embedded-libsystemd]
     steps:
     - uses: actions/checkout@v2
-    - name: install-libsystemd
+    - name: install-libsystemd-toolchain
+      if: matrix.strategy == 'embedded-libsystemd'
+      run: |
+        sudo apt-get update -y
+        sudo apt-get install -y meson ninja-build libcap-dev libmount-dev m4 gperf
+    - name: install-libsystemd-dev
+      if: matrix.strategy == 'default'
       run: |
         sudo apt-get update -y
         sudo apt-get install -y libsystemd-dev
@@ -28,12 +37,24 @@ jobs:
         sudo update-alternatives --install /usr/bin/cc cc /usr/bin/clang 10
         sudo update-alternatives --remove-all c++
         sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++ 10
-    - name: configure
+    - name: configure-debug
+      if: matrix.strategy == 'default' && matrix.os == 'ubuntu-18.04'
       run: |
         mkdir build
         cd build
-        #cmake -DCMAKE_BUILD_TYPE=Debug -BUILD_TESTS=ON -DBUILD_PERF_TESTS=ON -DBUILD_STRESS_TESTS=ON -DBUILD_LIBSYSTEMD=${{ matrix.embedded_systemd }} -DLIBSYSTEMD_VERSION=$(systemctl --version | grep systemd | cut -d' ' -f2) ..
-        cmake -DCMAKE_CXX_FLAGS="-O3 -W -Wextra -Wall -Wnon-virtual-dtor -Werror" -DBUILD_TESTS=ON -DENABLE_PERF_TESTS=ON -DENABLE_STRESS_TESTS=ON ..
+        cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS="-O0 -g -W -Wextra -Wall -Wnon-virtual-dtor -Werror" -DBUILD_TESTS=ON -DENABLE_PERF_TESTS=ON -DENABLE_STRESS_TESTS=ON ..
+    - name: configure-release
+      if: matrix.strategy == 'default' && matrix.os == 'ubuntu-20.04'
+      run: |
+        mkdir build
+        cd build
+        cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-O3 -DNDEBUG -W -Wextra -Wall -Wnon-virtual-dtor -Werror" -DBUILD_TESTS=ON -DENABLE_PERF_TESTS=ON -DENABLE_STRESS_TESTS=ON ..
+    - name: configure-with-embedded-libsystemd
+      if: matrix.strategy == 'embedded-libsystemd'
+      run: |
+        mkdir build
+        cd build
+        cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=ON -DENABLE_PERF_TESTS=ON -DENABLE_STRESS_TESTS=ON -DBUILD_LIBSYSTEMD=ON -DLIBSYSTEMD_VERSION=$(systemctl --version | grep systemd | cut -d' ' -f2) ..
     - name: make
       run: |
         cd build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,13 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: configure
-      run: ./configure
+      run: |
+        mkdir build
+        cd build
+        cmake -DCMAKE_BUILD_TYPE=Debug -BUILD_TESTS=ON -DBUILD_PERF_TESTS=ON -DBUILD_STRESS_TESTS=ON ..
     - name: make
-      run: make
-    - name: make check
-      run: make check
-    - name: make distcheck
-      run: make distcheck
+      run: make -j
+    - name: verify
+      run: |
+        sudo make install
+        ctest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,8 @@ jobs:
       run: |
         mkdir build
         cd build
-        cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=ON -DENABLE_PERF_TESTS=ON -DENABLE_STRESS_TESTS=ON -DBUILD_LIBSYSTEMD=ON -DLIBSYSTEMD_VERSION=$(systemctl --version | grep systemd | cut -d' ' -f2) ..
+        #cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=ON -DENABLE_PERF_TESTS=ON -DENABLE_STRESS_TESTS=ON -DBUILD_LIBSYSTEMD=ON -DLIBSYSTEMD_VERSION=$(systemctl --version | grep systemd | cut -d' ' -f2) ..
+        cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=ON -DENABLE_PERF_TESTS=ON -DENABLE_STRESS_TESTS=ON -DBUILD_LIBSYSTEMD=ON -DLIBSYSTEMD_VERSION=244 ..
     - name: make
       run: |
         cd build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,21 +10,26 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-18.04, ubuntu-20.04]
-        embedded_systemd: [ON, OFF]
+        compiler: [g++, clang]
     steps:
     - uses: actions/checkout@v2
-    - name: install-dependencies
+    - name: install-libsystemd
       run: |
         sudo apt-get update -y
         sudo apt-get install -y libsystemd-dev
+    - name: install-clang
+      if: matrix.compiler == 'clang'
+      run: sudo apt-get install -y clang
     - name: configure
       run: |
         mkdir build
         cd build
-        cmake -DCMAKE_BUILD_TYPE=Debug -BUILD_TESTS=ON -DBUILD_PERF_TESTS=ON -DBUILD_STRESS_TESTS=ON -DBUILD_LIBSYSTEMD=${{ matrix.embedded_systemd }} -DLIBSYSTEMD_VERSION=$(systemctl --version | grep systemd | cut -d' ' -f2) ..
-        #cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS=ON -DENABLE_PERF_TESTS=ON -DENABLE_STRESS_TESTS=ON ..
+        export CXX=${{ matrix.compiler }}
+        #cmake -DCMAKE_BUILD_TYPE=Debug -BUILD_TESTS=ON -DBUILD_PERF_TESTS=ON -DBUILD_STRESS_TESTS=ON -DBUILD_LIBSYSTEMD=${{ matrix.embedded_systemd }} -DLIBSYSTEMD_VERSION=$(systemctl --version | grep systemd | cut -d' ' -f2) ..
+        cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS=ON -DENABLE_PERF_TESTS=ON -DENABLE_STRESS_TESTS=ON ..
     - name: make
       run: |
         cd build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,23 +8,27 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-18.04, ubuntu-20.04]
+        embedded_systemd: [ON, OFF]
     steps:
     - uses: actions/checkout@v2
     - name: install-dependencies
       run: |
         sudo apt-get update -y
-        sudo apt-get install libsystemd-dev
+        sudo apt-get install -y libsystemd-dev
     - name: configure
       run: |
         mkdir build
         cd build
-        #cmake -DCMAKE_BUILD_TYPE=Debug -BUILD_TESTS=ON -DBUILD_PERF_TESTS=ON -DBUILD_STRESS_TESTS=ON -DBUILD_LIBSYSTEMD=ON -DLIBSYSTEMD_VERSION=242 ..
-        cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS=ON -DENABLE_PERF_TESTS=ON -DENABLE_STRESS_TESTS=ON ..
+        cmake -DCMAKE_BUILD_TYPE=Debug -BUILD_TESTS=ON -DBUILD_PERF_TESTS=ON -DBUILD_STRESS_TESTS=ON -DBUILD_LIBSYSTEMD=${{ matrix.embedded_systemd }} -DLIBSYSTEMD_VERSION=$(systemctl --version | grep systemd | cut -d' ' -f2) ..
+        #cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS=ON -DENABLE_PERF_TESTS=ON -DENABLE_STRESS_TESTS=ON ..
     - name: make
       run: |
         cd build
-        make -j
+        make -j2
     - name: verify
       run: |
         cd build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,13 +40,13 @@ jobs:
         sudo update-alternatives --remove-all c++
         sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++ 10
     - name: configure-debug
-      if: matrix.os == 'ubuntu-18.04'
+      if: matrix.build == 'shared-libsystemd' && matrix.os == 'ubuntu-18.04'
       run: |
         mkdir build
         cd build
         cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS="-O0 -g -W -Wextra -Wall -Wnon-virtual-dtor -Werror" -DBUILD_TESTS=ON -DENABLE_PERF_TESTS=ON -DENABLE_STRESS_TESTS=ON -DBUILD_CODE_GEN=ON ..
     - name: configure-release
-      if: matrix.os == 'ubuntu-20.04'
+      if: matrix.build == 'shared-libsystemd' && matrix.os == 'ubuntu-20.04'
       run: |
         mkdir build
         cd build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,8 +54,8 @@ jobs:
       run: |
         mkdir build
         cd build
-        #cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=ON -DENABLE_PERF_TESTS=ON -DENABLE_STRESS_TESTS=ON -DBUILD_LIBSYSTEMD=ON -DLIBSYSTEMD_VERSION=$(systemctl --version | grep systemd | cut -d' ' -f2) ..
-        cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=ON -DENABLE_PERF_TESTS=ON -DENABLE_STRESS_TESTS=ON -DBUILD_LIBSYSTEMD=ON -DLIBSYSTEMD_VERSION=244 ..
+        cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=ON -DENABLE_PERF_TESTS=ON -DENABLE_STRESS_TESTS=ON -DBUILD_LIBSYSTEMD=ON -DLIBSYSTEMD_VERSION=$(systemctl --version | grep systemd | cut -d' ' -f2) ..
+        #cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=ON -DENABLE_PERF_TESTS=ON -DENABLE_STRESS_TESTS=ON -DBUILD_LIBSYSTEMD=ON -DLIBSYSTEMD_VERSION=244 ..
     - name: make
       run: |
         cd build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,13 +22,17 @@ jobs:
         sudo apt-get install -y libsystemd-dev
     - name: install-clang
       if: matrix.compiler == 'clang'
-      run: sudo apt-get install -y clang
+      run: |
+        sudo apt-get install -y clang
+        sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/c++ 40
+        sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++ 60
+        sudo update-alternatives --config c++
     - name: configure
       run: |
         mkdir build
         cd build
-        export CC=${{ matrix.compiler }}
-        export CXX=${{ matrix.compiler }}
+        #export CC=${{ matrix.compiler }}
+        #export CXX=${{ matrix.compiler }}
         #cmake -DCMAKE_BUILD_TYPE=Debug -BUILD_TESTS=ON -DBUILD_PERF_TESTS=ON -DBUILD_STRESS_TESTS=ON -DBUILD_LIBSYSTEMD=${{ matrix.embedded_systemd }} -DLIBSYSTEMD_VERSION=$(systemctl --version | grep systemd | cut -d' ' -f2) ..
         cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS=ON -DENABLE_PERF_TESTS=ON -DENABLE_STRESS_TESTS=ON ..
     - name: make

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        #os: [ubuntu-18.04, ubuntu-20.04]
-        os: [ubuntu-20.04]
-        compiler: [g++]
-        #compiler: [g++, clang]
+        os: [ubuntu-18.04, ubuntu-20.04]
+        compiler: [g++, clang]
         strategy: [default, embedded-libsystemd]
     steps:
     - uses: actions/checkout@v2
@@ -42,20 +40,20 @@ jobs:
       run: |
         mkdir build
         cd build
-        cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS="-O0 -g -W -Wextra -Wall -Wnon-virtual-dtor -Werror" -DBUILD_TESTS=ON -DENABLE_PERF_TESTS=ON -DENABLE_STRESS_TESTS=ON ..
+        cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS="-O0 -g -W -Wextra -Wall -Wnon-virtual-dtor -Werror" -DBUILD_TESTS=ON -DENABLE_PERF_TESTS=ON -DENABLE_STRESS_TESTS=ON -DBUILD_CODE_GEN=ON ..
     - name: configure-release
       if: matrix.strategy == 'default' && matrix.os == 'ubuntu-20.04'
       run: |
         mkdir build
         cd build
-        cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-O3 -DNDEBUG -W -Wextra -Wall -Wnon-virtual-dtor -Werror" -DBUILD_TESTS=ON -DENABLE_PERF_TESTS=ON -DENABLE_STRESS_TESTS=ON ..
+        cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-O3 -DNDEBUG -W -Wextra -Wall -Wnon-virtual-dtor -Werror" -DBUILD_TESTS=ON -DENABLE_PERF_TESTS=ON -DENABLE_STRESS_TESTS=ON -DBUILD_CODE_GEN=ON ..
     - name: configure-with-embedded-libsystemd
       if: matrix.strategy == 'embedded-libsystemd'
       run: |
         mkdir build
         cd build
-        cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=ON -DENABLE_PERF_TESTS=ON -DENABLE_STRESS_TESTS=ON -DBUILD_LIBSYSTEMD=ON -DLIBSYSTEMD_VERSION=$(systemctl --version | grep systemd | cut -d' ' -f2) ..
-        #cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=ON -DENABLE_PERF_TESTS=ON -DENABLE_STRESS_TESTS=ON -DBUILD_LIBSYSTEMD=ON -DLIBSYSTEMD_VERSION=244 ..
+        #cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=ON -DENABLE_PERF_TESTS=ON -DENABLE_STRESS_TESTS=ON -DBUILD_CODE_GEN=ON -DBUILD_LIBSYSTEMD=ON -DLIBSYSTEMD_VERSION=$(systemctl --version | grep systemd | cut -d' ' -f2) ..
+        cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=ON -DENABLE_PERF_TESTS=ON -DENABLE_STRESS_TESTS=ON -DBUILD_CODE_GEN=ON -DBUILD_LIBSYSTEMD=ON -DLIBSYSTEMD_VERSION=244 ..
     - name: make
       run: |
         cd build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       run: |
         mkdir build
         cd build
-        cmake -DCMAKE_BUILD_TYPE=Debug -BUILD_TESTS=ON -DBUILD_PERF_TESTS=ON -DBUILD_STRESS_TESTS=ON ..
+        cmake -DCMAKE_BUILD_TYPE=Debug -BUILD_TESTS=ON -DBUILD_PERF_TESTS=ON -DBUILD_STRESS_TESTS=ON -DBUILD_LIBSYSTEMD=ON -DLIBSYSTEMD_VERSION=242 ..
     - name: make
       run: make -j
     - name: verify

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,11 @@ jobs:
         #cmake -DCMAKE_BUILD_TYPE=Debug -BUILD_TESTS=ON -DBUILD_PERF_TESTS=ON -DBUILD_STRESS_TESTS=ON -DBUILD_LIBSYSTEMD=ON -DLIBSYSTEMD_VERSION=242 ..
         cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS=ON -DENABLE_PERF_TESTS=ON -DENABLE_STRESS_TESTS=ON ..
     - name: make
-      run: make -j
+      run: |
+        cd build
+        make -j
     - name: verify
       run: |
+        cd build
         sudo make install
         ctest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,13 @@ jobs:
       if: matrix.compiler == 'clang'
       run: |
         sudo apt-get install -y clang
-        sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++ 40
-        sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++ 60
-        sudo update-alternatives --set c++
+        #sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++ 40
+        #sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++ 60
+        #sudo update-alternatives --config c++
+        #sudo update-alternatives --remove-all cc
+        sudo update-alternatives --remove-all c++
+        sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++ 10
+        sudo update-alternatives --config c++
     - name: configure
       run: |
         mkdir build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: install-dependencies
       run: |
-        apt-get update -y
+        sudo apt-get update -y
         sudo apt-get install libsystemd-dev
     - name: configure
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: configure
+      run: ./configure
+    - name: make
+      run: make
+    - name: make check
+      run: make check
+    - name: make distcheck
+      run: make distcheck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         mkdir build
         cd build
         #cmake -DCMAKE_BUILD_TYPE=Debug -BUILD_TESTS=ON -DBUILD_PERF_TESTS=ON -DBUILD_STRESS_TESTS=ON -DBUILD_LIBSYSTEMD=${{ matrix.embedded_systemd }} -DLIBSYSTEMD_VERSION=$(systemctl --version | grep systemd | cut -d' ' -f2) ..
-        cmake -DCMAKE_CXX_FLAGS="-O3 -W -Wextra -Wall -Werror -Wnon-virtual-dtor -pedantic" -DBUILD_TESTS=ON -DENABLE_PERF_TESTS=ON -DENABLE_STRESS_TESTS=ON ..
+        cmake -DCMAKE_CXX_FLAGS="-O3 -W -Wextra -Wall -Wnon-virtual-dtor -Werror" -DBUILD_TESTS=ON -DENABLE_PERF_TESTS=ON -DENABLE_STRESS_TESTS=ON ..
     - name: make
       run: |
         cd build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         mkdir build
         cd build
         #cmake -DCMAKE_BUILD_TYPE=Debug -BUILD_TESTS=ON -DBUILD_PERF_TESTS=ON -DBUILD_STRESS_TESTS=ON -DBUILD_LIBSYSTEMD=ON -DLIBSYSTEMD_VERSION=242 ..
-        cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS=ON -DBUILD_PERF_TESTS=ON -DBUILD_STRESS_TESTS=ON ..
+        cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS=ON -DENABLE_PERF_TESTS=ON -DENABLE_STRESS_TESTS=ON ..
     - name: make
       run: make -j
     - name: verify

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,16 +14,20 @@ jobs:
       matrix:
         os: [ubuntu-18.04, ubuntu-20.04]
         compiler: [g++, clang]
-        strategy: [default, embedded-libsystemd]
+        libsystemd: [use-shared]
+        include:
+          - os: ubuntu-20.04
+            compiler: g++
+            libsystemd: build-static-embedded
     steps:
     - uses: actions/checkout@v2
     - name: install-libsystemd-toolchain
-      if: matrix.strategy == 'embedded-libsystemd'
+      if: matrix.libsystemd == 'build-static-embedded'
       run: |
         sudo apt-get update -y
         sudo apt-get install -y meson ninja-build libcap-dev libmount-dev m4 gperf
     - name: install-libsystemd-dev
-      if: matrix.strategy == 'default'
+      if: matrix.libsystemd == 'use-shared'
       run: |
         sudo apt-get update -y
         sudo apt-get install -y libsystemd-dev
@@ -36,23 +40,22 @@ jobs:
         sudo update-alternatives --remove-all c++
         sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++ 10
     - name: configure-debug
-      if: matrix.strategy == 'default' && matrix.os == 'ubuntu-18.04'
+      if: matrix.os == 'ubuntu-18.04'
       run: |
         mkdir build
         cd build
         cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS="-O0 -g -W -Wextra -Wall -Wnon-virtual-dtor -Werror" -DBUILD_TESTS=ON -DENABLE_PERF_TESTS=ON -DENABLE_STRESS_TESTS=ON -DBUILD_CODE_GEN=ON ..
     - name: configure-release
-      if: matrix.strategy == 'default' && matrix.os == 'ubuntu-20.04'
+      if: matrix.os == 'ubuntu-20.04'
       run: |
         mkdir build
         cd build
         cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-O3 -DNDEBUG -W -Wextra -Wall -Wnon-virtual-dtor -Werror" -DBUILD_TESTS=ON -DENABLE_PERF_TESTS=ON -DENABLE_STRESS_TESTS=ON -DBUILD_CODE_GEN=ON ..
     - name: configure-with-embedded-libsystemd
-      if: matrix.strategy == 'embedded-libsystemd'
+      if: matrix.libsystemd == 'build-static-embedded'
       run: |
         mkdir build
         cd build
-        #cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=ON -DENABLE_PERF_TESTS=ON -DENABLE_STRESS_TESTS=ON -DBUILD_CODE_GEN=ON -DBUILD_LIBSYSTEMD=ON -DLIBSYSTEMD_VERSION=$(systemctl --version | grep systemd | cut -d' ' -f2) ..
         cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=ON -DENABLE_PERF_TESTS=ON -DENABLE_STRESS_TESTS=ON -DBUILD_CODE_GEN=ON -DBUILD_LIBSYSTEMD=ON -DLIBSYSTEMD_VERSION=244 ..
     - name: make
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,16 +18,16 @@ jobs:
         include:
           - os: ubuntu-20.04
             compiler: g++
-            libsystemd: embedded-static-libsystemd
+            build: embedded-static-libsystemd
     steps:
     - uses: actions/checkout@v2
     - name: install-libsystemd-toolchain
-      if: matrix.libsystemd == 'embedded-static-libsystemd'
+      if: matrix.build == 'embedded-static-libsystemd'
       run: |
         sudo apt-get update -y
         sudo apt-get install -y meson ninja-build libcap-dev libmount-dev m4 gperf
     - name: install-libsystemd-dev
-      if: matrix.libsystemd == 'shared-libsystemd'
+      if: matrix.build == 'shared-libsystemd'
       run: |
         sudo apt-get update -y
         sudo apt-get install -y libsystemd-dev
@@ -52,7 +52,7 @@ jobs:
         cd build
         cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-O3 -DNDEBUG -W -Wextra -Wall -Wnon-virtual-dtor -Werror" -DBUILD_TESTS=ON -DENABLE_PERF_TESTS=ON -DENABLE_STRESS_TESTS=ON -DBUILD_CODE_GEN=ON ..
     - name: configure-with-embedded-libsystemd
-      if: matrix.libsystemd == 'embedded-static-libsystemd'
+      if: matrix.build == 'embedded-static-libsystemd'
       run: |
         mkdir build
         cd build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,23 +24,16 @@ jobs:
       if: matrix.compiler == 'clang'
       run: |
         sudo apt-get install -y clang
-        #sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++ 40
-        #sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++ 60
-        #sudo update-alternatives --config c++
-        #sudo update-alternatives --remove-all cc
         sudo update-alternatives --remove-all cc
         sudo update-alternatives --install /usr/bin/cc cc /usr/bin/clang 10
         sudo update-alternatives --remove-all c++
         sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++ 10
-        #sudo update-alternatives --config c++
     - name: configure
       run: |
         mkdir build
         cd build
-        #export CC=${{ matrix.compiler }}
-        #export CXX=${{ matrix.compiler }}
         #cmake -DCMAKE_BUILD_TYPE=Debug -BUILD_TESTS=ON -DBUILD_PERF_TESTS=ON -DBUILD_STRESS_TESTS=ON -DBUILD_LIBSYSTEMD=${{ matrix.embedded_systemd }} -DLIBSYSTEMD_VERSION=$(systemctl --version | grep systemd | cut -d' ' -f2) ..
-        cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS=ON -DENABLE_PERF_TESTS=ON -DENABLE_STRESS_TESTS=ON ..
+        cmake -DCMAKE_CXX_FLAGS="-O3 -W -Wextra -Wall -Werror -Wnon-virtual-dtor -pedantic" -DBUILD_TESTS=ON -DENABLE_PERF_TESTS=ON -DENABLE_STRESS_TESTS=ON ..
     - name: make
       run: |
         cd build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - name: install-dependencies
+      run: |
+        apt-get update -y
+        sudo apt-get install libsystemd-dev
     - name: configure
       run: |
         mkdir build
         cd build
-        cmake -DCMAKE_BUILD_TYPE=Debug -BUILD_TESTS=ON -DBUILD_PERF_TESTS=ON -DBUILD_STRESS_TESTS=ON -DBUILD_LIBSYSTEMD=ON -DLIBSYSTEMD_VERSION=242 ..
+        #cmake -DCMAKE_BUILD_TYPE=Debug -BUILD_TESTS=ON -DBUILD_PERF_TESTS=ON -DBUILD_STRESS_TESTS=ON -DBUILD_LIBSYSTEMD=ON -DLIBSYSTEMD_VERSION=242 ..
+        cmake -DCMAKE_BUILD_TYPE=Debug -BUILD_TESTS=ON -DBUILD_PERF_TESTS=ON -DBUILD_STRESS_TESTS=ON ..
     - name: make
       run: make -j
     - name: verify

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         sudo apt-get install -y clang
         sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++ 40
         sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++ 60
-        sudo update-alternatives --config c++
+        sudo update-alternatives --set c++
     - name: configure
       run: |
         mkdir build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,20 +14,20 @@ jobs:
       matrix:
         os: [ubuntu-18.04, ubuntu-20.04]
         compiler: [g++, clang]
-        libsystemd: [use-shared]
+        build: [shared-libsystemd]
         include:
           - os: ubuntu-20.04
             compiler: g++
-            libsystemd: build-static-embedded
+            libsystemd: embedded-static-libsystemd
     steps:
     - uses: actions/checkout@v2
     - name: install-libsystemd-toolchain
-      if: matrix.libsystemd == 'build-static-embedded'
+      if: matrix.libsystemd == 'embedded-static-libsystemd'
       run: |
         sudo apt-get update -y
         sudo apt-get install -y meson ninja-build libcap-dev libmount-dev m4 gperf
     - name: install-libsystemd-dev
-      if: matrix.libsystemd == 'use-shared'
+      if: matrix.libsystemd == 'shared-libsystemd'
       run: |
         sudo apt-get update -y
         sudo apt-get install -y libsystemd-dev
@@ -52,7 +52,7 @@ jobs:
         cd build
         cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-O3 -DNDEBUG -W -Wextra -Wall -Wnon-virtual-dtor -Werror" -DBUILD_TESTS=ON -DENABLE_PERF_TESTS=ON -DENABLE_STRESS_TESTS=ON -DBUILD_CODE_GEN=ON ..
     - name: configure-with-embedded-libsystemd
-      if: matrix.libsystemd == 'build-static-embedded'
+      if: matrix.libsystemd == 'embedded-static-libsystemd'
       run: |
         mkdir build
         cd build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,11 @@ jobs:
         #sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++ 60
         #sudo update-alternatives --config c++
         #sudo update-alternatives --remove-all cc
+        sudo update-alternatives --remove-all cc
+        sudo update-alternatives --install /usr/bin/cc cc /usr/bin/clang 10
         sudo update-alternatives --remove-all c++
         sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++ 10
-        sudo update-alternatives --config c++
+        #sudo update-alternatives --config c++
     - name: configure
       run: |
         mkdir build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       if: matrix.compiler == 'clang'
       run: |
         sudo apt-get install -y clang
-        sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/c++ 40
+        sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++ 40
         sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++ 60
         sudo update-alternatives --config c++
     - name: configure

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 sdbus-c++
 =========
 
-![ci](https://github.com/Kistler-Group/sdbus-cpp/workflows/CI/badge.svg?branch=ci/add-github-actions)
+![ci](https://github.com/Kistler-Group/sdbus-cpp/workflows/CI/badge.svg)
 ![license](https://img.shields.io/github/license/Kistler-Group/sdbus-cpp)
 ![release](https://img.shields.io/github/v/release/Kistler-Group/sdbus-cpp)
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 sdbus-c++
 =========
 
-![](https://github.com/Kistler-Group/sdbus-cpp/workflows/CI/badge.svg?branch=ci/add-github-actions)
+![ci](https://github.com/Kistler-Group/sdbus-cpp/workflows/CI/badge.svg?branch=ci/add-github-actions)
+![license](https://img.shields.io/github/license/Kistler-Group/sdbus-cpp)
 
 sdbus-c++ is a high-level C++ D-Bus library for Linux designed to provide expressive, easy-to-use API in modern C++. It adds another layer of abstraction on top of sd-bus, a nice, fresh C D-Bus implementation by systemd.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 sdbus-c++
 =========
 
+![](https://github.com/Kistler-Group/sdbus-cpp/workflows/CI/badge.svg?branch=ci/add-github-actions)
+
 sdbus-c++ is a high-level C++ D-Bus library for Linux designed to provide expressive, easy-to-use API in modern C++. It adds another layer of abstraction on top of sd-bus, a nice, fresh C D-Bus implementation by systemd.
 
 sdbus-c++ has been written primarily as a replacement of dbus-c++, which currently suffers from a number of (unresolved) bugs, concurrency issues and inherent design complexities and limitations. sdbus-c++ has learned from dbus-c++ and has chosen a different path, a path of simple yet powerful design that is intuitive and friendly to the user and inherently free of those bugs.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ sdbus-c++
 
 ![ci](https://github.com/Kistler-Group/sdbus-cpp/workflows/CI/badge.svg?branch=ci/add-github-actions)
 ![license](https://img.shields.io/github/license/Kistler-Group/sdbus-cpp)
+![release](https://img.shields.io/github/v/release/Kistler-Group/sdbus-cpp)
 
 sdbus-c++ is a high-level C++ D-Bus library for Linux designed to provide expressive, easy-to-use API in modern C++. It adds another layer of abstraction on top of sd-bus, a nice, fresh C D-Bus implementation by systemd.
 

--- a/cmake/LibsystemdExternalProject.cmake
+++ b/cmake/LibsystemdExternalProject.cmake
@@ -35,8 +35,8 @@ message(STATUS "Building with embedded libsystemd v${LIBSYSTEMD_VERSION}")
 include(ExternalProject)
 ExternalProject_Add(LibsystemdBuildProject
                     PREFIX libsystemd-v${LIBSYSTEMD_VERSION}
-                    GIT_REPOSITORY    https://github.com/systemd/systemd.git
-                    GIT_TAG           v${LIBSYSTEMD_VERSION}
+                    GIT_REPOSITORY    https://github.com/systemd/systemd-stable.git
+                    GIT_TAG           v${LIBSYSTEMD_VERSION}-stable
                     GIT_SHALLOW       1
                     UPDATE_COMMAND    ""
                     CONFIGURE_COMMAND ${CMAKE_COMMAND} -E remove <BINARY_DIR>/*

--- a/cmake/LibsystemdExternalProject.cmake
+++ b/cmake/LibsystemdExternalProject.cmake
@@ -40,7 +40,7 @@ ExternalProject_Add(LibsystemdBuildProject
                     GIT_SHALLOW       1
                     UPDATE_COMMAND    ""
                     CONFIGURE_COMMAND ${CMAKE_COMMAND} -E remove <BINARY_DIR>/*
-                              COMMAND ${MESON} --prefix=<INSTALL_DIR> --buildtype=${LIBSYSTEMD_BUILD_TYPE} -Dstatic-libsystemd=pic <SOURCE_DIR> <BINARY_DIR>
+                              COMMAND ${MESON} --prefix=<INSTALL_DIR> --buildtype=${LIBSYSTEMD_BUILD_TYPE} -Dstatic-libsystemd=pic -Dselinux=false <SOURCE_DIR> <BINARY_DIR>
                     BUILD_COMMAND     ${BUILD_VERSION_H}
                           COMMAND     ${NINJA} -C <BINARY_DIR> libsystemd.a
                     BUILD_ALWAYS      0


### PR DESCRIPTION
This introduces GitHub CI which runs builds and tests in a matrix configuration. It also changes the systemd repo to stable one. And puts the CI badge (plus a few more badges) to the README page.

Fixes #44 