### PR TITLE
add getting bus peer credentials (uid/gids)

### DIFF
--- a/include/sdbus-c++/IConnection.h
+++ b/include/sdbus-c++/IConnection.h
@@ -31,6 +31,7 @@
 #include <memory>
 #include <chrono>
 #include <cstdint>
+#include <vector>
 
 namespace sdbus {
 
@@ -80,6 +81,13 @@ namespace sdbus {
          * @throws sdbus::Error in case of failure
          */
         virtual std::string getUniqueName() const = 0;
+
+        /*
+        virtual uid_t getCredsUid(std::string bus_name) const = 0;
+        virtual uid_t getCredsEuid(std::string bus_name) const = 0;
+        virtual gid_t getCredsGid(std::string bus_name) const = 0;
+        virtual std::vector<gid_t> getCredsSupplementaryGids(std::string bus_name) const = 0;
+        */
 
         /*!
          * @brief Enters I/O event loop on this bus connection

--- a/include/sdbus-c++/Message.h
+++ b/include/sdbus-c++/Message.h
@@ -138,6 +138,11 @@ namespace sdbus {
         void seal();
         void rewind(bool complete);
 
+        uid_t getCredsUid(const std::string bus_name) const;
+        uid_t getCredsEuid(const std::string bus_name) const;
+        gid_t getCredsGid(const std::string bus_name) const;
+        std::vector<gid_t> getCredsSupplementaryGids(const std::string bus_name) const;
+
         class Factory;
 
     protected:

--- a/src/Connection.h
+++ b/src/Connection.h
@@ -60,6 +60,12 @@ namespace sdbus::internal {
         void requestName(const std::string& name) override;
         void releaseName(const std::string& name) override;
         std::string getUniqueName() const override;
+
+        //uid_t getCredsUid(const std::string bus_name) const override;
+        //uid_t getCredsEuid(const std::string bus_name) const override;
+        //gid_t getCredsGid(const std::string bus_name) const override;
+        //std::vector<gid_t> getCredsSupplementaryGids(const std::string bus_name) const override;
+
         void enterEventLoop() override;
         void enterEventLoopAsync() override;
         void leaveEventLoop() override;

--- a/src/ISdBus.h
+++ b/src/ISdBus.h
@@ -72,6 +72,16 @@ namespace sdbus::internal {
         virtual int sd_bus_request_name(sd_bus *bus, const char *name, uint64_t flags) = 0;
         virtual int sd_bus_release_name(sd_bus *bus, const char *name) = 0;
         virtual int sd_bus_get_unique_name(sd_bus *bus, const char **name) = 0;
+
+        virtual sd_bus* sd_bus_message_get_bus(sd_bus_message *m) = 0;
+        virtual int sd_bus_get_name_creds(sd_bus *bus, const char *name, uint64_t mask, sd_bus_creds **creds) = 0;
+        virtual sd_bus_creds* sd_bus_creds_unref(sd_bus_creds *c) = 0;
+
+        virtual int sd_bus_creds_get_uid(sd_bus_creds *c, uid_t *uid) = 0;
+        virtual int sd_bus_creds_get_euid(sd_bus_creds *c, uid_t *uid) = 0;
+        virtual int sd_bus_creds_get_gid(sd_bus_creds *c, gid_t *gid) = 0;
+        virtual int sd_bus_creds_get_supplementary_gids(sd_bus_creds *c, const gid_t **gids) = 0;
+
         virtual int sd_bus_add_object_vtable(sd_bus *bus, sd_bus_slot **slot, const char *path, const char *interface, const sd_bus_vtable *vtable, void *userdata) = 0;
         virtual int sd_bus_add_object_manager(sd_bus *bus, sd_bus_slot **slot, const char *path) = 0;
         virtual int sd_bus_add_match(sd_bus *bus, sd_bus_slot **slot, const char *match, sd_bus_message_handler_t callback, void *userdata) = 0;

--- a/src/SdBus.cpp
+++ b/src/SdBus.cpp
@@ -196,6 +196,44 @@ int SdBus::sd_bus_get_unique_name(sd_bus *bus, const char **name)
     return ::sd_bus_get_unique_name(bus, name);
 }
 
+
+sd_bus* SdBus::sd_bus_message_get_bus(sd_bus_message *m)
+{
+    return ::sd_bus_message_get_bus(m);
+}
+
+int SdBus::sd_bus_get_name_creds(sd_bus *bus, const char *name, uint64_t mask, sd_bus_creds **creds)
+{
+    std::lock_guard lock(sdbusMutex_);
+
+    return ::sd_bus_get_name_creds(bus, name, mask, creds);
+}
+
+sd_bus_creds* SdBus::sd_bus_creds_unref(sd_bus_creds *c)
+{
+    return ::sd_bus_creds_unref(c);
+}
+
+int SdBus::sd_bus_creds_get_uid(sd_bus_creds *c, uid_t *uid)
+{
+    return ::sd_bus_creds_get_uid(c, uid);
+}
+
+int SdBus::sd_bus_creds_get_euid(sd_bus_creds *c, uid_t *uid)
+{
+    return ::sd_bus_creds_get_euid(c, uid);
+}
+
+int SdBus::sd_bus_creds_get_gid(sd_bus_creds *c, gid_t *gid)
+{
+    return ::sd_bus_creds_get_gid(c, gid);
+}
+
+int SdBus::sd_bus_creds_get_supplementary_gids(sd_bus_creds *c, const gid_t **gids)
+{
+    return ::sd_bus_creds_get_supplementary_gids(c, gids);
+}
+
 int SdBus::sd_bus_add_object_vtable(sd_bus *bus, sd_bus_slot **slot, const char *path, const char *interface, const sd_bus_vtable *vtable, void *userdata)
 {
     std::lock_guard lock(sdbusMutex_);

--- a/src/SdBus.h
+++ b/src/SdBus.h
@@ -64,6 +64,15 @@ public:
     virtual int sd_bus_request_name(sd_bus *bus, const char *name, uint64_t flags) override;
     virtual int sd_bus_release_name(sd_bus *bus, const char *name) override;
     virtual int sd_bus_get_unique_name(sd_bus *bus, const char **name) override;
+
+    virtual sd_bus* sd_bus_message_get_bus(sd_bus_message *m) override;
+    virtual int sd_bus_get_name_creds(sd_bus *bus, const char *name, uint64_t mask, sd_bus_creds **creds) override;
+    virtual sd_bus_creds* sd_bus_creds_unref(sd_bus_creds *c) override;
+    virtual int sd_bus_creds_get_uid(sd_bus_creds *c, uid_t *uid) override;
+    virtual int sd_bus_creds_get_euid(sd_bus_creds *c, uid_t *uid) override;
+    virtual int sd_bus_creds_get_gid(sd_bus_creds *c, gid_t *gid) override;
+    virtual int sd_bus_creds_get_supplementary_gids(sd_bus_creds *c, const gid_t **gids) override;
+
     virtual int sd_bus_add_object_vtable(sd_bus *bus, sd_bus_slot **slot, const char *path, const char *interface, const sd_bus_vtable *vtable, void *userdata) override;
     virtual int sd_bus_add_object_manager(sd_bus *bus, sd_bus_slot **slot, const char *path) override;
     virtual int sd_bus_add_match(sd_bus *bus, sd_bus_slot **slot, const char *match, sd_bus_message_handler_t callback, void *userdata) override;


### PR DESCRIPTION
exposes a subset of the sd_bus_creds_get_* family of
calls to retrieve the bus peer's userid and
group ids.

Example usage:
```c++
void example(sdbus::MethodCall call)
{
    [...]
    SubjectType subject;
    call >> subject;
    std::string bus_name = "";
    auto subject_kind = subject.get<0>();
    if (subject_kind == "system-bus-name") {
        auto subject_details_map = subject.get<1>();
        auto iter = subject_details_map.find("name");
        if (iter != subject_details_map.end()) {
            sdbus::Variant subject_detail_value = iter->second;
            bus_name = subject_detail_value.get<std::string>();
        }
    }
    [...]
    auto uid = call.getCredsUid(bus_name);
    gid_t gid = call.getCredsGid(bus_name);
    std::vector<gid_t> gids = call.getCredsSupplementaryGids(bus_name);
    [...]
}
```