### PR TITLE
Issue 133 race in proxy destruct 

### DIFF
--- a/src/Proxy.cpp
+++ b/src/Proxy.cpp
@@ -160,7 +160,7 @@ void Proxy::registerSignalHandler( const std::string& interfaceName
 
     auto& interface = interfaces_[interfaceName];
 
-    InterfaceData::SignalData signalData{*this, std::move(signalHandler), nullptr};
+    auto signalData = std::make_unique<InterfaceData::SignalData>(*this, std::move(signalHandler), nullptr);
     auto insertionResult = interface.signals_.emplace(signalName, std::move(signalData));
 
     auto inserted = insertionResult.second;
@@ -183,13 +183,13 @@ void Proxy::registerSignalHandlers(sdbus::internal::IConnection& connection)
         {
             const auto& signalName = signalItem.first;
             auto& signalData = signalItem.second;
-            auto& slot = signalData.slot_;
+            auto& slot = signalData->slot_;
             slot = connection.registerSignalHandler(destination_
                                                    , objectPath_
                                                    , interfaceName
                                                    , signalName
                                                    , &Proxy::sdbus_signal_handler
-                                                   , &signalData);
+                                                   , signalData.get());
         }
     }
 }

--- a/src/Proxy.cpp
+++ b/src/Proxy.cpp
@@ -182,14 +182,14 @@ void Proxy::registerSignalHandlers(sdbus::internal::IConnection& connection)
         for (auto& signalItem : signalsOnInterface)
         {
             const auto& signalName = signalItem.first;
-            auto& signalData = signalItem.second;
+            auto* signalData = signalItem.second.get();
             auto& slot = signalData->slot_;
             slot = connection.registerSignalHandler(destination_
                                                    , objectPath_
                                                    , interfaceName
                                                    , signalName
                                                    , &Proxy::sdbus_signal_handler
-                                                   , signalData.get());
+                                                   , signalData);
         }
     }
 }

--- a/src/Proxy.cpp
+++ b/src/Proxy.cpp
@@ -245,7 +245,7 @@ int Proxy::sdbus_signal_handler(sd_bus_message *sdbusMessage, void *userData, sd
     assert(signalData != nullptr);
     assert(signalData->callback_);
 
-    auto message = Message::Factory::create<Signal>(sdbusMessage, &signalData->proxy.connection_->getSdBusInterface());
+    auto message = Message::Factory::create<Signal>(sdbusMessage, &signalData->proxy_.connection_->getSdBusInterface());
     signalData->callback_(message);
     return 0;
 }

--- a/src/Proxy.cpp
+++ b/src/Proxy.cpp
@@ -183,13 +183,12 @@ void Proxy::registerSignalHandlers(sdbus::internal::IConnection& connection)
         {
             const auto& signalName = signalItem.first;
             auto* signalData = signalItem.second.get();
-            auto& slot = signalData->slot_;
-            slot = connection.registerSignalHandler(destination_
-                                                   , objectPath_
-                                                   , interfaceName
-                                                   , signalName
-                                                   , &Proxy::sdbus_signal_handler
-                                                   , signalData);
+            signalData->slot = connection.registerSignalHandler( destination_
+                                                               , objectPath_
+                                                               , interfaceName
+                                                               , signalName
+                                                               , &Proxy::sdbus_signal_handler
+                                                               , signalData);
         }
     }
 }
