### PR TITLE
Enable default construction of PendingAsyncCall

### DIFF
--- a/include/sdbus-c++/IProxy.h
+++ b/include/sdbus-c++/IProxy.h
@@ -286,6 +286,8 @@ namespace sdbus {
     class PendingAsyncCall
     {
     public:
+        PendingAsyncCall() = default;
+
         /*!
          * @brief Cancels the delivery of the pending asynchronous call result
          *

--- a/tests/integrationtests/DBusAsyncMethodsTests.cpp
+++ b/tests/integrationtests/DBusAsyncMethodsTests.cpp
@@ -201,6 +201,22 @@ TEST_F(SdbusTestObject, AnswersThatAsyncCallIsNotPendingAfterItHasBeenCompleted)
     ASSERT_TRUE(waitUntil([&call](){ return !call.isPending(); }));
 }
 
+TEST_F(SdbusTestObject, AnswersThatDefaultConstructedAsyncCallIsNotPending)
+{
+    sdbus::PendingAsyncCall call;
+
+    ASSERT_FALSE(call.isPending());
+}
+
+TEST_F(SdbusTestObject, SupportsAsyncCallCopyAssignment)
+{
+    sdbus::PendingAsyncCall call;
+
+    call = m_proxy->doOperationClientSideAsync(100);
+
+    ASSERT_TRUE(call.isPending());
+}
+
 TEST_F(SdbusTestObject, InvokesErroneousMethodAsynchronouslyOnClientSide)
 {
     std::promise<uint32_t> promise;


### PR DESCRIPTION
This is helpful in use cases where a user defined class wants to store a `PendingAsyncCall` as a member variable, or in a STL container.

I mentioned this change here: https://github.com/Kistler-Group/sdbus-cpp/discussions/169