### PR TITLE
Generate adaptors and proxies with virtual destructor

### DIFF
--- a/tools/xml2cpp-codegen/AdaptorGenerator.cpp
+++ b/tools/xml2cpp-codegen/AdaptorGenerator.cpp
@@ -131,7 +131,7 @@ std::string AdaptorGenerator::processInterface(Node& interface) const
                        << propertyRegistration
          << tab << "}" << endl << endl;
 
-    body << tab << "~" << className << "() = default;" << endl << endl;
+    body << tab << "virtual ~" << className << "() = default;" << endl << endl;
 
     if (!signalMethods.empty())
     {

--- a/tools/xml2cpp-codegen/ProxyGenerator.cpp
+++ b/tools/xml2cpp-codegen/ProxyGenerator.cpp
@@ -96,7 +96,7 @@ std::string ProxyGenerator::processInterface(Node& interface) const
             << registration
             << tab << "}" << endl << endl;
 
-    body << tab << "~" << className << "() = default;" << endl << endl;
+    body << tab << "virtual ~" << className << "() = default;" << endl << endl;
 
     if (!declaration.empty())
         body << declaration << endl;


### PR DESCRIPTION
The generated classes, when inherited by a base class a la `class MyObject : public sdbus::AdaptorInterfaces<my::ns::MyAdaptor>`, the generated adaptor/proxy does not have a virtual destructor. This causes issues when storing the created MyObject as a MyAdaptor, where upon destruction the destructor of MyObject is never called.