### PR TITLE
Fix issue #135: Segfault in Message::peekType()

### DIFF
--- a/src/Message.cpp
+++ b/src/Message.cpp
@@ -617,7 +617,7 @@ void Message::peekType(std::string& type, std::string& contents) const
     auto r = sd_bus_message_peek_type((sd_bus_message*)msg_, &typeSig, &contentsSig);
     SDBUS_THROW_ERROR_IF(r < 0, "Failed to peek message type", -r);
     type = typeSig;
-    contents = contentsSig;
+    contents = contentsSig ? contentsSig : "";
 }
 
 bool Message::isValid() const

--- a/tests/unittests/Message_test.cpp
+++ b/tests/unittests/Message_test.cpp
@@ -238,3 +238,29 @@ TEST(AMessage, CanCarryAComplexType)
 
     ASSERT_THAT(dataRead, Eq(dataWritten));
 }
+
+TEST(AMessage, CanPeekASimpleType)
+{
+    auto msg = sdbus::createPlainMessage();
+    msg << 123;
+    msg.seal();
+
+    std::string type;
+    std::string contents;
+    msg.peekType(type, contents);
+    ASSERT_THAT(type, "i");
+    ASSERT_THAT(contents, "");
+}
+
+TEST(AMessage, CanPeekContainerContents)
+{
+    auto msg = sdbus::createPlainMessage();
+    msg << std::map<int, std::string>{{1, "one"}, {2, "two"}};
+    msg.seal();
+
+    std::string type;
+    std::string contents;
+    msg.peekType(type, contents);
+    ASSERT_THAT(type, "a");
+    ASSERT_THAT(contents, "{is}");
+}


### PR DESCRIPTION
* Add missing nullptr check in Message::peekType().

* According to its specification, sd_bus_message_peek_type() sets a
  given contents parameter to NULL if the next element in a message is
  not a container. Since assigning a nullptr to a std::string has
  undefined behaviour (typically resulting in an invalid memory access),
  Message::peekType() must not assign contentsSig unconditionally.