### PR TITLE
Issue #230: Enable move for ObjectPath and Signature.

### DIFF
--- a/include/sdbus-c++/Types.h
+++ b/include/sdbus-c++/Types.h
@@ -155,7 +155,9 @@ namespace sdbus {
         using std::string::string;
         ObjectPath() = default; // Fixes gcc 6.3 error (default c-tor is not imported in above using declaration)
         ObjectPath(const ObjectPath&) = default; // Fixes gcc 8.3 error (deleted copy constructor)
+        ObjectPath(ObjectPath&&) = default; // Enable move - user-declared copy ctor prevents implicit creation
         ObjectPath& operator = (const ObjectPath&) = default; // Fixes gcc 8.3 error (deleted copy assignment)
+        ObjectPath& operator = (ObjectPath&&) = default; // Enable move - user-declared copy assign prevents implicit creation
         ObjectPath(std::string path)
             : std::string(std::move(path))
         {}
@@ -174,7 +176,9 @@ namespace sdbus {
         using std::string::string;
         Signature() = default; // Fixes gcc 6.3 error (default c-tor is not imported in above using declaration)
         Signature(const Signature&) = default; // Fixes gcc 8.3 error (deleted copy constructor)
+        Signature(Signature&&) = default; // Enable move - user-declared copy ctor prevents implicit creation
         Signature& operator = (const Signature&) = default; // Fixes gcc 8.3 error (deleted copy assignment)
+        Signature& operator = (Signature&&) = default; // Enable move - user-declared copy assign prevents implicit creation
         Signature(std::string path)
             : std::string(std::move(path))
         {}

--- a/tests/unittests/Types_test.cpp
+++ b/tests/unittests/Types_test.cpp
@@ -230,6 +230,15 @@ TEST(AnObjectPath, CanBeConstructedFromStdString)
     ASSERT_THAT(sdbus::ObjectPath{aPath}, Eq(aPath));
 }
 
+TEST(AnObjectPath, CanBeMovedLikeAStdString)
+{
+    std::string aPath{"/some/very/long/path/longer/than/sso"};
+    sdbus::ObjectPath oPath{aPath};
+
+    ASSERT_THAT(sdbus::ObjectPath{std::move(oPath)}, Eq(sdbus::ObjectPath(std::move(aPath))));
+    ASSERT_THAT(std::string(oPath), Eq(aPath));
+}
+
 TEST(ASignature, CanBeConstructedFromCString)
 {
     const char* aSignature = "us";
@@ -242,6 +251,15 @@ TEST(ASignature, CanBeConstructedFromStdString)
     std::string aSignature{"us"};
 
     ASSERT_THAT(sdbus::Signature{aSignature}, Eq(aSignature));
+}
+
+TEST(ASignature, CanBeMovedLikeAStdString)
+{
+    std::string aSignature{"us"};
+    sdbus::Signature oSignature{aSignature};
+
+    ASSERT_THAT(sdbus::Signature{std::move(oSignature)}, Eq(sdbus::Signature(std::move(aSignature))));
+    ASSERT_THAT(std::string(oSignature), Eq(aSignature));
 }
 
 TEST(AUnixFd, DuplicatesAndOwnsFdUponStandardConstruction)


### PR DESCRIPTION
* Since ObjectPath and Signature have a user-declared copy-ctor and copy
  assignment operator the implicit declaration of corresponding move
  operations is disabled. Explicitly add defaulted versions so that
  move operations actually move instead of copy.

* See: https://github.com/Kistler-Group/sdbus-cpp/issues/230