### PR TITLE
Catch exceptions in the background thread

### DIFF
--- a/src/Connection.cpp
+++ b/src/Connection.cpp
@@ -107,7 +107,17 @@ void Connection::enterEventLoop()
 void Connection::enterEventLoopAsync()
 {
     if (!asyncLoopThread_.joinable())
-        asyncLoopThread_ = std::thread([this](){ enterEventLoop(); });
+    {
+        asyncLoopThread_ = std::thread([this]()
+        {
+            try
+            {
+                enterEventLoop();
+            } catch (...) {
+                // Ignore unhandled exceptions
+            }
+        });
+    }
 }
 
 void Connection::leaveEventLoop()


### PR DESCRIPTION
Potentially `enterEventLoop()` may throw an exception. Since the async event loop is running in a background thread, there is no way for clients to catch and handle an exception. So to prevent termination of client's applications all exceptions get caught and silently ignored.