### PR TITLE
fix #145, signals are not filtered by sender

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -169,3 +169,6 @@ v0.8.3
 - Update CMake configuration flag names
 - Fix unused variable warning for release builds
 - Introduce CI workflow based on GitHub Actions
+
+v0.8.4
+- fix issue #145: signals are not filtered by sender

--- a/src/Connection.cpp
+++ b/src/Connection.cpp
@@ -298,8 +298,9 @@ SlotPtr Connection::registerSignalHandler( const std::string& sender
 {
     sd_bus_slot *slot{};
 
-    // alternatively to our own composeSignalMatchFilter() implementation, we could also use sd_bus_match_signal() from
-    // https://www.freedesktop.org/software/systemd/man/sd_bus_add_match.html#
+    // Alternatively to our own composeSignalMatchFilter() implementation, we could use sd_bus_match_signal() from
+    // https://www.freedesktop.org/software/systemd/man/sd_bus_add_match.html .
+    // But this would require libsystemd v237 or higher.
     auto filter = composeSignalMatchFilter(sender, objectPath, interfaceName, signalName);
     auto r = iface_->sd_bus_add_match(bus_.get(), &slot, filter.c_str(), callback, userData);
 

--- a/src/Connection.h
+++ b/src/Connection.h
@@ -99,7 +99,8 @@ namespace sdbus::internal {
         void emitInterfacesRemovedSignal( const std::string& objectPath
                                         , const std::vector<std::string>& interfaces ) override;
 
-        SlotPtr registerSignalHandler( const std::string& objectPath
+        SlotPtr registerSignalHandler( const std::string& sender
+                                     , const std::string& objectPath
                                      , const std::string& interfaceName
                                      , const std::string& signalName
                                      , sd_bus_message_handler_t callback
@@ -115,9 +116,9 @@ namespace sdbus::internal {
         BusPtr openBus(const std::function<int(sd_bus**)>& busFactory);
         void finishHandshake(sd_bus* bus);
         bool waitForNextRequest();
-        static std::string composeSignalMatchFilter( const std::string& objectPath
-                                                   , const std::string& interfaceName
-                                                   , const std::string& signalName );
+        static std::string composeSignalMatchFilter(const std::string &sender, const std::string &objectPath,
+                                                    const std::string &interfaceName,
+                                                    const std::string &signalName);
         void notifyEventLoopToExit();
         void clearExitNotification();
         void joinWithEventLoop();

--- a/src/IConnection.h
+++ b/src/IConnection.h
@@ -82,7 +82,8 @@ namespace sdbus::internal {
 
         [[nodiscard]] virtual SlotPtr addObjectManager(const std::string& objectPath, void* /*dummy*/ = nullptr) = 0;
 
-        [[nodiscard]] virtual SlotPtr registerSignalHandler( const std::string& objectPath
+        [[nodiscard]] virtual SlotPtr registerSignalHandler( const std::string& sender
+                                                           , const std::string& objectPath
                                                            , const std::string& interfaceName
                                                            , const std::string& signalName
                                                            , sd_bus_message_handler_t callback

--- a/src/Proxy.cpp
+++ b/src/Proxy.cpp
@@ -183,7 +183,8 @@ void Proxy::registerSignalHandlers(sdbus::internal::IConnection& connection)
         {
             const auto& signalName = signalItem.first;
             auto& slot = signalItem.second.slot_;
-            slot = connection.registerSignalHandler( objectPath_
+            slot = connection.registerSignalHandler( destination_
+                                                   , objectPath_
                                                    , interfaceName
                                                    , signalName
                                                    , &Proxy::sdbus_signal_handler

--- a/tests/integrationtests/DBusSignalsTests.cpp
+++ b/tests/integrationtests/DBusSignalsTests.cpp
@@ -67,6 +67,17 @@ TEST_F(SdbusTestObject, EmitsSimpleSignalToMultipleProxiesSuccesfully)
     ASSERT_TRUE(waitUntil(proxy2->m_gotSimpleSignal));
 }
 
+TEST_F(SdbusTestObject, ProxyDoesNotReceiveSignalFromOtherBusName)
+{
+    auto otherBusName = INTERFACE_NAME + "2";
+    auto connection2 = sdbus::createConnection(otherBusName);
+    auto adaptor2 = std::make_unique<TestAdaptor>(*connection2);
+
+    adaptor2->emitSimpleSignal();
+
+    ASSERT_FALSE(waitUntil(m_proxy->m_gotSimpleSignal, std::chrono::seconds(1)));
+}
+
 TEST_F(SdbusTestObject, EmitsSignalWithMapSuccesfully)
 {
     m_adaptor->emitSignalWithMap({{0, "zero"}, {1, "one"}});

--- a/tests/integrationtests/files/org.sdbuscpp.integrationtests.conf
+++ b/tests/integrationtests/files/org.sdbuscpp.integrationtests.conf
@@ -11,6 +11,9 @@
     <allow own="org.sdbuscpp.integrationtests"/>
     <allow send_destination="org.sdbuscpp.integrationtests"/>
     <allow send_interface="org.sdbuscpp.integrationtests"/>
+
+    <allow own="org.sdbuscpp.integrationtests2"/>
+    <allow send_destination="org.sdbuscpp.integrationtests2"/>
   </policy>
 
 </busconfig>


### PR DESCRIPTION
fix for #145 

A new integration test is added first with uncovers the issue. It shows that a proxy gets the signal from any/all bus names (destinations) if the object path and interface match. We want the proxy to only connect to the `destination` which was given as argument during construction.

A missing `sender=..` in the match filter rule solves the issue.