### PR TITLE
Add ability to set hook for exception propagation

### DIFF
--- a/include/sdbus-c++/IProxy.h
+++ b/include/sdbus-c++/IProxy.h
@@ -271,6 +271,10 @@ namespace sdbus {
          * @brief Returns object path of the underlying DBus object
          */
         virtual const std::string& getObjectPath() const = 0;
+
+        using translate_error_hook_type = std::function<std::exception_ptr(const sdbus::Error&)>;
+
+        virtual void setTranslateErrorHook(translate_error_hook_type hook) = 0;
     };
 
     /********************************************//**

--- a/src/Proxy.h
+++ b/src/Proxy.h
@@ -62,6 +62,8 @@ namespace sdbus::internal {
 
         const std::string& getObjectPath() const override;
 
+        void setTranslateErrorHook(IProxy::translate_error_hook_type hook) override;
+
     private:
         class SyncCallReplyData
         {
@@ -90,6 +92,7 @@ namespace sdbus::internal {
                        > connection_;
         std::string destination_;
         std::string objectPath_;
+        std::optional<translate_error_hook_type> error_hook_;
 
         using InterfaceName = std::string;
         struct InterfaceData


### PR DESCRIPTION
Motivation: we need a replace sdbus::Error with custom exception
classes, depending on content of sdbus::Error::getName()

Implementation notes: Hook should return new exception, wrapped
with std::exception_ptr, or nullptr (then original exception re-thrown)

(I tried to make change minimal)