### PR TITLE
Catch sdbus-c++ exceptions flying from Proxy callbacks to libsystemd

### DIFF
--- a/include/sdbus-c++/ConvenienceApiClasses.inl
+++ b/include/sdbus-c++/ConvenienceApiClasses.inl
@@ -593,7 +593,7 @@ namespace sdbus {
                 {
                     reply >> args;
                 }
-                catch (const sdbus::Error& e)
+                catch (const Error& e)
                 {
                     // Catch message unpack exceptions and pass them to the callback
                     // in the expected manner to avoid propagating them up the call
@@ -641,17 +641,7 @@ namespace sdbus {
             tuple_of_function_input_arg_types_t<_Function> signalArgs;
 
             // Deserialize input arguments from the signal message into the tuple
-            try
-            {
-                signal >> signalArgs;
-            }
-            catch (const sdbus::Error& e)
-            {
-                // The convenience API callback cannot handle an incoming signal with
-                // an unexpected payload, so catch and ignore this exception to avoid
-                // propagating it up the call stack to the event loop.
-                return;
-            }
+            signal >> signalArgs;
 
             // Invoke callback with input arguments from the tuple.
             sdbus::apply(callback, signalArgs);

--- a/src/Object.cpp
+++ b/src/Object.cpp
@@ -337,7 +337,7 @@ int Object::sdbus_method_callback(sd_bus_message *sdbusMessage, void *userData, 
     {
         callback(message);
     }
-    catch (const sdbus::Error& e)
+    catch (const Error& e)
     {
         sd_bus_error_set(retError, e.getName().c_str(), e.getMessage().c_str());
     }
@@ -371,7 +371,7 @@ int Object::sdbus_property_get_callback( sd_bus */*bus*/
     {
         callback(reply);
     }
-    catch (const sdbus::Error& e)
+    catch (const Error& e)
     {
         sd_bus_error_set(retError, e.getName().c_str(), e.getMessage().c_str());
     }
@@ -406,7 +406,7 @@ int Object::sdbus_property_set_callback( sd_bus */*bus*/
     {
         callback(value);
     }
-    catch (const sdbus::Error& e)
+    catch (const Error& e)
     {
         sd_bus_error_set(retError, e.getName().c_str(), e.getMessage().c_str());
     }


### PR DESCRIPTION
This simply assures that `sdbus::Error` exceptions don't bubble from `Proxy` callbacks up to the libsystemd, which is a C library, and this may be unsafe. The only situation that I could think of that this may have happened until now was:

* Clients themselves did not catch these exceptions from their sdbus-c++ calls in their callback handlers, and these calls threw;
* Or, deserialization of arguments in e.g. a signal handler failed (because of signature mismatch, for example).

These situations shall not put down the entire event loop to its knees, hence they are caught just for sure and ignored.

Fixes https://github.com/Kistler-Group/sdbus-cpp/issues/178