### PR TITLE
Fix #214: Add means to unregister signal handler

### DIFF
--- a/include/sdbus-c++/ConvenienceApiClasses.h
+++ b/include/sdbus-c++/ConvenienceApiClasses.h
@@ -216,6 +216,17 @@ namespace sdbus {
         std::string interfaceName_;
     };
 
+    class SignalUnsubscriber
+    {
+    public:
+        SignalUnsubscriber(IProxy& proxy, const std::string& signalName);
+        void onInterface(std::string interfaceName);
+
+    private:
+        IProxy& proxy_;
+        const std::string& signalName_;
+    };
+
     class PropertyGetter
     {
     public:

--- a/include/sdbus-c++/ConvenienceApiClasses.inl
+++ b/include/sdbus-c++/ConvenienceApiClasses.inl
@@ -671,6 +671,21 @@ namespace sdbus {
         });
     }
 
+    /*** ------------------ ***/
+    /*** SignalUnsubscriber ***/
+    /*** ------------------ ***/
+
+    inline SignalUnsubscriber::SignalUnsubscriber(IProxy& proxy, const std::string& signalName)
+        : proxy_(proxy)
+        , signalName_(signalName)
+    {
+    }
+
+    inline void SignalUnsubscriber::onInterface(std::string interfaceName)
+    {
+        proxy_.unregisterSignalHandler(interfaceName, signalName_);
+    }
+
     /*** -------------- ***/
     /*** PropertyGetter ***/
     /*** -------------- ***/

--- a/include/sdbus-c++/IProxy.h
+++ b/include/sdbus-c++/IProxy.h
@@ -144,6 +144,17 @@ namespace sdbus {
                                           , signal_handler signalHandler ) = 0;
 
         /*!
+         * @brief Unregisters the handler of the desired signal
+         *
+         * @param[in] interfaceName Name of an interface that the signal belongs to
+         * @param[in] signalName Name of the signal
+         *
+         * @throws sdbus::Error in case of failure
+         */
+        virtual void unregisterSignalHandler( const std::string& interfaceName
+                                            , const std::string& signalName ) = 0;
+
+        /*!
          * @brief Finishes the registration of signal handlers
          *
          * The method physically subscribes to the desired signals.
@@ -228,6 +239,23 @@ namespace sdbus {
          * @throws sdbus::Error in case of failure
          */
         [[nodiscard]] SignalSubscriber uponSignal(const std::string& signalName);
+
+        /*!
+         * @brief Unregisters signal handler of a given signal of the proxied D-Bus object
+         *
+         * @param[in] signalName Name of the signal
+         * @return A helper object for convenient unregistration of the signal handler
+         *
+         * This is a high-level, convenience way of unregistering a D-Bus signal's handler.
+         *
+         * Example of use:
+         * @code
+         * object_.muteSignal("fooSignal").onInterface("com.kistler.foo");
+         * @endcode
+         *
+         * @throws sdbus::Error in case of failure
+         */
+        [[nodiscard]] SignalUnsubscriber muteSignal(const std::string& signalName);
 
         /*!
          * @brief Gets value of a property of the proxied D-Bus object
@@ -367,6 +395,11 @@ namespace sdbus {
     inline SignalSubscriber IProxy::uponSignal(const std::string& signalName)
     {
         return SignalSubscriber(*this, signalName);
+    }
+
+    inline SignalUnsubscriber IProxy::muteSignal(const std::string& signalName)
+    {
+        return SignalUnsubscriber(*this, signalName);
     }
 
     inline PropertyGetter IProxy::getProperty(const std::string& propertyName)

--- a/src/Proxy.cpp
+++ b/src/Proxy.cpp
@@ -167,6 +167,16 @@ void Proxy::registerSignalHandler( const std::string& interfaceName
     SDBUS_THROW_ERROR_IF(!inserted, "Failed to register signal handler: handler already exists", EINVAL);
 }
 
+void Proxy::unregisterSignalHandler( const std::string& interfaceName
+                                   , const std::string& signalName )
+{
+    auto& interface = interfaces_[interfaceName];
+
+    auto removeResult = interface.signals_.erase(signalName);
+
+    SDBUS_THROW_ERROR_IF(removeResult == 0, "Failed to unregister signal handler: handler not exists", EINVAL);
+}
+
 void Proxy::finishRegistration()
 {
     registerSignalHandlers(*connection_);

--- a/src/Proxy.h
+++ b/src/Proxy.h
@@ -58,6 +58,9 @@ namespace sdbus::internal {
         void registerSignalHandler( const std::string& interfaceName
                                   , const std::string& signalName
                                   , signal_handler signalHandler ) override;
+        void unregisterSignalHandler( const std::string& interfaceName
+                                    , const std::string& signalName ) override;
+
         void finishRegistration() override;
         void unregister() override;
 

--- a/tests/integrationtests/integrationtests-proxy.h
+++ b/tests/integrationtests/integrationtests-proxy.h
@@ -169,6 +169,17 @@ public:
         proxy_.callMethod("emitTwoSimpleSignals").onInterface(INTERFACE_NAME);
     }
 
+    void unregisterSimpleSignalHandler()
+    {
+        proxy_.muteSignal("simpleSignal").onInterface(INTERFACE_NAME);
+    }
+
+    void reRegisterSimpleSignalHandler()
+    {
+        proxy_.uponSignal("simpleSignal").onInterface(INTERFACE_NAME).call([this](){ this->onSimpleSignal(); });
+        proxy_.finishRegistration();
+    }
+
 public:
     uint32_t action()
     {


### PR DESCRIPTION
Summary:
I implemented your second approach as follows:
- Add `void IProxy::unregisterSignalHandler(const std::string& interfaceName, const std::string& signalName)` method.
- Add new auxiliary class `SignalUnsubscriber`.
- Add `SignalUnsubscriber IProxy::muteSignal(const std::string& signalName)` method.
- Extend **integrationtests/DBusSignalsTests** by adding 4 testcases for unregistring signal's handler.