### PR TITLE
fix: minor documentation and test improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ $ sudo make install
 
 * `BUILD_TESTS` [boolean]
 
-  Option for building sdbus-c++ unit and integration tests, invokable by `make test`. That incorporates downloading and building static libraries of Google Test. Default value: `OFF`. Use `-DBUILD_TESTS=ON` to enable building the tests. With this option turned on, you may also enable/disable the following options:
+  Option for building sdbus-c++ unit and integration tests, invokable by `make test` (Note: before invoking `make test`, make sure you copy `tests/integrationtests/files/org.sdbuscpp.integrationtests.conf` file to `/etc/dbus-1/system.d` directory). That incorporates downloading and building static libraries of Google Test. Default value: `OFF`. Use `-DBUILD_TESTS=ON` to enable building the tests. With this option turned on, you may also enable/disable the following options:
 
     * `ENABLE_PERF_TESTS` [boolean]
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ $ sudo make install
 
 * `BUILD_TESTS` [boolean]
 
-  Option for building sdbus-c++ unit and integration tests, invokable by `make test` (Note: before invoking `make test`, make sure you copy `tests/integrationtests/files/org.sdbuscpp.integrationtests.conf` file to `/etc/dbus-1/system.d` directory). That incorporates downloading and building static libraries of Google Test. Default value: `OFF`. Use `-DBUILD_TESTS=ON` to enable building the tests. With this option turned on, you may also enable/disable the following options:
+  Option for building sdbus-c++ unit and integration tests, invokable by `cmake --build . --target test` (Note: before invoking `cmake --build . --target test`, make sure you copy `tests/integrationtests/files/org.sdbuscpp.integrationtests.conf` file to `/etc/dbus-1/system.d` directory). That incorporates downloading and building static libraries of Google Test. Default value: `OFF`. Use `-DBUILD_TESTS=ON` to enable building the tests. With this option turned on, you may also enable/disable the following options:
 
     * `ENABLE_PERF_TESTS` [boolean]
 

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ The library is built using CMake:
 $ mkdir build
 $ cd build
 $ cmake .. -DCMAKE_BUILD_TYPE=Release ${OTHER_CONFIG_FLAGS}
