### PR TITLE
Add IProxy::getConnection()

### DIFF
--- a/include/sdbus-c++/IProxy.h
+++ b/include/sdbus-c++/IProxy.h
@@ -268,6 +268,13 @@ namespace sdbus {
         [[nodiscard]] PropertySetter setProperty(const std::string& propertyName);
 
         /*!
+         * @brief Provides D-Bus connection used by the proxy
+         *
+         * @return Reference to the D-Bus connection
+         */
+        virtual sdbus::IConnection& getConnection() const = 0;
+
+        /*!
          * @brief Returns object path of the underlying DBus object
          */
         virtual const std::string& getObjectPath() const = 0;

--- a/src/Proxy.cpp
+++ b/src/Proxy.cpp
@@ -199,6 +199,11 @@ void Proxy::unregister()
     interfaces_.clear();
 }
 
+sdbus::IConnection& Proxy::getConnection() const
+{
+    return dynamic_cast<sdbus::IConnection&>(*connection_);
+}
+
 const std::string& Proxy::getObjectPath() const
 {
     return objectPath_;

--- a/src/Proxy.h
+++ b/src/Proxy.h
@@ -60,6 +60,7 @@ namespace sdbus::internal {
         void finishRegistration() override;
         void unregister() override;
 
+        sdbus::IConnection& getConnection() const override;
         const std::string& getObjectPath() const override;
 
     private:


### PR DESCRIPTION
This provides access to the proxy's bus connection so code using the proxy does not need to store an external reference to it.

A matching function is already available in `IObject`.

I mentioned this change here: https://github.com/Kistler-Group/sdbus-cpp/discussions/169