### PR TITLE
Add README and sdbus-c++ tutorial as additional pages in doxydocs

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -12,6 +12,10 @@ if(BUILD_DOXYGEN_DOC)
             COMMENT "Generating API documentation with Doxygen"
             VERBATIM)
 
+        # workaround bug https://github.com/doxygen/doxygen/pull/6787
+        add_custom_command(TARGET doc POST_BUILD
+          COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_LIST_DIR}/sdbus-c++-class-diagram.png ${CMAKE_CURRENT_BINARY_DIR}/html/.)
+        
         install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/html DESTINATION ${CMAKE_INSTALL_DOCDIR} OPTIONAL)
     else()
         message(WARNING "Documentation enabled, but Doxygen cannot be found")

--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -790,7 +790,9 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = "@CMAKE_CURRENT_SOURCE_DIR@/../include" @CMAKE_CURRENT_SOURCE_DIR@/using-sdbus-c++.md 
+INPUT                  = "@CMAKE_CURRENT_SOURCE_DIR@/../include" \
+                          @CMAKE_CURRENT_SOURCE_DIR@/../README.md \
+                          @CMAKE_CURRENT_SOURCE_DIR@/using-sdbus-c++.md
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses
@@ -982,7 +984,7 @@ FILTER_SOURCE_PATTERNS =
 # (index.html). This can be useful if you have a project on for instance GitHub
 # and want to reuse the introduction page also for the doxygen output.
 
-USE_MDFILE_AS_MAINPAGE =
+USE_MDFILE_AS_MAINPAGE = README.md
 
 #---------------------------------------------------------------------------
 # Configuration options related to source browsing

--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -790,7 +790,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = "@CMAKE_CURRENT_SOURCE_DIR@/../include"
+INPUT                  = "@CMAKE_CURRENT_SOURCE_DIR@/../include" @CMAKE_CURRENT_SOURCE_DIR@/using-sdbus-c++.md 
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses

--- a/docs/using-sdbus-c++.md
+++ b/docs/using-sdbus-c++.md
@@ -1,4 +1,4 @@
-Using sdbus-c++ library
+Using sdbus-c++ library     {#mainpage}
 =======================
 
 **Table of contents**

--- a/docs/using-sdbus-c++.md
+++ b/docs/using-sdbus-c++.md
@@ -1,4 +1,4 @@
-Using sdbus-c++ library     {#mainpage}
+Using sdbus-c++ library
 =======================
 
 **Table of contents**


### PR DESCRIPTION
Here's a couple small changes to enhance the project's current doxydocs.

I've added "{#mainpage}" to the "using-sdbus-c++" file to tell doxygen to use that as the mainpage for the documentation.  

I also had to add a custom rule that copies the png into the html directory.  This is to work around a bug in doxygen related to images inside of markdown text. 

And of course the Doxyfile.in needed to have the using-sdbus-c++ included. 
