### PR TITLE
Fixes for floating point systemd version such as  243.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,10 @@ if(NOT BUILD_LIBSYSTEMD)
                             "and building libsystemd in as part of sdbus-c++ during configuration)")
     endif()
     add_library(Systemd::Libsystemd ALIAS PkgConfig::Systemd)
-    set(LIBSYSTEMD_VERSION ${Systemd_VERSION})
+	string(REGEX MATCHALL "([0-9]+)" SYSTEMD_VERSION_LIST "${Systemd_VERSION}")
+
+	list(GET SYSTEMD_VERSION_LIST 0 LIBSYSTEMD_VERSION)
+	message(STATUS "LIBSYSTEMD_VERSION is: ${LIBSYSTEMD_VERSION}")
 else()
     # Build static libsystemd library as an external project
     include(cmake/LibsystemdExternalProject.cmake)


### PR DESCRIPTION
```
~/package $ pkg-config --modversion libsystemd
243.4
~/package $
```
Split it to the list and use the first one


Refer to https://bugzilla.redhat.com/show_bug.cgi?id=1862714