### PR TITLE
feat: add support for session bus connection at custom address

### DIFF
--- a/include/sdbus-c++/IConnection.h
+++ b/include/sdbus-c++/IConnection.h
@@ -363,7 +363,7 @@ namespace sdbus {
     }
 
     /*!
-     * @brief Creates/opens D-Bus system connection
+     * @brief Creates/opens D-Bus system bus connection
      *
      * @return Connection instance
      *
@@ -372,7 +372,7 @@ namespace sdbus {
     [[nodiscard]] std::unique_ptr<sdbus::IConnection> createConnection();
 
     /*!
-     * @brief Creates/opens D-Bus system connection with a name
+     * @brief Creates/opens D-Bus system bus connection with a name
      *
      * @param[in] name Name to request on the connection after its opening
      * @return Connection instance
@@ -382,8 +382,7 @@ namespace sdbus {
     [[nodiscard]] std::unique_ptr<sdbus::IConnection> createConnection(const std::string& name);
 
     /*!
-     * @brief Creates/opens D-Bus user connection when in a user context,
-     * and a system connection, otherwise.
+     * @brief Creates/opens D-Bus session bus connection when in a user context, and a system bus connection, otherwise.
      *
      * @return Connection instance
      *
@@ -392,8 +391,7 @@ namespace sdbus {
     [[nodiscard]] std::unique_ptr<sdbus::IConnection> createDefaultBusConnection();
 
     /*!
-     * @brief Creates/opens D-Bus user connection with a name when in a user
-     * context, and a system connection with a name, otherwise.
+     * @brief Creates/opens D-Bus session bus connection with a name when in a user context, and a system bus connection with a name, otherwise.
      *
      * @param[in] name Name to request on the connection after its opening
      * @return Connection instance
@@ -403,7 +401,7 @@ namespace sdbus {
     [[nodiscard]] std::unique_ptr<sdbus::IConnection> createDefaultBusConnection(const std::string& name);
 
     /*!
-     * @brief Creates/opens D-Bus system connection
+     * @brief Creates/opens D-Bus system bus connection
      *
      * @return Connection instance
      *
@@ -412,7 +410,7 @@ namespace sdbus {
     [[nodiscard]] std::unique_ptr<sdbus::IConnection> createSystemBusConnection();
 
     /*!
-     * @brief Creates/opens D-Bus system connection with a name
+     * @brief Creates/opens D-Bus system bus connection with a name
      *
      * @param[in] name Name to request on the connection after its opening
      * @return Connection instance
@@ -422,7 +420,7 @@ namespace sdbus {
     [[nodiscard]] std::unique_ptr<sdbus::IConnection> createSystemBusConnection(const std::string& name);
 
     /*!
-     * @brief Creates/opens D-Bus session connection
+     * @brief Creates/opens D-Bus session bus connection
      *
      * @return Connection instance
      *
@@ -431,7 +429,7 @@ namespace sdbus {
     [[nodiscard]] std::unique_ptr<sdbus::IConnection> createSessionBusConnection();
 
     /*!
-     * @brief Creates/opens D-Bus session connection with a name
+     * @brief Creates/opens D-Bus session bus connection with a name
      *
      * @param[in] name Name to request on the connection after its opening
      * @return Connection instance
@@ -440,7 +438,17 @@ namespace sdbus {
      */
     [[nodiscard]] std::unique_ptr<sdbus::IConnection> createSessionBusConnection(const std::string& name);
 
-    [[nodiscard]] std::unique_ptr<sdbus::IConnection> createSessionBusConnectionWithAddress(const std::string& addr);
+    /*!
+     * @brief Creates/opens D-Bus session bus connection at a custom address
+     *
+     * @param[in] address ";"-separated list of addresses of bus brokers to try to connect
+     * @return Connection instance
+     *
+     * @throws sdbus::Error in case of failure
+     *
+     * Consult manual pages for `sd_bus_set_address` of the underlying sd-bus library for more information.
+     */
+    [[nodiscard]] std::unique_ptr<sdbus::IConnection> createSessionBusConnectionWithAddress(const std::string& address);
 
     /*!
      * @brief Creates/opens D-Bus system connection on a remote host using ssh

--- a/include/sdbus-c++/IConnection.h
+++ b/include/sdbus-c++/IConnection.h
@@ -440,6 +440,8 @@ namespace sdbus {
      */
     [[nodiscard]] std::unique_ptr<sdbus::IConnection> createSessionBusConnection(const std::string& name);
 
