### PR TITLE
fix method name in example

### DIFF
--- a/docs/using-sdbus-c++.md
+++ b/docs/using-sdbus-c++.md
@@ -1003,7 +1003,7 @@ void concatenate(sdbus::Result<std::string>&& result, std::vector<int32_t> numbe
         }
 
         // Let's send the reply message back to the client
-        methodResult.returnReply(result);
+        methodResult.returnResults(result);
 
         // Emit the 'concatenated' signal with the resulting string
         this->emitConcatenated(result);
@@ -1011,7 +1011,7 @@ void concatenate(sdbus::Result<std::string>&& result, std::vector<int32_t> numbe
 }
 ```
 
-The `Result` is a convenience class that represents a future method result, and it is where we write the results (`returnReply()`) or an error (`returnError()`) which we want to send back to the client.
+The `Result` is a convenience class that represents a future method result, and it is where we write the results (`returnResults()`) or an error (`returnError()`) which we want to send back to the client.
 
 Registraion (`implementedAs()`) doesn't change. Nothing else needs to change.
 


### PR DESCRIPTION
That method has its name almost two years by now. Time to show it some respect ;)

https://github.com/Kistler-Group/sdbus-cpp/blob/dc0f487751690999aaa61e507bbd16bdf111949d/include/sdbus-c%2B%2B/MethodResult.h#L61