-$ make
-$ sudo make install
+$ cmake --build .
+$ sudo cmake --build . --target install
 ```
 
 ### CMake configuration flags for sdbus-c++
@@ -36,7 +36,7 @@ $ sudo make install
 
     * `BUILD_DOXYGEN_DOC` [boolean]
 
-      Option for building Doxygen documentation of sdbus-c++ API. If enabled, the documentation must still be built explicitly through `make doc`. Default value: `OFF`. Use `-DBUILD_DOXYGEN_DOC=OFF` to disable searching for Doxygen and building Doxygen documentation of sdbus-c++ API.
+      Option for building Doxygen documentation of sdbus-c++ API. If enabled, the documentation must still be built explicitly through `cmake --build . --target doc`. Default value: `OFF`. Use `-DBUILD_DOXYGEN_DOC=OFF` to disable searching for Doxygen and building Doxygen documentation of sdbus-c++ API.
 
 * `BUILD_TESTS` [boolean]
 

--- a/docs/using-sdbus-c++.md
+++ b/docs/using-sdbus-c++.md
@@ -1169,11 +1169,13 @@ sdbus-c++ provides support for standard D-Bus interfaces. These are:
 
 The implementation of methods that these interfaces define is provided by the library. `Peer`, `Introspectable` and `Properties` are automatically part of interfaces of every D-Bus object. `ObjectManager` is not automatically present and has to be enabled by the client when using `IObject` API. When using generated `ObjectManager_adaptor`, `ObjectManager` is enabled automatically in its constructor.
 
-Pre-generated `*_proxy` and `*_adaptor` convenience classes for these standard interfaces are located in `sdbus-c++/StandardInterfaces.h`. We add them simply as additional parameters of `sdbus::ProxyInterfaces` or `sdbus::AdaptorInterfaces` class template, and our proxy or adaptor class inherits convenience functions from those interface classes.
+Pre-generated `*_proxy` and `*_adaptor` convenience classes for these standard interfaces are located in `sdbus-c++/StandardInterfaces.h`. To use them, we simply have to add them as additional parameters of `sdbus::ProxyInterfaces` or `sdbus::AdaptorInterfaces` class template, and our proxy or adaptor class inherits convenience functions from those interface classes.
 
-For example, to conveniently emit a `PropertyChanged` signal under `org.freedesktop.DBus.Properties` interface, we just issue `emitPropertiesChangedSignal` function of our adaptor object.
+For example, for our `Concatenator` example above in this tutorial, we may want to conveniently emit a `PropertyChanged` signal under `org.freedesktop.DBus.Properties` interface. First, we must augment our `Concatenator` class to also inherit from `org.freedesktop.DBus.Properties` interface: `class Concatenator : public sdbus::AdaptorInterfaces<org::sdbuscpp::Concatenator_adaptor, sdbus::Properties_adaptor> {...};`, and then we just issue `emitPropertiesChangedSignal` function of our adaptor object.
 
 Note that signals of afore-mentioned standard D-Bus interfaces are not emitted by the library automatically. It's clients who are supposed to emit them.
+
+Working examples of using standard D-Bus interfaces can be found in [sdbus-c++ integration tests](/tests/integrationtests/DBusStandardInterfacesTests.cpp).
 
 Conclusion
 ----------

--- a/docs/using-sdbus-c++.md
+++ b/docs/using-sdbus-c++.md
@@ -100,6 +100,19 @@ Tip: If you get `ERROR: Program or command 'getent' not found or not executable`
 
 Contributors willing to help with bringing sdbus-c++ to other popular package systems are welcome.
 
+Verifying sdbus-c++
+-------------------
+
+You can build and run sdbus-c++ unit and integration tests to verify sdbus-c++ build:
+
+```
+$ cd build
+$ cmake .. -DBUILD_TESTS=ON
+$ make
+$ sudo cp ../tests/integrationtests/files/org.sdbuscpp.integrationtests.conf /etc/dbus-1/system.d/
+$ make test
+```
+
 Header files and namespaces
 ---------------------------
 

--- a/docs/using-sdbus-c++.md
+++ b/docs/using-sdbus-c++.md
@@ -108,9 +108,8 @@ You can build and run sdbus-c++ unit and integration tests to verify sdbus-c++ b
 ```
 $ cd build
 $ cmake .. -DBUILD_TESTS=ON
-$ make
 $ sudo cp ../tests/integrationtests/files/org.sdbuscpp.integrationtests.conf /etc/dbus-1/system.d/
-$ make test
+$ cmake --build . --target test
 ```
 
 Header files and namespaces

--- a/tests/integrationtests/DBusConnectionTests.cpp
+++ b/tests/integrationtests/DBusConnectionTests.cpp
@@ -54,8 +54,8 @@ TEST(Connection, CanRequestRegisteredDbusName)
 {
     auto connection = sdbus::createConnection();
 
-    ASSERT_NO_THROW(connection->requestName(INTERFACE_NAME));
-    connection->releaseName(INTERFACE_NAME);
+    ASSERT_NO_THROW(connection->requestName(INTERFACE_NAME))
+        << "Perhaps you've forgotten to copy `org.sdbuscpp.integrationtests.conf` file to `/etc/dbus-1/system.d` directory before running the tests?";
 }
 
 TEST(Connection, CannotRequestNonregisteredDbusName)
@@ -87,6 +87,4 @@ TEST(Connection, CanEnterAndLeaveEventLoop)
     connection->leaveEventLoop();
 
     t.join();
-
-    connection->releaseName(INTERFACE_NAME);
 }

--- a/tests/integrationtests/DBusGeneralTests.cpp
+++ b/tests/integrationtests/DBusGeneralTests.cpp
@@ -51,6 +51,4 @@ TEST(AdaptorAndProxy, CanBeConstructedSuccesfully)
 
     ASSERT_NO_THROW(TestAdaptor adaptor(*connection));
     ASSERT_NO_THROW(TestProxy proxy(INTERFACE_NAME, OBJECT_PATH));
-
-    connection->releaseName(INTERFACE_NAME);
 }


### PR DESCRIPTION
This PR:

* removes unnecessary `releaseName()` calls in integration tests,
* adds a custom gtest message if a connection test fails, pointing the user to the potential cause of the issue,
* adds more documentation on how to test sdbus-c++ build.

Fixes #162 
Fixes #155 