### PR TITLE
fix: use non-mutating find in signal unregistration

### DIFF
--- a/src/Proxy.cpp
+++ b/src/Proxy.cpp
@@ -170,11 +170,10 @@ void Proxy::registerSignalHandler( const std::string& interfaceName
 void Proxy::unregisterSignalHandler( const std::string& interfaceName
                                    , const std::string& signalName )
 {
-    auto& interface = interfaces_[interfaceName];
+    auto it = interfaces_.find(interfaceName);
 
-    auto removeResult = interface.signals_.erase(signalName);
-
-    SDBUS_THROW_ERROR_IF(removeResult == 0, "Failed to unregister signal handler: handler not exists", EINVAL);
+    if (it != interfaces_.end())
+        it->second.signals_.erase(signalName);
 }
 
 void Proxy::finishRegistration()

--- a/tests/integrationtests/DBusSignalsTests.cpp
+++ b/tests/integrationtests/DBusSignalsTests.cpp
@@ -32,6 +32,7 @@
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 #include <string>
+#include <chrono>
 
 using ::testing::Eq;
 using ::testing::DoubleEq;
@@ -76,7 +77,7 @@ TEST_F(SdbusTestObject, ProxyDoesNotReceiveSignalFromOtherBusName)
 
     adaptor2->emitSimpleSignal();
 
-    ASSERT_FALSE(waitUntil(m_proxy->m_gotSimpleSignal, std::chrono::seconds(1)));
+    ASSERT_FALSE(waitUntil(m_proxy->m_gotSimpleSignal, 2s));
 }
 
 TEST_F(SdbusTestObject, EmitsSignalWithMapSuccesfully)
@@ -115,16 +116,16 @@ TEST_F(SdbusTestObject, CanAccessAssociatedSignalMessageInSignalHandler)
     ASSERT_THAT(m_proxy->m_signalMemberName, Eq("simpleSignal"));
 }
 
-TEST_F(SdbusTestObject, UnregisterSignalHandler)
+TEST_F(SdbusTestObject, UnregistersSignalHandler)
 {
     ASSERT_NO_THROW(m_proxy->unregisterSimpleSignalHandler());
 
     m_adaptor->emitSimpleSignal();
 
-    ASSERT_FALSE(waitUntil(m_proxy->m_gotSimpleSignal));
+    ASSERT_FALSE(waitUntil(m_proxy->m_gotSimpleSignal, 2s));
 }
 
-TEST_F(SdbusTestObject, UnregisterSignalHandlerForSomeProxies)
+TEST_F(SdbusTestObject, UnregistersSignalHandlerForSomeProxies)
 {
     auto proxy1 = std::make_unique<TestProxy>(*s_adaptorConnection, BUS_NAME, OBJECT_PATH);
     auto proxy2 = std::make_unique<TestProxy>(*s_adaptorConnection, BUS_NAME, OBJECT_PATH);
@@ -135,24 +136,17 @@ TEST_F(SdbusTestObject, UnregisterSignalHandlerForSomeProxies)
 
     ASSERT_TRUE(waitUntil(proxy1->m_gotSimpleSignal));
     ASSERT_TRUE(waitUntil(proxy2->m_gotSimpleSignal));
-    ASSERT_FALSE(waitUntil(m_proxy->m_gotSimpleSignal));
+    ASSERT_FALSE(waitUntil(m_proxy->m_gotSimpleSignal, 2s));
 }
 
-TEST_F(SdbusTestObject, FailsUnregisterSignalHandlerTwice)
-{
-    ASSERT_NO_THROW(m_proxy->unregisterSimpleSignalHandler());
-
-    ASSERT_THROW(m_proxy->unregisterSimpleSignalHandler(), sdbus::Error);
-}
-
-TEST_F(SdbusTestObject, ReRegisterSignalHandler)
+TEST_F(SdbusTestObject, ReRegistersSignalHandler)
 {
     // unregister simple-signal handler
     ASSERT_NO_THROW(m_proxy->unregisterSimpleSignalHandler());
 
     m_adaptor->emitSimpleSignal();
 
-    ASSERT_FALSE(waitUntil(m_proxy->m_gotSimpleSignal));
+    ASSERT_FALSE(waitUntil(m_proxy->m_gotSimpleSignal, 2s));
 
     // re-register simple-signal handler
     ASSERT_NO_THROW(m_proxy->reRegisterSimpleSignalHandler());


### PR DESCRIPTION
Fixes [comment](https://github.com/Kistler-Group/sdbus-cpp/pull/223/files#r768955213)

/cc @dleeds-cpi 