### PR TITLE
fix: missing copy assignment operator in gcc 8.3

### DIFF
--- a/include/sdbus-c++/Types.h
+++ b/include/sdbus-c++/Types.h
@@ -155,6 +155,7 @@ namespace sdbus {
         using std::string::string;
         ObjectPath() = default; // Fixes gcc 6.3 error (default c-tor is not imported in above using declaration)
         ObjectPath(const ObjectPath&) = default; // Fixes gcc 8.3 error (deleted copy constructor)
+        ObjectPath& operator = (const ObjectPath&) = default; // Fixes gcc 8.3 error (deleted copy assignment)
         ObjectPath(std::string path)
             : std::string(std::move(path))
         {}
@@ -173,6 +174,7 @@ namespace sdbus {
         using std::string::string;
         Signature() = default; // Fixes gcc 6.3 error (default c-tor is not imported in above using declaration)
         Signature(const Signature&) = default; // Fixes gcc 8.3 error (deleted copy constructor)
+        Signature& operator = (const Signature&) = default; // Fixes gcc 8.3 error (deleted copy assignment)
         Signature(std::string path)
             : std::string(std::move(path))
         {}


### PR DESCRIPTION
Explicitly list default copy assignment operator otherwise it is deleted in gcc 8.3.