### PR TITLE
Add createDefaultBusConnection()

### DIFF
--- a/include/sdbus-c++/IConnection.h
+++ b/include/sdbus-c++/IConnection.h
@@ -266,6 +266,27 @@ namespace sdbus {
     [[nodiscard]] std::unique_ptr<sdbus::IConnection> createConnection(const std::string& name);
 
     /*!
+     * @brief Creates/opens D-Bus user connection when in a user context,
+     * and a system connection, otherwise.
+     *
+     * @return Connection instance
+     *
+     * @throws sdbus::Error in case of failure
+     */
+    [[nodiscard]] std::unique_ptr<sdbus::IConnection> createDefaultBusConnection();
+
+    /*!
+     * @brief Creates/opens D-Bus user connection with a name when in a user
+     * context, and a system connection with a name, otherwise.
+     *
+     * @param[in] name Name to request on the connection after its opening
+     * @return Connection instance
+     *
+     * @throws sdbus::Error in case of failure
+     */
+    [[nodiscard]] std::unique_ptr<sdbus::IConnection> createDefaultBusConnection(const std::string& name);
+
+    /*!
      * @brief Creates/opens D-Bus system connection
      *
      * @return Connection instance

--- a/src/Connection.h
+++ b/src/Connection.h
@@ -48,10 +48,12 @@ namespace sdbus::internal {
     {
     public:
         // Bus type tags
+        struct default_bus_t{};
         struct system_bus_t{};
         struct session_bus_t{};
         struct remote_system_bus_t{};
 
+        Connection(std::unique_ptr<ISdBus>&& interface, default_bus_t);
         Connection(std::unique_ptr<ISdBus>&& interface, system_bus_t);
         Connection(std::unique_ptr<ISdBus>&& interface, session_bus_t);
         Connection(std::unique_ptr<ISdBus>&& interface, remote_system_bus_t, const std::string& host);

--- a/src/ISdBus.h
+++ b/src/ISdBus.h
@@ -66,6 +66,7 @@ namespace sdbus::internal {
         virtual int sd_bus_emit_interfaces_added_strv(sd_bus *bus, const char *path, char **interfaces) = 0;
         virtual int sd_bus_emit_interfaces_removed_strv(sd_bus *bus, const char *path, char **interfaces) = 0;
 
+        virtual int sd_bus_open(sd_bus **ret) = 0;
         virtual int sd_bus_open_user(sd_bus **ret) = 0;
         virtual int sd_bus_open_system(sd_bus **ret) = 0;
         virtual int sd_bus_open_system_remote(sd_bus **ret, const char* host) = 0;

--- a/src/SdBus.cpp
+++ b/src/SdBus.cpp
@@ -161,6 +161,11 @@ int SdBus::sd_bus_emit_interfaces_removed_strv(sd_bus *bus, const char *path, ch
     return ::sd_bus_emit_interfaces_removed_strv(bus, path, interfaces);
 }
 
+int SdBus::sd_bus_open(sd_bus **ret)
+{
+    return ::sd_bus_open(ret);
+}
+
 int SdBus::sd_bus_open_user(sd_bus **ret)
 {
     return ::sd_bus_open_user(ret);

--- a/src/SdBus.h
+++ b/src/SdBus.h
@@ -58,6 +58,7 @@ public:
     virtual int sd_bus_emit_interfaces_added_strv(sd_bus *bus, const char *path, char **interfaces) override;
     virtual int sd_bus_emit_interfaces_removed_strv(sd_bus *bus, const char *path, char **interfaces) override;
 
+    virtual int sd_bus_open(sd_bus **ret) override;
     virtual int sd_bus_open_user(sd_bus **ret) override;
     virtual int sd_bus_open_system(sd_bus **ret) override;
     virtual int sd_bus_open_system_remote(sd_bus **ret, const char* hsot) override;

--- a/tests/unittests/mocks/SdBusMock.h
+++ b/tests/unittests/mocks/SdBusMock.h
@@ -57,6 +57,7 @@ public:
     MOCK_METHOD3(sd_bus_emit_interfaces_added_strv, int(sd_bus *bus, const char *path, char **interfaces));
     MOCK_METHOD3(sd_bus_emit_interfaces_removed_strv, int(sd_bus *bus, const char *path, char **interfaces));
 
+    MOCK_METHOD1(sd_bus_open, int(sd_bus **ret));
     MOCK_METHOD1(sd_bus_open_user, int(sd_bus **ret));
     MOCK_METHOD1(sd_bus_open_system, int(sd_bus **ret));
     MOCK_METHOD2(sd_bus_open_system_remote, int(sd_bus **ret, const char *host));


### PR DESCRIPTION
This internally calls `sd_bus_open()`, which automatically selects the system or session bus connection based on the presence and content of a `DBUS_STARTER_BUS_TYPE` environment variable and whether the calling process has root privileges.

This option is very helpful when creating services and clients that will use the system bus in production, but connect to a session for testing.

Note: it was desirable to change `createConnection()` to open the default bus instead of creating a new function, but I assumed this would be too controversial, as it could break existing code that relies on it always opening the system bus.

**Additional changes**
* Removed assertions null-checking `make_unique()` return values. `make_unique()` calls `new`, and `new` is expected to throw or abort on failure, making the assertions unhelpful.
* Corrected a typo in the `ClosesAndUnrefsBusWhenDestructed` unit test for the system bus (tested the wrong bus).