### PR TITLE
fix #133

### DIFF
--- a/src/Proxy.cpp
+++ b/src/Proxy.cpp
@@ -158,6 +158,7 @@ void Proxy::registerSignalHandler( const std::string& interfaceName
 {
     SDBUS_THROW_ERROR_IF(!signalHandler, "Invalid signal handler provided", EINVAL);
 
+    std::unique_lock lock(mutex_);
     auto& interface = interfaces_[interfaceName];
 
     InterfaceData::SignalData signalData{std::move(signalHandler), nullptr};
@@ -174,6 +175,7 @@ void Proxy::finishRegistration()
 
 void Proxy::registerSignalHandlers(sdbus::internal::IConnection& connection)
 {
+    // std::unique_lock lock(mutex_);
     for (auto& interfaceItem : interfaces_)
     {
         const auto& interfaceName = interfaceItem.first;

--- a/src/Proxy.h
+++ b/src/Proxy.h
@@ -103,6 +103,7 @@ namespace sdbus::internal {
             std::map<SignalName, SignalData> signals_;
         };
         std::map<InterfaceName, InterfaceData> interfaces_;
+        std::mutex mutex_;
 
         // We need to keep track of pending async calls. When the proxy is being destructed, we must
         // remove all slots of these pending calls, otherwise in case when the connection outlives


### PR DESCRIPTION
take this as first draft, not sure if doing it like this is good at all.
Also not completed, as the commented unique_lock line produces a deadlock (Proxy::registerSignalHandlers locks it's own mutex first and then in Connection::registerSignalHandler locks sdbusMutex_, while sdbusMutex_ is already locked when Proxy::sdbus_signal_handler is called and then it tries to lock Proxy's mutex). Don't have a good idea how to handle this...