### PR TITLE
Support Error parameter in signal handlers

### DIFF
--- a/docs/using-sdbus-c++.md
+++ b/docs/using-sdbus-c++.md
@@ -546,6 +546,15 @@ When registering methods, calling methods or emitting signals, multiple lines of
 
 sdbus-c++ users shall prefer the convenience API to the lower level, basic API. When feasible, using generated adaptor and proxy stubs is even better. These stubs provide yet another, higher API level built on top of the convenience API. They are described in the following section.
 
+> **_Note_:** By default, signal callback handlers are not invoked (i.e., the signal is silently dropped) if there is a signal signature mismatch. If clients want to be informed of such situations, they can prepend `const sdbus::Error*` parameter to their signal callback handler's parameter list. This argument will be `nullptr` in normal cases, and will provide access to the corresponding `sdbus::Error` object in case of deserialization failures. An example of a handler with the signature (`int`) different from the real signal contents (`string`):
+> ```c++
+>     void onConcatenated(const sdbus::Error* e, int wrongParameter)
+>     {
+>         assert(e);
+>         assert(e->getMessage() == "Failed to deserialize a int32 value");
+>     }
+> ```
+
 > **_Tip_:** When registering a D-Bus object, we can additionally provide names of input and output parameters of its methods and names of parameters of its signals. When the object is introspected, these names are listed in the resulting introspection XML, which improves the description of object's interfaces:
 > ```c++
 >    concatenator->registerMethod("concatenate")

--- a/include/sdbus-c++/TypeTraits.h
+++ b/include/sdbus-c++/TypeTraits.h
@@ -378,12 +378,14 @@ namespace sdbus {
         : public function_traits_base<_ReturnType, _Args...>
     {
         static constexpr bool is_async = false;
+        static constexpr bool has_error_param = false;
     };
 
     template <typename... _Args>
     struct function_traits<void(const Error*, _Args...)>
         : public function_traits_base<void, _Args...>
     {
+        static constexpr bool has_error_param = true;
     };
 
     template <typename... _Args, typename... _Results>
@@ -442,6 +444,9 @@ namespace sdbus {
 
     template <class _Function>
     constexpr auto is_async_method_v = function_traits<_Function>::is_async;
+
+    template <class _Function>
+    constexpr auto has_error_param_v = function_traits<_Function>::has_error_param;
 
     template <typename _FunctionType>
     using function_arguments_t = typename function_traits<_FunctionType>::arguments_type;


### PR DESCRIPTION
Currently, signal handlers are not invoked (i.e., the signal is silently dropped) if there is a signal signature mismatch. This PR enables clients to be informed of such situations (e.g. they make a mistake in signal's signature). So with this, if clients want to be informed of such situations, they can prepend `const sdbus::Error*` parameter to their signal handler's parameter list. This argument will be `nullptr` in normal cases, and will provide access to the corresponding `sdbus::Error` exception in case of deserialization failures