### PR TITLE
feat: add support for match rules

### DIFF
--- a/docs/using-sdbus-c++.md
+++ b/docs/using-sdbus-c++.md
@@ -19,7 +19,8 @@ Using sdbus-c++ library
 14. [Asynchronous client-side methods](#asynchronous-client-side-methods)
 15. [Using D-Bus properties](#using-d-bus-properties)
 16. [Standard D-Bus interfaces](#standard-d-bus-interfaces)
-17. [Conclusion](#conclusion)
+17. [Support for match rules](#support-for-match-rules)
+18. [Conclusion](#conclusion)
 
 Introduction
 ------------
@@ -1278,6 +1279,11 @@ For example, for our `Concatenator` example above in this tutorial, we may want 
 Note that signals of afore-mentioned standard D-Bus interfaces are not emitted by the library automatically. It's clients who are supposed to emit them.
 
 Working examples of using standard D-Bus interfaces can be found in [sdbus-c++ integration tests](/tests/integrationtests/DBusStandardInterfacesTests.cpp) or the [examples](/examples) directory.
+
+Support for match rules
+-----------------------
+
+`IConnection` class provides `addMatch` method that you can use to install match rules. An associated callback handler will be called upon an incoming message matching given match rule. There is support for both client-owned and floating (library-owned) match rules. Consult `IConnection` header or sdbus-c++ doxygen documentation for more information.
 
 Conclusion
 ----------

--- a/include/sdbus-c++/IConnection.h
+++ b/include/sdbus-c++/IConnection.h
@@ -266,6 +266,47 @@ namespace sdbus {
         virtual void addObjectManager(const std::string& objectPath, floating_slot_t) = 0;
 
         /*!
+         * @brief Adds a match rule for incoming message dispatching
+         *
+         * @param[in] match Match expression to filter incoming D-Bus message
+         * @param[in] callback Callback handler to be called upon incoming D-Bus message matching the rule
+         * @return RAII-style slot handle representing the ownership of the subscription
+         *
+         * The method installs a match rule for messages received on the specified bus connection.
+         * The syntax of the match rule expression passed in match is described in the D-Bus specification.
+         * The specified handler function callback is called for each incoming message matching the specified
+         * expression. The match is installed synchronously when connected to a bus broker, i.e. the call
+         * sends a control message requested the match to be added to the broker and waits until the broker
+         * confirms the match has been installed successfully.
+         *
+         * Simply let go of the slot instance to uninstall the match rule from the bus connection. The slot
+         * must not outlive the connection for the slot is associated with it.
+         *
+         * For more information, consult `man sd_bus_add_match`.
+         *
+         * @throws sdbus::Error in case of failure
+         */
+        [[nodiscard]] virtual Slot addMatch(const std::string& match, message_handler callback) = 0;
+
+        /*!
+         * @brief Adds a floating match rule for incoming message dispatching
+         *
+         * @param[in] match Match expression to filter incoming D-Bus message
+         * @param[in] callback Callback handler to be called upon incoming D-Bus message matching the rule
+         * @param[in] Floating slot tag
+         *
+         * The method installs a floating match rule for messages received on the specified bus connection.
+         * Floating means that the bus connection object owns the match rule, i.e. lifetime of the match rule
+         * is bound to the lifetime of the bus connection.
+         *
+         * Refer to the @c addMatch(const std::string& match, message_handler callback) documentation for more
+         * information.
+         *
+         * @throws sdbus::Error in case of failure
+         */
+        virtual void addMatch(const std::string& match, message_handler callback, floating_slot_t) = 0;
+
+        /*!
          * @copydoc IConnection::enterEventLoop()
          *
          * @deprecated This function has been replaced by enterEventLoop()

--- a/include/sdbus-c++/TypeTraits.h
+++ b/include/sdbus-c++/TypeTraits.h
@@ -46,6 +46,7 @@ namespace sdbus {
     class MethodCall;
     class MethodReply;
     class Signal;
+    class Message;
     class PropertySetCall;
     class PropertyGetReply;
     template <typename... _Results> class Result;
@@ -58,6 +59,7 @@ namespace sdbus {
     using method_callback = std::function<void(MethodCall msg)>;
     using async_reply_handler = std::function<void(MethodReply& reply, const Error* error)>;
     using signal_handler = std::function<void(Signal& signal)>;
+    using message_handler = std::function<void(Message& msg)>;
     using property_set_callback = std::function<void(PropertySetCall& msg)>;
     using property_get_callback = std::function<void(PropertyGetReply& reply)>;
 

--- a/src/Connection.h
+++ b/src/Connection.h
@@ -74,6 +74,9 @@ namespace sdbus::internal {
         void setMethodCallTimeout(uint64_t timeout) override;
         uint64_t getMethodCallTimeout() const override;
 
+        [[nodiscard]] Slot addMatch(const std::string& match, message_handler callback) override;
+        void addMatch(const std::string& match, message_handler callback, floating_slot_t) override;
+
         const ISdBus& getSdBusInterface() const override;
         ISdBus& getSdBusInterface() override;
 
@@ -138,6 +141,13 @@ namespace sdbus::internal {
             int fd{-1};
         };
 
+        struct MatchInfo
+        {
+            message_handler callback;
+            Connection& connection;
+            sd_bus_slot *slot;
+        };
+
     private:
         std::unique_ptr<ISdBus> iface_;
         BusPtr bus_;
@@ -147,6 +157,7 @@ namespace sdbus::internal {
         EventFd loopExitFd_;
         EventFd eventFd_;
         std::atomic<uint64_t> activeTimeout_{};
+        std::vector<Slot> floatingMatchRules_;
     };
 
 }

--- a/src/Proxy.cpp
+++ b/src/Proxy.cpp
@@ -276,7 +276,7 @@ int Proxy::sdbus_async_reply_handler(sd_bus_message *sdbusMessage, void *userDat
         // Intentionally left blank -- sdbus-c++ exceptions shall not bubble up to the underlying C sd-bus library
     }
 
-    return 1;
+    return 0;
 }
 
 int Proxy::sdbus_signal_handler(sd_bus_message *sdbusMessage, void *userData, sd_bus_error */*retError*/)


### PR DESCRIPTION
This implements support for synchronous installation of D-Bus match rules. See [D-Bus specification](https://dbus.freedesktop.org/doc/dbus-specification.html) for more info on match rules.