### PR TITLE
Add a wrapper for sd-event integration

### DIFF
--- a/include/sdbus-c++/IConnection.h
+++ b/include/sdbus-c++/IConnection.h
@@ -34,6 +34,8 @@
 #include <cstdint>
 #include <optional>
 
+struct sd_event;
+
 namespace sdbus {
 
     /********************************************//**
@@ -132,6 +134,25 @@ namespace sdbus {
          * @throws sdbus::Error in case of failure
          */
         virtual std::string getUniqueName() const = 0;
+
+        /*!
+         * @brief Attach the bus connection to an sd-event event loop
+         *
+         * @throws sdbus::Error in case of failure
+         */
+        virtual void attachSdEventLoop(sd_event *ev, int priority = 0) = 0;
+
+        /*!
+         * @brief Detach the bus connection from an sd-event event loop
+         *
+         * @throws sdbus::Error in case of failure
+         */
+        virtual void detachSdEventLoop() = 0;
+
+        /*!
+         * @brief Get current sd-event event loop for the bus connection
+         */
+        virtual sd_event *getSdEventLoop() = 0;
 
         /*!
          * @brief Enters I/O event loop on this bus connection

--- a/src/Connection.cpp
+++ b/src/Connection.cpp
@@ -92,6 +92,24 @@ std::string Connection::getUniqueName() const
     return unique;
 }
 
+void Connection::attachSdEventLoop(sd_event *ev, int priority)
+{
+    auto r = iface_->sd_bus_attach_event(bus_.get(), ev, priority);
+    SDBUS_THROW_ERROR_IF(r < 0, "Failed to attach to event loop", -r);
+}
+
+void Connection::detachSdEventLoop()
+{
+    auto r = iface_->sd_bus_detach_event(bus_.get());
+    SDBUS_THROW_ERROR_IF(r < 0, "Failed to detach from event loop", -r);
+}
+
+sd_event *Connection::getSdEventLoop()
+{
+    return iface_->sd_bus_get_event(bus_.get());
+}
+
+
 void Connection::enterEventLoop()
 {
     loopThreadId_ = std::this_thread::get_id();

--- a/src/Connection.h
+++ b/src/Connection.h
@@ -61,6 +61,9 @@ namespace sdbus::internal {
         void requestName(const std::string& name) override;
         void releaseName(const std::string& name) override;
         std::string getUniqueName() const override;
+        void attachSdEventLoop(sd_event *ev, int priority = 0) override;
+        void detachSdEventLoop() override;
+        sd_event *getSdEventLoop() override;
         void enterEventLoop() override;
         void enterEventLoopAsync() override;
         void leaveEventLoop() override;

--- a/src/ISdBus.h
+++ b/src/ISdBus.h
@@ -96,6 +96,10 @@ namespace sdbus::internal {
         virtual int sd_bus_creds_get_egid(sd_bus_creds *c, gid_t *egid) = 0;
         virtual int sd_bus_creds_get_supplementary_gids(sd_bus_creds *c, const gid_t **gids) = 0;
         virtual int sd_bus_creds_get_selinux_context(sd_bus_creds *c, const char **label) = 0;
+
+        virtual int sd_bus_attach_event(sd_bus *bus, sd_event *e, int priority) = 0;
+        virtual int sd_bus_detach_event(sd_bus *bus) = 0;
+        virtual sd_event *sd_bus_get_event(sd_bus *bus) = 0;
     };
 
 }

--- a/src/SdBus.cpp
+++ b/src/SdBus.cpp
@@ -335,4 +335,19 @@ int SdBus::sd_bus_creds_get_selinux_context(sd_bus_creds *c, const char **label)
     return ::sd_bus_creds_get_selinux_context(c, label);
 }
 
+int SdBus::sd_bus_attach_event(sd_bus *bus, sd_event *e, int priority)
+{
+    return ::sd_bus_attach_event(bus, e, priority);
+}
+
+int SdBus::sd_bus_detach_event(sd_bus *bus)
+{
+    return ::sd_bus_detach_event(bus);
+}
+
+sd_event *SdBus::sd_bus_get_event(sd_bus *bus)
+{
+    return ::sd_bus_get_event(bus);
+}
+
 }

--- a/src/SdBus.h
+++ b/src/SdBus.h
@@ -89,6 +89,10 @@ public:
     virtual int sd_bus_creds_get_supplementary_gids(sd_bus_creds *c, const gid_t **gids) override;
     virtual int sd_bus_creds_get_selinux_context(sd_bus_creds *c, const char **label) override;
 
+    virtual int sd_bus_attach_event(sd_bus *bus, sd_event *e, int priority) override;
+    virtual int sd_bus_detach_event(sd_bus *bus) override;
+    virtual sd_event *sd_bus_get_event(sd_bus *bus) override;
+
 private:
     std::recursive_mutex sdbusMutex_;
 };

--- a/tests/unittests/mocks/SdBusMock.h
+++ b/tests/unittests/mocks/SdBusMock.h
@@ -87,6 +87,10 @@ public:
     MOCK_METHOD2(sd_bus_creds_get_egid, int(sd_bus_creds *, gid_t *));
     MOCK_METHOD2(sd_bus_creds_get_supplementary_gids, int(sd_bus_creds *, const gid_t **));
     MOCK_METHOD2(sd_bus_creds_get_selinux_context, int(sd_bus_creds *, const char **));
+
+    MOCK_METHOD3(sd_bus_attach_event, int(sd_bus *, sd_event *, int));
+    MOCK_METHOD1(sd_bus_detach_event, int(sd_bus *));
+    MOCK_METHOD1(sd_bus_get_event, sd_event*(sd_bus *));
 };
 
 #endif //SDBUS_CXX_SDBUS_MOCK_H


### PR DESCRIPTION
As discussed here: https://github.com/Kistler-Group/sdbus-cpp/discussions/262