### PR TITLE
fix(tests): printer for std::chrono in googletest v1.11.0

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,7 +19,7 @@ if (NOT TARGET GTest::gmock)
     if (NOT TARGET GTest::gmock)
         include(FetchContent)
 
-        message("Fetching googletest...")
+        message("Fetching googletest v${GOOGLETEST_VERSION}...")
         FetchContent_Declare(googletest
                             GIT_REPOSITORY ${GOOGLETEST_GIT_REPO}
                             GIT_TAG        release-${GOOGLETEST_VERSION}

--- a/tests/integrationtests/Defs.h
+++ b/tests/integrationtests/Defs.h
@@ -56,20 +56,18 @@ const bool DEFAULT_BLOCKING_VALUE{true};
 
 constexpr const double DOUBLE_VALUE{3.24L};
 
-/** Duration stream operator for human readable gtest value output.
- *
- * Note that the conversion to double is lossy if the input type has 64 or more bits.
- * This is ok for our integration tests because they don't have very
- * accurate timing requirements.
- *
- * @return human readable duration in seconds
- */
-template< class Rep, class Period >
-static std::ostream& operator<<(std::ostream& os, const std::chrono::duration<Rep, Period>& d)
-{
-    auto seconds = std::chrono::duration_cast<std::chrono::duration<double>>(d);
-    return os << seconds.count() << " s";
-}
 }}
+
+namespace testing::internal {
+
+// Printer for std::chrono::duration types.
+// This is a workaround, since it's not a good thing to add this to std namespace.
+template< class Rep, class Period >
+void PrintTo(const ::std::chrono::duration<Rep, Period>& d, ::std::ostream* os) {
+    auto seconds = std::chrono::duration_cast<std::chrono::duration<double>>(d);
+    *os << seconds.count() << "s";
+}
+
+}
 
 #endif /* SDBUS_CPP_INTEGRATIONTESTS_DEFS_H_ */


### PR DESCRIPTION
Fixes #234 

@lubo-svk @Oxymoron79 