@@ -243,10 +242,10 @@ int Proxy::sdbus_signal_handler(sd_bus_message *sdbusMessage, void *userData, sd
 {
     auto* signalData = static_cast<InterfaceData::SignalData*>(userData);
     assert(signalData != nullptr);
-    assert(signalData->callback_);
+    assert(signalData->callback);
 
-    auto message = Message::Factory::create<Signal>(sdbusMessage, &signalData->proxy_.connection_->getSdBusInterface());
-    signalData->callback_(message);
+    auto message = Message::Factory::create<Signal>(sdbusMessage, &signalData->proxy.connection_->getSdBusInterface());
+    signalData->callback(message);
     return 0;
 }
 

--- a/src/Proxy.h
+++ b/src/Proxy.h
@@ -97,7 +97,7 @@ namespace sdbus::internal {
             using SignalName = std::string;
             struct SignalData
             {
-                Proxy& proxy;
+                Proxy& proxy_;
                 signal_handler callback_;
                 // slot_ must be listed after callback_ to ensure that slot_ is destructed first.
                 // Destructing the slot_ will sd_bus_slot_unref() the callback.

--- a/src/Proxy.h
+++ b/src/Proxy.h
@@ -158,8 +158,8 @@ namespace sdbus::internal {
             }
 
         private:
-            std::unordered_map<void*, std::shared_ptr<CallData>> calls_;
             std::mutex mutex_;
+            std::unordered_map<void*, std::shared_ptr<CallData>> calls_;
         } pendingAsyncCalls_;
     };
 

--- a/src/Proxy.h
+++ b/src/Proxy.h
@@ -149,6 +149,7 @@ namespace sdbus::internal {
             {
                 std::unique_lock lock(mutex_);
                 auto asyncCallSlots = std::move(calls_);
+                calls_ = {};
                 lock.unlock();
 
                 // Releasing call slot pointer acquires global sd-bus mutex. We have to perform the release

--- a/src/Proxy.h
+++ b/src/Proxy.h
@@ -98,17 +98,17 @@ namespace sdbus::internal {
             struct SignalData
             {
                 SignalData(Proxy& proxy, signal_handler callback, SlotPtr slot)
-                    : proxy_(proxy)
-                    , callback_(std::move(callback))
-                    , slot_(std::move(slot))
+                    : proxy(proxy)
+                    , callback(std::move(callback))
+                    , slot(std::move(slot))
                 {}
-                Proxy& proxy_;
-                signal_handler callback_;
+                Proxy& proxy;
+                signal_handler callback;
                 // slot_ must be listed after callback_ to ensure that slot_ is destructed first.
                 // Destructing the slot_ will sd_bus_slot_unref() the callback.
                 // Only after sd_bus_slot_unref(), we can safely delete the callback. The bus mutex (SdBus::sdbusMutex_)
                 // ensures that sd_bus_slot_unref() and the callback execute sequentially.
-                SlotPtr slot_;
+                SlotPtr slot;
             };
             std::map<SignalName, std::unique_ptr<SignalData>> signals_;
         };

--- a/src/Proxy.h
+++ b/src/Proxy.h
@@ -97,6 +97,11 @@ namespace sdbus::internal {
             using SignalName = std::string;
             struct SignalData
             {
+                SignalData(Proxy& proxy, signal_handler callback, SlotPtr slot)
+                    : proxy_(proxy)
+                    , callback_(std::move(callback))
+                    , slot_(std::move(slot))
+                {}
                 Proxy& proxy_;
                 signal_handler callback_;
                 // slot_ must be listed after callback_ to ensure that slot_ is destructed first.
@@ -105,7 +110,7 @@ namespace sdbus::internal {
                 // ensures that sd_bus_slot_unref() and the callback execute sequentially.
                 SlotPtr slot_;
             };
-            std::map<SignalName, SignalData> signals_;
+            std::map<SignalName, std::unique_ptr<SignalData>> signals_;
         };
         std::map<InterfaceName, InterfaceData> interfaces_;
 

--- a/src/Proxy.h
+++ b/src/Proxy.h
@@ -95,10 +95,10 @@ namespace sdbus::internal {
         struct InterfaceData
         {
             using SignalName = std::string;
-            using Callback = std::function<int(sd_bus_message *sdbusMessage)>;
             struct SignalData
             {
-                Callback callback_;
+                Proxy& proxy;
+                signal_handler callback_;
                 // slot_ must be listed after callback_ to ensure that slot_ is destructed first.
                 // Destructing the slot_ will sd_bus_slot_unref() the callback.
                 // Only after sd_bus_slot_unref(), we can safely delete the callback. The bus mutex (SdBus::sdbusMutex_)


### PR DESCRIPTION
replaces #134 
fixes #133

@ChristianS99 's observations about the race condition while destructing a proxy were extremely helpful. As it was mentioned, #134 didn't solve all issues in an elegant way. So this PR should replace it.

[interfaces_](https://github.com/Kistler-Group/sdbus-cpp/blob/master/src/Proxy.h#L105) is the critical resource which is potentially shared by the main thread and connection loop thread.

The first approach was to wrap all access to `interfaces_` into it's own thread-safe class, similar to [class AsyncCalls](https://github.com/Kistler-Group/sdbus-cpp/blob/master/src/Proxy.h#L111). But this solution was complex and didn't fully solve the [ABA problem](https://en.wikipedia.org/wiki/ABA_problem) which @ChristianS99 described.

So the solution in this PR is to just avoid the need to access `interfaces_` inside signal handler callbacks. This even saves a `std::map` lookup for every callback, but it comes at the cost of another extra lambda being wrapped around the callback. The actual access to `interfaces_` is saved in the callback by passing the relevant data before as user data to the underlying libsdbus.

The solution is tested with the two test programs provided in #133. They no longer create a SEGV.

In addition, two potentially dangerous code segments inside `class AsyncCalls` were fixed:
- ensure the mutex is destructed last
- a clear() shouldn't leave the container in a "moved-out" state.