### PR TITLE
Provide CMake config and PkgConfig files for tools

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 cmake_minimum_required(VERSION 3.5)
 
-project(sdbus-c++-tools)
+project(sdbus-c++-tools VERSION 0.8.3)
 
 include(GNUInstallDirs)
 
@@ -49,4 +49,27 @@ target_include_directories(sdbus-c++-xml2cpp PRIVATE ${EXPAT_INCLUDE_DIRS})
 # INSTALLATION
 #----------------------------------
 
-install(TARGETS sdbus-c++-xml2cpp EXPORT sdbus-c++-xml2cpp DESTINATION ${CMAKE_INSTALL_BINDIR})
+install(TARGETS sdbus-c++-xml2cpp EXPORT sdbus-c++-tools-targets DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+#----------------------------------
+# CMAKE CONFIG & PACKAGE CONFIG
+#----------------------------------
+
+include(CMakePackageConfigHelpers)
+
+install(EXPORT sdbus-c++-tools-targets
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/sdbus-c++-tools
+        NAMESPACE SDBusCpp::
+        COMPONENT dev)
+
+configure_package_config_file(cmake/sdbus-c++-tools-config.cmake.in cmake/sdbus-c++-tools-config.cmake
+                              INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/sdbus-c++)
+write_basic_package_version_file(cmake/sdbus-c++-tools-config-version.cmake COMPATIBILITY SameMajorVersion)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/cmake/sdbus-c++-tools-config.cmake
+              ${CMAKE_CURRENT_BINARY_DIR}/cmake/sdbus-c++-tools-config-version.cmake
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/sdbus-c++-tools
+        COMPONENT dev)
+
+configure_file(pkgconfig/sdbus-c++-tools.pc.in pkgconfig/sdbus-c++-tools.pc @ONLY)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/pkgconfig/sdbus-c++-tools.pc
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig COMPONENT dev)

--- a/tools/cmake/sdbus-c++-tools-config.cmake.in
+++ b/tools/cmake/sdbus-c++-tools-config.cmake.in
@@ -1,0 +1,4 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-targets.cmake")
+check_required_components("sdbus-c++-xml2cpp")

--- a/tools/pkgconfig/sdbus-c++-tools.pc.in
+++ b/tools/pkgconfig/sdbus-c++-tools.pc.in
@@ -1,0 +1,8 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=@CMAKE_INSTALL_PREFIX@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
+
+Name: @PROJECT_NAME@
+Description: Stub generator tool for sdbus-c++ library
+Version: @SDBUSCPP_VERSION@


### PR DESCRIPTION
When a project uses automatically generated interface headers using the stub generator it is convenient if the conversion by the stub generator can be integrated into the project itself. Until now it was not possible to search for the availibility of the stub generator and it had to be invoked blindly.

This commit provides CMake and PkgConfig files which allow projects to check availibility of the stub generator as well as its version and to automatically resolve its installation path.