### PR TITLE
Don't include libsystemd as pkg-config dependency when statically linked

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -210,6 +210,11 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/cmake/sdbus-c++-config.cmake
         DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/sdbus-c++
         COMPONENT dev)
 
+if(BUILD_SHARED_LIBS AND (BUILD_LIBSYSTEMD OR Systemd_LINK_LIBRARIES MATCHES "/libsystemd\.a(;|$)"))
+    set(PKGCONFIG_REQS ".private")
+else()
+    set(PKGCONFIG_REQS "")
+endif()
 configure_file(pkgconfig/sdbus-c++.pc.in pkgconfig/sdbus-c++.pc @ONLY)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/pkgconfig/sdbus-c++.pc
         DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig COMPONENT dev)

--- a/pkgconfig/sdbus-c++.pc.in
+++ b/pkgconfig/sdbus-c++.pc.in
@@ -5,7 +5,7 @@ includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 
 Name: @PROJECT_NAME@
 Description: C++ library on top of sd-bus, a systemd D-Bus library
-Requires: libsystemd
+Requires@PKGCONFIG_REQS@: libsystemd
 Version: @SDBUSCPP_VERSION@
 Libs: -L${libdir} -l@PROJECT_NAME@
 Cflags: -I${includedir}


### PR DESCRIPTION
This works whether `BUILD_LIBSYSTEMD` is `ON` or the separate build of libsystemd picked up by pkg-config is static. The Gentoo Linux package requires the latter.