### PR TITLE
Add API to set signal destination

### DIFF
--- a/include/sdbus-c++/Message.h
+++ b/include/sdbus-c++/Message.h
@@ -215,6 +215,7 @@ namespace sdbus {
 
     public:
         Signal() = default;
+        void setDestination(const std::string& destination);
         void send() const;
     };
 

--- a/src/Message.cpp
+++ b/src/Message.cpp
@@ -818,6 +818,12 @@ void Signal::send() const
     SDBUS_THROW_ERROR_IF(r < 0, "Failed to emit signal", -r);
 }
 
+void Signal::setDestination(const std::string& destination)
+{
+    auto r = sd_bus_message_set_destination((sd_bus_message*)msg_, destination.c_str());
+    SDBUS_THROW_ERROR_IF(r < 0, "Failed to set signal destination", -r);
+}
+
 PlainMessage createPlainMessage()
 {
     static auto connection = internal::createConnection();


### PR DESCRIPTION
With this patch it is possible to create unicast signals - e.g. I want to keep client informed about the progress in processing of his request using regularly sent dbus signals so that the client could print a progress bar or something. Only the client that sent original request is interested in such signal:

```
auto signal = dbus_object->createSignal(interface, "ProcessProgress");
signal.setDestination(request_sender);
signal << items_processed;
signal << items_total;
dbus_object->emitSignal(signal);
```
