### PR TITLE
Fix invalid assert

### DIFF
--- a/src/Connection.cpp
+++ b/src/Connection.cpp
@@ -73,7 +73,7 @@ Connection::~Connection()
 void Connection::requestName(const std::string& name)
 {
     SDBUS_CHECK_SERVICE_NAME(name);
-    
+
     auto r = iface_->sd_bus_request_name(bus_.get(), name.c_str(), 0);
     SDBUS_THROW_ERROR_IF(r < 0, "Failed to request bus name", -r);
 }
@@ -423,7 +423,7 @@ bool Connection::processPendingRequest()
 bool Connection::waitForNextRequest()
 {
     assert(bus_ != nullptr);
-    assert(eventFd_.fd != 0);
+    assert(eventFd_.fd >= 0);
 
     auto sdbusPollData = getEventLoopPollData();
     struct pollfd fds[] = {

--- a/src/Connection.h
+++ b/src/Connection.h
@@ -134,7 +134,7 @@ namespace sdbus::internal {
         {
             EventFd();
             ~EventFd();
-            int fd;
+            int fd{-1};
         };
 
     private:


### PR DESCRIPTION
Value of `0` is a valid file descriptor. It is usually assigned to standard input, but in services which close stadard I/O file descriptors, it can be reused. If it does get reused in EventFd, the code causes the service to abort despite everything being ok. The assert is somewhat superfluous as the file descriptor is always valid. If we fail to initialise it in the constructor, we throw. Even if we would survived the failed constructor (we don't), the value would have been undefined, so the usefulness of the assert is close to none. But well..., let's keep it, and have the file descriptor default initialised to an invalid value.