### PR TITLE
feat: add support for proxy with no event loop thread

### DIFF
--- a/include/sdbus-c++/ProxyInterfaces.h
+++ b/include/sdbus-c++/ProxyInterfaces.h
@@ -112,6 +112,22 @@ namespace sdbus {
         /*!
          * @brief Creates native-like proxy object instance
          *
+         * @param[in] destination Bus name that provides a D-Bus object
+         * @param[in] objectPath Path of the D-Bus object
+         * @param[in] dont_run_event_loop_thread tag to specify the behavior regarding running an event loop thread
+         *
+         * This constructor overload creates a proxy that manages its own D-Bus connection(s).
+         * For more information on its behavior, consult @ref createProxy(std::string,std::string,sdbus::dont_run_event_loop_thread_t)
+         */
+        ProxyInterfaces(std::string destination, std::string objectPath, dont_run_event_loop_thread_t)
+            : ProxyObjectHolder(createProxy(std::move(destination), std::move(objectPath), dont_run_event_loop_thread))
+            , _Interfaces(getProxy())...
+        {
+        }
+
+        /*!
+         * @brief Creates native-like proxy object instance
+         *
          * @param[in] connection D-Bus connection to be used by the proxy object
          * @param[in] destination Bus name that provides a D-Bus object
          * @param[in] objectPath Path of the D-Bus object
@@ -138,6 +154,23 @@ namespace sdbus {
         ProxyInterfaces(std::unique_ptr<sdbus::IConnection>&& connection, std::string destination, std::string objectPath)
             : ProxyObjectHolder(createProxy(std::move(connection), std::move(destination), std::move(objectPath)))
             , _Interfaces(getProxy())...
+        {
+        }
+
+        /*!
+         * @brief Creates native-like proxy object instance
+         *
+         * @param[in] connection D-Bus connection to be used by the proxy object
+         * @param[in] destination Bus name that provides a D-Bus object
+         * @param[in] objectPath Path of the D-Bus object
+         * @param[in] dont_run_event_loop_thread tag to specify the behavior regarding running an event loop thread
+         *
+         * The proxy created this way becomes an owner of the connection.
+         * For more information on its behavior, consult @ref createProxy(std::unique_ptr<sdbus::IConnection>&&,std::string,std::string,sdbus::dont_run_event_loop_thread_t)
+         */
+        ProxyInterfaces(std::unique_ptr<sdbus::IConnection>&& connection, std::string destination, std::string objectPath, dont_run_event_loop_thread_t)
+                : ProxyObjectHolder(createProxy(std::move(connection), std::move(destination), std::move(objectPath), dont_run_event_loop_thread))
+                , _Interfaces(getProxy())...
         {
         }
 

--- a/src/Proxy.h
+++ b/src/Proxy.h
@@ -50,6 +50,10 @@ namespace sdbus::internal {
         Proxy( std::unique_ptr<sdbus::internal::IConnection>&& connection
              , std::string destination
              , std::string objectPath );
+        Proxy( std::unique_ptr<sdbus::internal::IConnection>&& connection
+             , std::string destination
+             , std::string objectPath
+             , dont_run_event_loop_thread_t );
 
         MethodCall createMethodCall(const std::string& interfaceName, const std::string& methodName) override;
         MethodReply callMethod(const MethodCall& message, uint64_t timeout) override;

--- a/tests/integrationtests/DBusMethodsTests.cpp
+++ b/tests/integrationtests/DBusMethodsTests.cpp
@@ -272,3 +272,12 @@ TEST_F(SdbusTestObject, CannotSetGeneralMethodTimeoutWithLibsystemdVersionLessTh
     ASSERT_THROW(s_adaptorConnection->getMethodCallTimeout(), sdbus::Error);
 }
 #endif
+
+TEST_F(SdbusTestObject, CanCallMethodSynchronouslyWithoutAnEventLoopThread)
+{
+    auto proxy = std::make_unique<TestProxy>(BUS_NAME, OBJECT_PATH, sdbus::dont_run_event_loop_thread);
+
+    auto multiplyRes = proxy->multiply(INT64_VALUE, DOUBLE_VALUE);
+
+    ASSERT_THAT(multiplyRes, Eq(INT64_VALUE * DOUBLE_VALUE));
+}

--- a/tests/integrationtests/TestProxy.cpp
+++ b/tests/integrationtests/TestProxy.cpp
@@ -39,6 +39,13 @@ TestProxy::TestProxy(std::string destination, std::string objectPath)
     registerProxy();
 }
 
+TestProxy::TestProxy(std::string destination, std::string objectPath, dont_run_event_loop_thread_t)
+    : ProxyInterfaces(std::move(destination), std::move(objectPath), dont_run_event_loop_thread)
+{
+    // It doesn't make sense to register any signals here since proxy upon a D-Bus connection with no event loop thread
+    // will not receive any incoming messages except replies to synchronous D-Bus calls.
+}
+
 TestProxy::TestProxy(sdbus::IConnection& connection, std::string destination, std::string objectPath)
     : ProxyInterfaces(connection, std::move(destination), std::move(objectPath))
 {

--- a/tests/integrationtests/TestProxy.h
+++ b/tests/integrationtests/TestProxy.h
@@ -73,6 +73,7 @@ class TestProxy final : public sdbus::ProxyInterfaces< org::sdbuscpp::integratio
 {
 public:
     TestProxy(std::string destination, std::string objectPath);
+    TestProxy(std::string destination, std::string objectPath, dont_run_event_loop_thread_t);
     TestProxy(sdbus::IConnection& connection, std::string destination, std::string objectPath);
     ~TestProxy();
 


### PR DESCRIPTION
This adds a possibility to create a proxy which has its own D-Bus connection to a bus, but which doesn't run an event loop thread for it internally. Such proxies are "light-weight", meant to be created, used (for some classic D-Bus calls), and discarded.