### PR TITLE
xml2cpp: Add missing EXPAT include dirs

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -43,6 +43,7 @@ set(CMAKE_CXX_STANDARD 14)
 
 add_executable(sdbus-c++-xml2cpp ${SDBUSCPP_XML2CPP_SRCS})
 target_link_libraries (sdbus-c++-xml2cpp ${EXPAT_LIBRARIES})
+target_include_directories(sdbus-c++-xml2cpp PRIVATE ${EXPAT_INCLUDE_DIRS})
 
 #----------------------------------
 # INSTALLATION


### PR DESCRIPTION
I was working on a conan.io package for sdbus-c++ and I had a problem to build it with `-DBUILD_CODE_GEN=ON` option, because it couldn't find EXPAT headers.

This patch is required if EXPAT library is installed in non-standard location.
Without `target_include_directories` cmake will find EXPAT library:
  ```
  -- Found EXPAT: .../lib/libexpat.a (found version "2.2.10")
  ```

But `xml.cpp` compilation will fail with error:
  ```
  tools/xml2cpp-codegen/xml.cpp:7:10: fatal error: expat.h: No such file or directory
    7 | #include <expat.h>
  ```