### PR TITLE
fix: minor fixes for async timeout handling

### DIFF
--- a/include/sdbus-c++/IConnection.h
+++ b/include/sdbus-c++/IConnection.h
@@ -84,7 +84,8 @@ namespace sdbus {
              *
              * @return a duration since the CLOCK_MONOTONIC epoch started.
              */
-            [[nodiscard]] std::chrono::microseconds getAbsoluteTimeout() const {
+            [[nodiscard]] std::chrono::microseconds getAbsoluteTimeout() const
+            {
                 return std::chrono::microseconds(timeout_usec);
             }
 

--- a/src/Proxy.cpp
+++ b/src/Proxy.cpp
@@ -67,14 +67,14 @@ MethodCall Proxy::createMethodCall(const std::string& interfaceName, const std::
 MethodReply Proxy::callMethod(const MethodCall& message, uint64_t timeout)
 {
     // Sending method call synchronously is the only operation that blocks, waiting for the method
-    // reply message among the incoming message on the sd-bus connection socket. But typically there
+    // reply message among the incoming messages on the sd-bus connection socket. But typically there
     // already is somebody that generally handles incoming D-Bus messages -- the connection event loop
     // running typically in its own thread. We have to avoid polling on socket from several threads.
     // So we have to branch here: either we are within the context of the event loop thread, then we
     // can send the message simply via sd_bus_call, which blocks. Or we are in another thread, then
     // we can perform the send operation of the method call message from here (because that is thread-
     // safe like other sd-bus API accesses), but the incoming reply we have to get through the event
-    // loop thread, because this is be the only rightful listener on the sd-bus connection socket.
+    // loop thread, because this is the only rightful listener on the sd-bus connection socket.
     // So, technically, we use async means to wait here for reply received by the event loop thread.
 
     SDBUS_THROW_ERROR_IF(!message.isValid(), "Invalid method call message provided", EINVAL);


### PR DESCRIPTION
This is a kind of little follow-up to #91 and contains:

* removal of `notifyEventLoopNewTimeout` call from synchronously sent messages,
* using `activeTimeout_` in a more relaxed way, without heavy ordering constraints,
* a little code reformatting and re-organization, mostly for consistency.