### PR TITLE
refactor: use pseudo D-Bus connection for plain messages

### DIFF
--- a/src/Connection.h
+++ b/src/Connection.h
@@ -57,12 +57,15 @@ namespace sdbus::internal {
         inline static constexpr custom_session_bus_t custom_session_bus{};
         struct remote_system_bus_t{};
         inline static constexpr remote_system_bus_t remote_system_bus{};
+        struct pseudo_bus_t{}; // A bus connection that is not really established with D-Bus daemon
+        inline static constexpr pseudo_bus_t pseudo_bus{};
 
         Connection(std::unique_ptr<ISdBus>&& interface, default_bus_t);
         Connection(std::unique_ptr<ISdBus>&& interface, system_bus_t);
         Connection(std::unique_ptr<ISdBus>&& interface, session_bus_t);
         Connection(std::unique_ptr<ISdBus>&& interface, custom_session_bus_t, const std::string& address);
         Connection(std::unique_ptr<ISdBus>&& interface, remote_system_bus_t, const std::string& host);
+        Connection(std::unique_ptr<ISdBus>&& interface, pseudo_bus_t);
         ~Connection() override;
 
         void requestName(const std::string& name) override;
@@ -126,6 +129,7 @@ namespace sdbus::internal {
         Connection(std::unique_ptr<ISdBus>&& interface, const BusFactory& busFactory);
 
         BusPtr openBus(const std::function<int(sd_bus**)>& busFactory);
+        BusPtr openPseudoBus();
         void finishHandshake(sd_bus* bus);
         bool waitForNextRequest();
         static std::string composeSignalMatchFilter( const std::string &sender

--- a/src/IConnection.h
+++ b/src/IConnection.h
@@ -95,6 +95,7 @@ namespace sdbus::internal {
     };
 
     [[nodiscard]] std::unique_ptr<sdbus::internal::IConnection> createConnection();
+    [[nodiscard]] std::unique_ptr<sdbus::internal::IConnection> createPseudoConnection();
 
 }
 

--- a/src/ISdBus.h
+++ b/src/ISdBus.h
@@ -79,11 +79,15 @@ namespace sdbus::internal {
         virtual int sd_bus_add_match(sd_bus *bus, sd_bus_slot **slot, const char *match, sd_bus_message_handler_t callback, void *userdata) = 0;
         virtual sd_bus_slot* sd_bus_slot_unref(sd_bus_slot *slot) = 0;
 
+        virtual int sd_bus_new(sd_bus **ret) = 0;
+        virtual int sd_bus_start(sd_bus *bus) = 0;
+
         virtual int sd_bus_process(sd_bus *bus, sd_bus_message **r) = 0;
         virtual int sd_bus_get_poll_data(sd_bus *bus, PollData* data) = 0;
 
         virtual int sd_bus_flush(sd_bus *bus) = 0;
         virtual sd_bus *sd_bus_flush_close_unref(sd_bus *bus) = 0;
+        virtual sd_bus *sd_bus_close_unref(sd_bus *bus) = 0;
 
         virtual int sd_bus_message_set_destination(sd_bus_message *m, const char *destination) = 0;
 

--- a/src/Message.cpp
+++ b/src/Message.cpp
@@ -864,9 +864,13 @@ void Signal::setDestination(const std::string& destination)
 
 PlainMessage createPlainMessage()
 {
-    static auto connection = internal::createConnection();
+    //static auto connection = internal::createConnection();
+    // Let's create a pseudo connection -- one that does not really connect to the real bus.
+    // This is a bit of a hack, but it enables use to work with D-Bus message locally without
+    // the need of D-Bus daemon. This is especially useful in unit tests of both sdbus-c++ and client code.
+    // Additionally, it's light-weight and fast solution.
+    static auto connection = internal::createPseudoConnection();
     return connection->createPlainMessage();
 }
-
 
 }

--- a/src/SdBus.cpp
+++ b/src/SdBus.cpp
@@ -261,6 +261,16 @@ sd_bus_slot* SdBus::sd_bus_slot_unref(sd_bus_slot *slot)
     return ::sd_bus_slot_unref(slot);
 }
 
+int SdBus::sd_bus_new(sd_bus **ret)
+{
+    return ::sd_bus_new(ret);
+}
+
+int SdBus::sd_bus_start(sd_bus *bus)
+{
+    return ::sd_bus_start(bus);
+}
+
 int SdBus::sd_bus_process(sd_bus *bus, sd_bus_message **r)
 {
     std::lock_guard lock(sdbusMutex_);
@@ -295,6 +305,16 @@ int SdBus::sd_bus_flush(sd_bus *bus)
 sd_bus* SdBus::sd_bus_flush_close_unref(sd_bus *bus)
 {
     return ::sd_bus_flush_close_unref(bus);
+}
+
+sd_bus* SdBus::sd_bus_close_unref(sd_bus *bus)
+{
+#if LIBSYSTEMD_VERSION>=241
+    return ::sd_bus_close_unref(bus);
+#else
+    ::sd_bus_close(bus);
+    return ::sd_bus_unref(bus);
+#endif
 }
 
 int SdBus::sd_bus_message_set_destination(sd_bus_message *m, const char *destination)

--- a/src/SdBus.h
+++ b/src/SdBus.h
@@ -71,11 +71,15 @@ public:
     virtual int sd_bus_add_match(sd_bus *bus, sd_bus_slot **slot, const char *match, sd_bus_message_handler_t callback, void *userdata) override;
     virtual sd_bus_slot* sd_bus_slot_unref(sd_bus_slot *slot) override;
 
+    virtual int sd_bus_new(sd_bus **ret) override;
+    virtual int sd_bus_start(sd_bus *bus) override;
+
     virtual int sd_bus_process(sd_bus *bus, sd_bus_message **r) override;
     virtual int sd_bus_get_poll_data(sd_bus *bus, PollData* data) override;
 
     virtual int sd_bus_flush(sd_bus *bus) override;
     virtual sd_bus *sd_bus_flush_close_unref(sd_bus *bus) override;
+    virtual sd_bus *sd_bus_close_unref(sd_bus *bus) override;
 
     virtual int sd_bus_message_set_destination(sd_bus_message *m, const char *destination) override;
 

--- a/tests/unittests/Connection_test.cpp
+++ b/tests/unittests/Connection_test.cpp
@@ -173,6 +173,12 @@ template<> void AConnectionNameRequest<Connection::remote_system_bus_t>::setUpBu
 {
     EXPECT_CALL(*sdBusIntfMock_, sd_bus_open_system_remote(_, _)).WillOnce(DoAll(SetArgPointee<0>(fakeBusPtr_), Return(1)));
 }
+template<> void AConnectionNameRequest<Connection::pseudo_bus_t>::setUpBusOpenExpectation()
+{
+    EXPECT_CALL(*sdBusIntfMock_, sd_bus_new(_)).WillOnce(DoAll(SetArgPointee<0>(fakeBusPtr_), Return(1)));
+    // `sd_bus_start` for pseudo connection shall return an error value, remember this is a fake connection...
+    EXPECT_CALL(*sdBusIntfMock_, sd_bus_start(fakeBusPtr_)).WillOnce(Return(-EINVAL));
+}
 template <typename _BusTypeTag>
 std::unique_ptr<Connection> AConnectionNameRequest<_BusTypeTag>::makeConnection()
 {
@@ -192,6 +198,7 @@ typedef ::testing::Types< Connection::default_bus_t
                         , Connection::session_bus_t
                         , Connection::custom_session_bus_t
                         , Connection::remote_system_bus_t
+                        , Connection::pseudo_bus_t
                         > BusTypeTags;
 
 TYPED_TEST_SUITE(AConnectionNameRequest, BusTypeTags);

--- a/tests/unittests/mocks/SdBusMock.h
+++ b/tests/unittests/mocks/SdBusMock.h
@@ -70,11 +70,15 @@ public:
     MOCK_METHOD5(sd_bus_add_match, int(sd_bus *bus, sd_bus_slot **slot, const char *match, sd_bus_message_handler_t callback, void *userdata));
     MOCK_METHOD1(sd_bus_slot_unref, sd_bus_slot*(sd_bus_slot *slot));
 
+    MOCK_METHOD1(sd_bus_new, int(sd_bus **ret));
+    MOCK_METHOD1(sd_bus_start, int(sd_bus *bus));
+
     MOCK_METHOD2(sd_bus_process, int(sd_bus *bus, sd_bus_message **r));
     MOCK_METHOD2(sd_bus_get_poll_data, int(sd_bus *bus, PollData* data));
 
     MOCK_METHOD1(sd_bus_flush, int(sd_bus *bus));
     MOCK_METHOD1(sd_bus_flush_close_unref, sd_bus *(sd_bus *bus));
+    MOCK_METHOD1(sd_bus_close_unref, sd_bus *(sd_bus *bus));
 
     MOCK_METHOD2(sd_bus_message_set_destination, int(sd_bus_message *m, const char *destination));
 


### PR DESCRIPTION
This fixes #277 and addresses @dleeds-cpi's proposal that is part of discussion #169.

To create a plain D-Bus messages (used to implement the concept of `Variant`s, for example), we need a D-Bus connection. However, with current sd-bus API and its implementation, it's possible to optimize and create a "pseudo" connection which does not really connect to and thus does not need D-Bus daemon, yet remains in a state that is sufficient to create local D-Bus messages and work with them.

This is a bit of a hack, but

* it enables us and our clients to write unit tests around plain messages and `Variant`s that fulfill FIRST principles, and are independent from presence of D-Bus daemon.
* leads to faster and more light-weight code when creating plain D-Bus messages/`Variant`s.

@dleeds-cpi would you please review? :)