+    [[nodiscard]] std::unique_ptr<sdbus::IConnection> createSessionBusConnectionWithAddress(const std::string& addr);
+
     /*!
      * @brief Creates/opens D-Bus system connection on a remote host using ssh
      *

--- a/src/Connection.h
+++ b/src/Connection.h
@@ -48,16 +48,21 @@ namespace sdbus::internal {
     public:
         // Bus type tags
         struct default_bus_t{};
+        inline static constexpr default_bus_t default_bus{};
         struct system_bus_t{};
+        inline static constexpr system_bus_t system_bus{};
         struct session_bus_t{};
-        struct remote_system_bus_t{};
+        inline static constexpr session_bus_t session_bus{};
         struct custom_session_bus_t{};
+        inline static constexpr custom_session_bus_t custom_session_bus{};
+        struct remote_system_bus_t{};
+        inline static constexpr remote_system_bus_t remote_system_bus{};
 
         Connection(std::unique_ptr<ISdBus>&& interface, default_bus_t);
         Connection(std::unique_ptr<ISdBus>&& interface, system_bus_t);
         Connection(std::unique_ptr<ISdBus>&& interface, session_bus_t);
+        Connection(std::unique_ptr<ISdBus>&& interface, custom_session_bus_t, const std::string& address);
         Connection(std::unique_ptr<ISdBus>&& interface, remote_system_bus_t, const std::string& host);
-        Connection(std::unique_ptr<ISdBus>&& interface, custom_session_bus_t, const std::string& addr);
         ~Connection() override;
 
         void requestName(const std::string& name) override;

--- a/src/Connection.h
+++ b/src/Connection.h
@@ -51,11 +51,13 @@ namespace sdbus::internal {
         struct system_bus_t{};
         struct session_bus_t{};
         struct remote_system_bus_t{};
+        struct custom_session_bus_t{};
 
         Connection(std::unique_ptr<ISdBus>&& interface, default_bus_t);
         Connection(std::unique_ptr<ISdBus>&& interface, system_bus_t);
         Connection(std::unique_ptr<ISdBus>&& interface, session_bus_t);
         Connection(std::unique_ptr<ISdBus>&& interface, remote_system_bus_t, const std::string& host);
+        Connection(std::unique_ptr<ISdBus>&& interface, custom_session_bus_t, const std::string& addr);
         ~Connection() override;
 
         void requestName(const std::string& name) override;

--- a/src/ISdBus.h
+++ b/src/ISdBus.h
@@ -67,8 +67,9 @@ namespace sdbus::internal {
         virtual int sd_bus_emit_interfaces_removed_strv(sd_bus *bus, const char *path, char **interfaces) = 0;
 
         virtual int sd_bus_open(sd_bus **ret) = 0;
-        virtual int sd_bus_open_user(sd_bus **ret) = 0;
         virtual int sd_bus_open_system(sd_bus **ret) = 0;
+        virtual int sd_bus_open_user(sd_bus **ret) = 0;
+        virtual int sd_bus_open_user_with_address(sd_bus **ret, const char* address) = 0;
         virtual int sd_bus_open_system_remote(sd_bus **ret, const char* host) = 0;
         virtual int sd_bus_request_name(sd_bus *bus, const char *name, uint64_t flags) = 0;
         virtual int sd_bus_release_name(sd_bus *bus, const char *name) = 0;
@@ -96,12 +97,6 @@ namespace sdbus::internal {
         virtual int sd_bus_creds_get_egid(sd_bus_creds *c, gid_t *egid) = 0;
         virtual int sd_bus_creds_get_supplementary_gids(sd_bus_creds *c, const gid_t **gids) = 0;
         virtual int sd_bus_creds_get_selinux_context(sd_bus_creds *c, const char **label) = 0;
-
-        virtual int sd_bus_new(sd_bus **bus) = 0;
-        virtual int sd_bus_set_address(sd_bus *bus, const char *addr) = 0;
-        virtual int sd_bus_set_bus_client(sd_bus *bus, int b) = 0;
-        virtual int sd_bus_set_trusted(sd_bus *bus, int b) = 0;
-        virtual int sd_bus_start(sd_bus *bus) = 0;
     };
 
 }

--- a/src/ISdBus.h
+++ b/src/ISdBus.h
@@ -96,6 +96,12 @@ namespace sdbus::internal {
         virtual int sd_bus_creds_get_egid(sd_bus_creds *c, gid_t *egid) = 0;
         virtual int sd_bus_creds_get_supplementary_gids(sd_bus_creds *c, const gid_t **gids) = 0;
         virtual int sd_bus_creds_get_selinux_context(sd_bus_creds *c, const char **label) = 0;
+
+        virtual int sd_bus_new(sd_bus **bus) = 0;
+        virtual int sd_bus_set_address(sd_bus *bus, const char *addr) = 0;
+        virtual int sd_bus_set_bus_client(sd_bus *bus, int b) = 0;
+        virtual int sd_bus_set_trusted(sd_bus *bus, int b) = 0;
+        virtual int sd_bus_start(sd_bus *bus) = 0;
     };
 
 }

--- a/src/SdBus.cpp
+++ b/src/SdBus.cpp
@@ -166,14 +166,46 @@ int SdBus::sd_bus_open(sd_bus **ret)
     return ::sd_bus_open(ret);
 }
 
+int SdBus::sd_bus_open_system(sd_bus **ret)
+{
+    return ::sd_bus_open_system(ret);
+}
+
 int SdBus::sd_bus_open_user(sd_bus **ret)
 {
     return ::sd_bus_open_user(ret);
 }
 
-int SdBus::sd_bus_open_system(sd_bus **ret)
+int SdBus::sd_bus_open_user_with_address(sd_bus **ret, const char* address)
 {
-    return ::sd_bus_open_system(ret);
+    sd_bus* bus = nullptr;
+
+    int r = sd_bus_new(&bus);
+    if (r < 0)
+        return r;
+
+    r = sd_bus_set_address(bus, address);
+    if (r < 0)
+        return r;
+
+    r = sd_bus_set_bus_client(bus, true);
+    if (r < 0)
+        return r;
+
+    // Copying behavior from
+    // https://github.com/systemd/systemd/blob/fee6441601c979165ebcbb35472036439f8dad5f/src/libsystemd/sd-bus/sd-bus.c#L1381
+    // Here, we make the bus as trusted
+    r = sd_bus_set_trusted(bus, true);
+    if (r < 0)
+        return r;
+
+    r = sd_bus_start(bus);
+    if (r < 0)
+        return r;
+
+    *ret = bus;
+
+    return 0;
 }
 
 int SdBus::sd_bus_open_system_remote(sd_bus **ret, const char *host)
@@ -333,31 +365,6 @@ int SdBus::sd_bus_creds_get_selinux_context(sd_bus_creds *c, const char **label)
     std::lock_guard lock(sdbusMutex_);
 
     return ::sd_bus_creds_get_selinux_context(c, label);
-}
-
-int SdBus::sd_bus_new(sd_bus **bus)
-{
-    return ::sd_bus_new(bus);
-}
-
-int SdBus::sd_bus_set_address(sd_bus *bus, const char *addr)
-{
-    return ::sd_bus_set_address(bus, addr);
-}
-
-int SdBus::sd_bus_set_bus_client(sd_bus *bus, int b)
-{
-    return ::sd_bus_set_bus_client(bus, b);
-}
-
-int SdBus::sd_bus_set_trusted(sd_bus *bus, int b)
-{
-    return ::sd_bus_set_trusted(bus, b);
-}
-
-int SdBus::sd_bus_start(sd_bus *bus)
-{
-    return ::sd_bus_start(bus);
 }
 
 }

--- a/src/SdBus.cpp
+++ b/src/SdBus.cpp
@@ -335,4 +335,29 @@ int SdBus::sd_bus_creds_get_selinux_context(sd_bus_creds *c, const char **label)
     return ::sd_bus_creds_get_selinux_context(c, label);
 }
 
+int SdBus::sd_bus_new(sd_bus **bus)
+{
+    return ::sd_bus_new(bus);
+}
+
+int SdBus::sd_bus_set_address(sd_bus *bus, const char *addr)
+{
+    return ::sd_bus_set_address(bus, addr);
+}
+
+int SdBus::sd_bus_set_bus_client(sd_bus *bus, int b)
+{
+    return ::sd_bus_set_bus_client(bus, b);
+}
+
+int SdBus::sd_bus_set_trusted(sd_bus *bus, int b)
+{
+    return ::sd_bus_set_trusted(bus, b);
+}
+
+int SdBus::sd_bus_start(sd_bus *bus)
+{
+    return ::sd_bus_start(bus);
+}
+
 }

--- a/src/SdBus.h
+++ b/src/SdBus.h
@@ -89,6 +89,12 @@ public:
     virtual int sd_bus_creds_get_supplementary_gids(sd_bus_creds *c, const gid_t **gids) override;
     virtual int sd_bus_creds_get_selinux_context(sd_bus_creds *c, const char **label) override;
 
+    virtual int sd_bus_new(sd_bus **bus) override;
+    virtual int sd_bus_set_address(sd_bus *bus, const char *addr) override;
+    virtual int sd_bus_set_bus_client(sd_bus *bus, int b) override;
+    virtual int sd_bus_set_trusted(sd_bus *bus, int b) override;
+    virtual int sd_bus_start(sd_bus *bus) override;
+
 private:
     std::recursive_mutex sdbusMutex_;
 };

--- a/src/SdBus.h
+++ b/src/SdBus.h
@@ -59,8 +59,9 @@ public:
     virtual int sd_bus_emit_interfaces_removed_strv(sd_bus *bus, const char *path, char **interfaces) override;
 
     virtual int sd_bus_open(sd_bus **ret) override;
-    virtual int sd_bus_open_user(sd_bus **ret) override;
     virtual int sd_bus_open_system(sd_bus **ret) override;
+    virtual int sd_bus_open_user(sd_bus **ret) override;
+    virtual int sd_bus_open_user_with_address(sd_bus **ret, const char* address) override;
     virtual int sd_bus_open_system_remote(sd_bus **ret, const char* hsot) override;
     virtual int sd_bus_request_name(sd_bus *bus, const char *name, uint64_t flags) override;
     virtual int sd_bus_release_name(sd_bus *bus, const char *name) override;
@@ -88,12 +89,6 @@ public:
     virtual int sd_bus_creds_get_egid(sd_bus_creds *c, gid_t *egid) override;
     virtual int sd_bus_creds_get_supplementary_gids(sd_bus_creds *c, const gid_t **gids) override;
     virtual int sd_bus_creds_get_selinux_context(sd_bus_creds *c, const char **label) override;
-
-    virtual int sd_bus_new(sd_bus **bus) override;
-    virtual int sd_bus_set_address(sd_bus *bus, const char *addr) override;
-    virtual int sd_bus_set_bus_client(sd_bus *bus, int b) override;
-    virtual int sd_bus_set_trusted(sd_bus *bus, int b) override;
-    virtual int sd_bus_start(sd_bus *bus) override;
 
 private:
     std::recursive_mutex sdbusMutex_;

--- a/tests/unittests/Connection_test.cpp
+++ b/tests/unittests/Connection_test.cpp
@@ -35,12 +35,7 @@ using ::testing::DoAll;
 using ::testing::SetArgPointee;
 using ::testing::Return;
 using ::testing::NiceMock;
-using sdbus::internal::Connection;
-constexpr sdbus::internal::Connection::default_bus_t default_bus;
-constexpr sdbus::internal::Connection::system_bus_t system_bus;
-constexpr sdbus::internal::Connection::session_bus_t session_bus;
-constexpr sdbus::internal::Connection::custom_session_bus_t custom_session_bus;
-constexpr sdbus::internal::Connection::remote_system_bus_t remote_system_bus;
+using ::sdbus::internal::Connection;
 
 class ConnectionCreationTest : public ::testing::Test
 {
@@ -59,81 +54,81 @@ TEST_F(ADefaultBusConnection, OpensAndFlushesBusWhenCreated)
 {
     EXPECT_CALL(*sdBusIntfMock_, sd_bus_open(_)).WillOnce(DoAll(SetArgPointee<0>(fakeBusPtr_), Return(1)));
     EXPECT_CALL(*sdBusIntfMock_, sd_bus_flush(_)).Times(1);
-    Connection(std::move(sdBusIntfMock_), default_bus);
+    Connection(std::move(sdBusIntfMock_), Connection::default_bus);
 }
 
 TEST_F(ASystemBusConnection, OpensAndFlushesBusWhenCreated)
 {
     EXPECT_CALL(*sdBusIntfMock_, sd_bus_open_system(_)).WillOnce(DoAll(SetArgPointee<0>(fakeBusPtr_), Return(1)));
     EXPECT_CALL(*sdBusIntfMock_, sd_bus_flush(_)).Times(1);
-    Connection(std::move(sdBusIntfMock_), system_bus);
+    Connection(std::move(sdBusIntfMock_), Connection::system_bus);
 }
 
 TEST_F(ASessionBusConnection, OpensAndFlushesBusWhenCreated)
 {
     EXPECT_CALL(*sdBusIntfMock_, sd_bus_open_user(_)).WillOnce(DoAll(SetArgPointee<0>(fakeBusPtr_), Return(1)));
     EXPECT_CALL(*sdBusIntfMock_, sd_bus_flush(_)).Times(1);
-    Connection(std::move(sdBusIntfMock_), session_bus);
+    Connection(std::move(sdBusIntfMock_), Connection::session_bus);
 }
 
 TEST_F(ADefaultBusConnection, ClosesAndUnrefsBusWhenDestructed)
 {
     ON_CALL(*sdBusIntfMock_, sd_bus_open(_)).WillByDefault(DoAll(SetArgPointee<0>(fakeBusPtr_), Return(1)));
     EXPECT_CALL(*sdBusIntfMock_, sd_bus_flush_close_unref(_)).Times(1);
-    Connection(std::move(sdBusIntfMock_), default_bus);
+    Connection(std::move(sdBusIntfMock_), Connection::default_bus);
 }
 
 TEST_F(ASystemBusConnection, ClosesAndUnrefsBusWhenDestructed)
 {
     ON_CALL(*sdBusIntfMock_, sd_bus_open_system(_)).WillByDefault(DoAll(SetArgPointee<0>(fakeBusPtr_), Return(1)));
     EXPECT_CALL(*sdBusIntfMock_, sd_bus_flush_close_unref(_)).Times(1);
-    Connection(std::move(sdBusIntfMock_), system_bus);
+    Connection(std::move(sdBusIntfMock_), Connection::system_bus);
 }
 
 TEST_F(ASessionBusConnection, ClosesAndUnrefsBusWhenDestructed)
 {
     ON_CALL(*sdBusIntfMock_, sd_bus_open_user(_)).WillByDefault(DoAll(SetArgPointee<0>(fakeBusPtr_), Return(1)));
     EXPECT_CALL(*sdBusIntfMock_, sd_bus_flush_close_unref(_)).Times(1);
-    Connection(std::move(sdBusIntfMock_), session_bus);
+    Connection(std::move(sdBusIntfMock_), Connection::session_bus);
 }
 
 TEST_F(ADefaultBusConnection, ThrowsErrorWhenOpeningTheBusFailsDuringConstruction)
 {
     ON_CALL(*sdBusIntfMock_, sd_bus_open(_)).WillByDefault(DoAll(SetArgPointee<0>(fakeBusPtr_), Return(-1)));
-    ASSERT_THROW(Connection(std::move(sdBusIntfMock_), default_bus), sdbus::Error);
+    ASSERT_THROW(Connection(std::move(sdBusIntfMock_), Connection::default_bus), sdbus::Error);
 }
 
 TEST_F(ASystemBusConnection, ThrowsErrorWhenOpeningTheBusFailsDuringConstruction)
 {
     ON_CALL(*sdBusIntfMock_, sd_bus_open_system(_)).WillByDefault(DoAll(SetArgPointee<0>(fakeBusPtr_), Return(-1)));
-    ASSERT_THROW(Connection(std::move(sdBusIntfMock_), system_bus), sdbus::Error);
+    ASSERT_THROW(Connection(std::move(sdBusIntfMock_), Connection::system_bus), sdbus::Error);
 }
 
 TEST_F(ASessionBusConnection, ThrowsErrorWhenOpeningTheBusFailsDuringConstruction)
 {
     ON_CALL(*sdBusIntfMock_, sd_bus_open_user(_)).WillByDefault(DoAll(SetArgPointee<0>(fakeBusPtr_), Return(-1)));
-    ASSERT_THROW(Connection(std::move(sdBusIntfMock_), session_bus), sdbus::Error);
+    ASSERT_THROW(Connection(std::move(sdBusIntfMock_), Connection::session_bus), sdbus::Error);
 }
 
 TEST_F(ADefaultBusConnection, ThrowsErrorWhenFlushingTheBusFailsDuringConstruction)
 {
     ON_CALL(*sdBusIntfMock_, sd_bus_open(_)).WillByDefault(DoAll(SetArgPointee<0>(fakeBusPtr_), Return(1)));
     ON_CALL(*sdBusIntfMock_, sd_bus_flush(_)).WillByDefault(Return(-1));
-    ASSERT_THROW(Connection(std::move(sdBusIntfMock_), default_bus), sdbus::Error);
+    ASSERT_THROW(Connection(std::move(sdBusIntfMock_), Connection::default_bus), sdbus::Error);
 }
 
 TEST_F(ASystemBusConnection, ThrowsErrorWhenFlushingTheBusFailsDuringConstruction)
 {
     ON_CALL(*sdBusIntfMock_, sd_bus_open_system(_)).WillByDefault(DoAll(SetArgPointee<0>(fakeBusPtr_), Return(1)));
     ON_CALL(*sdBusIntfMock_, sd_bus_flush(_)).WillByDefault(Return(-1));
-    ASSERT_THROW(Connection(std::move(sdBusIntfMock_), system_bus), sdbus::Error);
+    ASSERT_THROW(Connection(std::move(sdBusIntfMock_), Connection::system_bus), sdbus::Error);
 }
 
 TEST_F(ASessionBusConnection, ThrowsErrorWhenFlushingTheBusFailsDuringConstruction)
 {
     ON_CALL(*sdBusIntfMock_, sd_bus_open_user(_)).WillByDefault(DoAll(SetArgPointee<0>(fakeBusPtr_), Return(1)));
     ON_CALL(*sdBusIntfMock_, sd_bus_flush(_)).WillByDefault(Return(-1));
-    ASSERT_THROW(Connection(std::move(sdBusIntfMock_), session_bus), sdbus::Error);
+    ASSERT_THROW(Connection(std::move(sdBusIntfMock_), Connection::session_bus), sdbus::Error);
 }
 
 namespace
@@ -172,11 +167,7 @@ template<> void AConnectionNameRequest<Connection::session_bus_t>::setUpBusOpenE
 }
 template<> void AConnectionNameRequest<Connection::custom_session_bus_t>::setUpBusOpenExpectation()
 {
-    EXPECT_CALL(*sdBusIntfMock_, sd_bus_new(_)).WillOnce(DoAll(SetArgPointee<0>(fakeBusPtr_), Return(1)));
-    ON_CALL(*sdBusIntfMock_, sd_bus_set_address(_, _)).WillByDefault(Return(1));
-    ON_CALL(*sdBusIntfMock_, sd_bus_set_bus_client(_, _)).WillByDefault(Return(1));
-    ON_CALL(*sdBusIntfMock_, sd_bus_set_trusted(_, _)).WillByDefault(Return(1));
-    ON_CALL(*sdBusIntfMock_, sd_bus_start(_)).WillByDefault(Return(1));
+    EXPECT_CALL(*sdBusIntfMock_, sd_bus_open_user_with_address(_, _)).WillOnce(DoAll(SetArgPointee<0>(fakeBusPtr_), Return(1)));
 }
 template<> void AConnectionNameRequest<Connection::remote_system_bus_t>::setUpBusOpenExpectation()
 {
@@ -189,11 +180,11 @@ std::unique_ptr<Connection> AConnectionNameRequest<_BusTypeTag>::makeConnection(
 }
 template<> std::unique_ptr<Connection> AConnectionNameRequest<Connection::custom_session_bus_t>::makeConnection()
 {
-    return std::make_unique<Connection>(std::unique_ptr<NiceMock<SdBusMock>>(sdBusIntfMock_), custom_session_bus, "custom session bus");
+    return std::make_unique<Connection>(std::unique_ptr<NiceMock<SdBusMock>>(sdBusIntfMock_), Connection::custom_session_bus, "custom session bus");
 }
 template<> std::unique_ptr<Connection> AConnectionNameRequest<Connection::remote_system_bus_t>::makeConnection()
 {
-    return std::make_unique<Connection>(std::unique_ptr<NiceMock<SdBusMock>>(sdBusIntfMock_), remote_system_bus, "some host");
+    return std::make_unique<Connection>(std::unique_ptr<NiceMock<SdBusMock>>(sdBusIntfMock_), Connection::remote_system_bus, "some host");
 }
 
 typedef ::testing::Types< Connection::default_bus_t

--- a/tests/unittests/mocks/SdBusMock.h
+++ b/tests/unittests/mocks/SdBusMock.h
@@ -87,6 +87,11 @@ public:
     MOCK_METHOD2(sd_bus_creds_get_egid, int(sd_bus_creds *, gid_t *));
     MOCK_METHOD2(sd_bus_creds_get_supplementary_gids, int(sd_bus_creds *, const gid_t **));
     MOCK_METHOD2(sd_bus_creds_get_selinux_context, int(sd_bus_creds *, const char **));
+    MOCK_METHOD1(sd_bus_new, int(sd_bus **bus));
+    MOCK_METHOD2(sd_bus_set_address, int(sd_bus *bus, const char *addr));
+    MOCK_METHOD2(sd_bus_set_bus_client, int(sd_bus *bus, int b));
+    MOCK_METHOD2(sd_bus_set_trusted, int(sd_bus *bus, int b));
+    MOCK_METHOD1(sd_bus_start, int(sd_bus *bus));
 };
 
 #endif //SDBUS_CXX_SDBUS_MOCK_H

--- a/tests/unittests/mocks/SdBusMock.h
+++ b/tests/unittests/mocks/SdBusMock.h
@@ -58,8 +58,9 @@ public:
     MOCK_METHOD3(sd_bus_emit_interfaces_removed_strv, int(sd_bus *bus, const char *path, char **interfaces));
 
     MOCK_METHOD1(sd_bus_open, int(sd_bus **ret));
-    MOCK_METHOD1(sd_bus_open_user, int(sd_bus **ret));
     MOCK_METHOD1(sd_bus_open_system, int(sd_bus **ret));
+    MOCK_METHOD1(sd_bus_open_user, int(sd_bus **ret));
+    MOCK_METHOD2(sd_bus_open_user_with_address, int(sd_bus **ret, const char* address));
     MOCK_METHOD2(sd_bus_open_system_remote, int(sd_bus **ret, const char *host));
     MOCK_METHOD3(sd_bus_request_name, int(sd_bus *bus, const char *name, uint64_t flags));
     MOCK_METHOD2(sd_bus_release_name, int(sd_bus *bus, const char *name));
@@ -87,11 +88,6 @@ public:
     MOCK_METHOD2(sd_bus_creds_get_egid, int(sd_bus_creds *, gid_t *));
     MOCK_METHOD2(sd_bus_creds_get_supplementary_gids, int(sd_bus_creds *, const gid_t **));
     MOCK_METHOD2(sd_bus_creds_get_selinux_context, int(sd_bus_creds *, const char **));
-    MOCK_METHOD1(sd_bus_new, int(sd_bus **bus));
-    MOCK_METHOD2(sd_bus_set_address, int(sd_bus *bus, const char *addr));
-    MOCK_METHOD2(sd_bus_set_bus_client, int(sd_bus *bus, int b));
-    MOCK_METHOD2(sd_bus_set_trusted, int(sd_bus *bus, int b));
-    MOCK_METHOD1(sd_bus_start, int(sd_bus *bus));
 };
 
 #endif //SDBUS_CXX_SDBUS_MOCK_H


### PR DESCRIPTION
The new function helper `createSessionBusConnectionWithAddress` allows
to create connection to session bus with custom address.

Signed-off-by: Alexander Livenets <a.livenets@gmail.com>