### PR TITLE
googletest-download: replace master with main

### DIFF
--- a/tests/googletest-download/CMakeLists.txt.in
+++ b/tests/googletest-download/CMakeLists.txt.in
@@ -8,7 +8,7 @@ include(ExternalProject)
 
 ExternalProject_Add(googletest
     GIT_REPOSITORY    https://github.com/google/googletest.git
-    GIT_TAG           master
+    GIT_TAG           main
     GIT_SHALLOW       1
     SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-src"
     BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-build"


### PR DESCRIPTION
Upstream googletest deleted the master branch in favor of main.﻿
