### PR TITLE
refactor: support move semantics in generated adaptor and proxy classes

### DIFF
--- a/include/sdbus-c++/AdaptorInterfaces.h
+++ b/include/sdbus-c++/AdaptorInterfaces.h
@@ -141,6 +141,11 @@ namespace sdbus {
 
     protected:
         using base_type = AdaptorInterfaces;
+
+        AdaptorInterfaces(const AdaptorInterfaces&) = delete;
+        AdaptorInterfaces& operator=(const AdaptorInterfaces&) = delete;
+        AdaptorInterfaces(AdaptorInterfaces&&) = default;
+        AdaptorInterfaces& operator=(AdaptorInterfaces&&) = default;
         ~AdaptorInterfaces() = default;
     };
 

--- a/include/sdbus-c++/ProxyInterfaces.h
+++ b/include/sdbus-c++/ProxyInterfaces.h
@@ -175,6 +175,11 @@ namespace sdbus {
 
     protected:
         using base_type = ProxyInterfaces;
+
+        ProxyInterfaces(const ProxyInterfaces&) = delete;
+        ProxyInterfaces& operator=(const ProxyInterfaces&) = delete;
+        ProxyInterfaces(ProxyInterfaces&&) = default;
+        ProxyInterfaces& operator=(ProxyInterfaces&&) = default;
         ~ProxyInterfaces() = default;
     };
 

--- a/tests/integrationtests/integrationtests-adaptor.h
+++ b/tests/integrationtests/integrationtests-adaptor.h
@@ -20,54 +20,59 @@ public:
 
 protected:
     integrationtests_adaptor(sdbus::IObject& object)
-        : object_(object)
+        : object_(&object)
     {
-        object_.setInterfaceFlags(INTERFACE_NAME).markAsDeprecated().withPropertyUpdateBehavior(sdbus::Flags::EMITS_NO_SIGNAL);
-        object_.registerMethod("noArgNoReturn").onInterface(INTERFACE_NAME).implementedAs([this](){ return this->noArgNoReturn(); });
-        object_.registerMethod("getInt").onInterface(INTERFACE_NAME).withOutputParamNames("anInt").implementedAs([this](){ return this->getInt(); });
-        object_.registerMethod("getTuple").onInterface(INTERFACE_NAME).withOutputParamNames("arg0", "arg1").implementedAs([this](){ return this->getTuple(); });
-        object_.registerMethod("multiply").onInterface(INTERFACE_NAME).withInputParamNames("a", "b").withOutputParamNames("result").implementedAs([this](const int64_t& a, const double& b){ return this->multiply(a, b); });
-        object_.registerMethod("multiplyWithNoReply").onInterface(INTERFACE_NAME).withInputParamNames("a", "b").implementedAs([this](const int64_t& a, const double& b){ return this->multiplyWithNoReply(a, b); }).markAsDeprecated().withNoReply();
-        object_.registerMethod("getInts16FromStruct").onInterface(INTERFACE_NAME).withInputParamNames("arg0").withOutputParamNames("arg0").implementedAs([this](const sdbus::Struct<uint8_t, int16_t, double, std::string, std::vector<int16_t>>& arg0){ return this->getInts16FromStruct(arg0); });
-        object_.registerMethod("processVariant").onInterface(INTERFACE_NAME).withInputParamNames("variant").withOutputParamNames("result").implementedAs([this](const sdbus::Variant& variant){ return this->processVariant(variant); });
-        object_.registerMethod("getMapOfVariants").onInterface(INTERFACE_NAME).withInputParamNames("x", "y").withOutputParamNames("aMapOfVariants").implementedAs([this](const std::vector<int32_t>& x, const sdbus::Struct<sdbus::Variant, sdbus::Variant>& y){ return this->getMapOfVariants(x, y); });
-        object_.registerMethod("getStructInStruct").onInterface(INTERFACE_NAME).withOutputParamNames("aMapOfVariants").implementedAs([this](){ return this->getStructInStruct(); });
-        object_.registerMethod("sumStructItems").onInterface(INTERFACE_NAME).withInputParamNames("arg0", "arg1").withOutputParamNames("arg0").implementedAs([this](const sdbus::Struct<uint8_t, uint16_t>& arg0, const sdbus::Struct<int32_t, int64_t>& arg1){ return this->sumStructItems(arg0, arg1); });
-        object_.registerMethod("sumVectorItems").onInterface(INTERFACE_NAME).withInputParamNames("arg0", "arg1").withOutputParamNames("arg0").implementedAs([this](const std::vector<uint16_t>& arg0, const std::vector<uint64_t>& arg1){ return this->sumVectorItems(arg0, arg1); });
-        object_.registerMethod("doOperation").onInterface(INTERFACE_NAME).withInputParamNames("arg0").withOutputParamNames("arg0").implementedAs([this](const uint32_t& arg0){ return this->doOperation(arg0); });
-        object_.registerMethod("doOperationAsync").onInterface(INTERFACE_NAME).withInputParamNames("arg0").withOutputParamNames("arg0").implementedAs([this](sdbus::Result<uint32_t>&& result, uint32_t arg0){ this->doOperationAsync(std::move(result), std::move(arg0)); });
-        object_.registerMethod("getSignature").onInterface(INTERFACE_NAME).withOutputParamNames("arg0").implementedAs([this](){ return this->getSignature(); });
-        object_.registerMethod("getObjPath").onInterface(INTERFACE_NAME).withOutputParamNames("arg0").implementedAs([this](){ return this->getObjPath(); });
-        object_.registerMethod("getUnixFd").onInterface(INTERFACE_NAME).withOutputParamNames("arg0").implementedAs([this](){ return this->getUnixFd(); });
-        object_.registerMethod("getComplex").onInterface(INTERFACE_NAME).withOutputParamNames("arg0").implementedAs([this](){ return this->getComplex(); }).markAsDeprecated();
-        object_.registerMethod("throwError").onInterface(INTERFACE_NAME).implementedAs([this](){ return this->throwError(); });
-        object_.registerMethod("throwErrorWithNoReply").onInterface(INTERFACE_NAME).implementedAs([this](){ return this->throwErrorWithNoReply(); }).withNoReply();
-        object_.registerMethod("doPrivilegedStuff").onInterface(INTERFACE_NAME).implementedAs([this](){ return this->doPrivilegedStuff(); }).markAsPrivileged();
-        object_.registerMethod("emitTwoSimpleSignals").onInterface(INTERFACE_NAME).implementedAs([this](){ return this->emitTwoSimpleSignals(); });
-        object_.registerSignal("simpleSignal").onInterface(INTERFACE_NAME).markAsDeprecated();
-        object_.registerSignal("signalWithMap").onInterface(INTERFACE_NAME).withParameters<std::map<int32_t, std::string>>("aMap");
-        object_.registerSignal("signalWithVariant").onInterface(INTERFACE_NAME).withParameters<sdbus::Variant>("aVariant");
-        object_.registerProperty("action").onInterface(INTERFACE_NAME).withGetter([this](){ return this->action(); }).withSetter([this](const uint32_t& value){ this->action(value); }).withUpdateBehavior(sdbus::Flags::EMITS_INVALIDATION_SIGNAL);
-        object_.registerProperty("blocking").onInterface(INTERFACE_NAME).withGetter([this](){ return this->blocking(); }).withSetter([this](const bool& value){ this->blocking(value); });
-        object_.registerProperty("state").onInterface(INTERFACE_NAME).withGetter([this](){ return this->state(); }).markAsDeprecated().withUpdateBehavior(sdbus::Flags::CONST_PROPERTY_VALUE);
+        object_->setInterfaceFlags(INTERFACE_NAME).markAsDeprecated().withPropertyUpdateBehavior(sdbus::Flags::EMITS_NO_SIGNAL);
+        object_->registerMethod("noArgNoReturn").onInterface(INTERFACE_NAME).implementedAs([this](){ return this->noArgNoReturn(); });
+        object_->registerMethod("getInt").onInterface(INTERFACE_NAME).withOutputParamNames("anInt").implementedAs([this](){ return this->getInt(); });
+        object_->registerMethod("getTuple").onInterface(INTERFACE_NAME).withOutputParamNames("arg0", "arg1").implementedAs([this](){ return this->getTuple(); });
+        object_->registerMethod("multiply").onInterface(INTERFACE_NAME).withInputParamNames("a", "b").withOutputParamNames("result").implementedAs([this](const int64_t& a, const double& b){ return this->multiply(a, b); });
+        object_->registerMethod("multiplyWithNoReply").onInterface(INTERFACE_NAME).withInputParamNames("a", "b").implementedAs([this](const int64_t& a, const double& b){ return this->multiplyWithNoReply(a, b); }).markAsDeprecated().withNoReply();
+        object_->registerMethod("getInts16FromStruct").onInterface(INTERFACE_NAME).withInputParamNames("arg0").withOutputParamNames("arg0").implementedAs([this](const sdbus::Struct<uint8_t, int16_t, double, std::string, std::vector<int16_t>>& arg0){ return this->getInts16FromStruct(arg0); });
+        object_->registerMethod("processVariant").onInterface(INTERFACE_NAME).withInputParamNames("variant").withOutputParamNames("result").implementedAs([this](const sdbus::Variant& variant){ return this->processVariant(variant); });
+        object_->registerMethod("getMapOfVariants").onInterface(INTERFACE_NAME).withInputParamNames("x", "y").withOutputParamNames("aMapOfVariants").implementedAs([this](const std::vector<int32_t>& x, const sdbus::Struct<sdbus::Variant, sdbus::Variant>& y){ return this->getMapOfVariants(x, y); });
+        object_->registerMethod("getStructInStruct").onInterface(INTERFACE_NAME).withOutputParamNames("aMapOfVariants").implementedAs([this](){ return this->getStructInStruct(); });
+        object_->registerMethod("sumStructItems").onInterface(INTERFACE_NAME).withInputParamNames("arg0", "arg1").withOutputParamNames("arg0").implementedAs([this](const sdbus::Struct<uint8_t, uint16_t>& arg0, const sdbus::Struct<int32_t, int64_t>& arg1){ return this->sumStructItems(arg0, arg1); });
+        object_->registerMethod("sumVectorItems").onInterface(INTERFACE_NAME).withInputParamNames("arg0", "arg1").withOutputParamNames("arg0").implementedAs([this](const std::vector<uint16_t>& arg0, const std::vector<uint64_t>& arg1){ return this->sumVectorItems(arg0, arg1); });
+        object_->registerMethod("doOperation").onInterface(INTERFACE_NAME).withInputParamNames("arg0").withOutputParamNames("arg0").implementedAs([this](const uint32_t& arg0){ return this->doOperation(arg0); });
+        object_->registerMethod("doOperationAsync").onInterface(INTERFACE_NAME).withInputParamNames("arg0").withOutputParamNames("arg0").implementedAs([this](sdbus::Result<uint32_t>&& result, uint32_t arg0){ this->doOperationAsync(std::move(result), std::move(arg0)); });
+        object_->registerMethod("getSignature").onInterface(INTERFACE_NAME).withOutputParamNames("arg0").implementedAs([this](){ return this->getSignature(); });
+        object_->registerMethod("getObjPath").onInterface(INTERFACE_NAME).withOutputParamNames("arg0").implementedAs([this](){ return this->getObjPath(); });
+        object_->registerMethod("getUnixFd").onInterface(INTERFACE_NAME).withOutputParamNames("arg0").implementedAs([this](){ return this->getUnixFd(); });
+        object_->registerMethod("getComplex").onInterface(INTERFACE_NAME).withOutputParamNames("arg0").implementedAs([this](){ return this->getComplex(); }).markAsDeprecated();
+        object_->registerMethod("throwError").onInterface(INTERFACE_NAME).implementedAs([this](){ return this->throwError(); });
+        object_->registerMethod("throwErrorWithNoReply").onInterface(INTERFACE_NAME).implementedAs([this](){ return this->throwErrorWithNoReply(); }).withNoReply();
+        object_->registerMethod("doPrivilegedStuff").onInterface(INTERFACE_NAME).implementedAs([this](){ return this->doPrivilegedStuff(); }).markAsPrivileged();
+        object_->registerMethod("emitTwoSimpleSignals").onInterface(INTERFACE_NAME).implementedAs([this](){ return this->emitTwoSimpleSignals(); });
+        object_->registerSignal("simpleSignal").onInterface(INTERFACE_NAME).markAsDeprecated();
+        object_->registerSignal("signalWithMap").onInterface(INTERFACE_NAME).withParameters<std::map<int32_t, std::string>>("aMap");
+        object_->registerSignal("signalWithVariant").onInterface(INTERFACE_NAME).withParameters<sdbus::Variant>("aVariant");
+        object_->registerProperty("action").onInterface(INTERFACE_NAME).withGetter([this](){ return this->action(); }).withSetter([this](const uint32_t& value){ this->action(value); }).withUpdateBehavior(sdbus::Flags::EMITS_INVALIDATION_SIGNAL);
+        object_->registerProperty("blocking").onInterface(INTERFACE_NAME).withGetter([this](){ return this->blocking(); }).withSetter([this](const bool& value){ this->blocking(value); });
+        object_->registerProperty("state").onInterface(INTERFACE_NAME).withGetter([this](){ return this->state(); }).markAsDeprecated().withUpdateBehavior(sdbus::Flags::CONST_PROPERTY_VALUE);
     }
+
+    integrationtests_adaptor(const integrationtests_adaptor&) = delete;
+    integrationtests_adaptor& operator=(const integrationtests_adaptor&) = delete;
+    integrationtests_adaptor(integrationtests_adaptor&&) = default;
+    integrationtests_adaptor& operator=(integrationtests_adaptor&&) = default;
 
     ~integrationtests_adaptor() = default;
 
 public:
     void emitSimpleSignal()
     {
-        object_.emitSignal("simpleSignal").onInterface(INTERFACE_NAME);
+        object_->emitSignal("simpleSignal").onInterface(INTERFACE_NAME);
     }
 
     void emitSignalWithMap(const std::map<int32_t, std::string>& aMap)
     {
-        object_.emitSignal("signalWithMap").onInterface(INTERFACE_NAME).withArguments(aMap);
+        object_->emitSignal("signalWithMap").onInterface(INTERFACE_NAME).withArguments(aMap);
     }
 
     void emitSignalWithVariant(const sdbus::Variant& aVariant)
     {
-        object_.emitSignal("signalWithVariant").onInterface(INTERFACE_NAME).withArguments(aVariant);
+        object_->emitSignal("signalWithVariant").onInterface(INTERFACE_NAME).withArguments(aVariant);
     }
 
 private:
@@ -101,7 +106,7 @@ private:
     virtual std::string state() = 0;
 
 private:
-    sdbus::IObject& object_;
+    sdbus::IObject* object_;
 };
 
 }} // namespaces

--- a/tests/integrationtests/integrationtests-proxy.h
+++ b/tests/integrationtests/integrationtests-proxy.h
@@ -20,12 +20,17 @@ public:
 
 protected:
     integrationtests_proxy(sdbus::IProxy& proxy)
-        : proxy_(proxy)
+        : proxy_(&proxy)
     {
-        proxy_.uponSignal("simpleSignal").onInterface(INTERFACE_NAME).call([this](){ this->onSimpleSignal(); });
-        proxy_.uponSignal("signalWithMap").onInterface(INTERFACE_NAME).call([this](const std::map<int32_t, std::string>& aMap){ this->onSignalWithMap(aMap); });
-        proxy_.uponSignal("signalWithVariant").onInterface(INTERFACE_NAME).call([this](const sdbus::Variant& aVariant){ this->onSignalWithVariant(aVariant); });
+        proxy_->uponSignal("simpleSignal").onInterface(INTERFACE_NAME).call([this](){ this->onSimpleSignal(); });
+        proxy_->uponSignal("signalWithMap").onInterface(INTERFACE_NAME).call([this](const std::map<int32_t, std::string>& aMap){ this->onSignalWithMap(aMap); });
+        proxy_->uponSignal("signalWithVariant").onInterface(INTERFACE_NAME).call([this](const sdbus::Variant& aVariant){ this->onSignalWithVariant(aVariant); });
     }
+
+    integrationtests_proxy(const integrationtests_proxy&) = delete;
+    integrationtests_proxy& operator=(const integrationtests_proxy&) = delete;
+    integrationtests_proxy(integrationtests_proxy&&) = default;
+    integrationtests_proxy& operator=(integrationtests_proxy&&) = default;
 
     ~integrationtests_proxy() = default;
 
@@ -36,178 +41,178 @@ protected:
 public:
     void noArgNoReturn()
     {
-        proxy_.callMethod("noArgNoReturn").onInterface(INTERFACE_NAME);
+        proxy_->callMethod("noArgNoReturn").onInterface(INTERFACE_NAME);
     }
 
     int32_t getInt()
     {
         int32_t result;
-        proxy_.callMethod("getInt").onInterface(INTERFACE_NAME).storeResultsTo(result);
+        proxy_->callMethod("getInt").onInterface(INTERFACE_NAME).storeResultsTo(result);
         return result;
     }
 
     std::tuple<uint32_t, std::string> getTuple()
     {
         std::tuple<uint32_t, std::string> result;
-        proxy_.callMethod("getTuple").onInterface(INTERFACE_NAME).storeResultsTo(result);
+        proxy_->callMethod("getTuple").onInterface(INTERFACE_NAME).storeResultsTo(result);
         return result;
     }
 
     double multiply(const int64_t& a, const double& b)
     {
         double result;
-        proxy_.callMethod("multiply").onInterface(INTERFACE_NAME).withArguments(a, b).storeResultsTo(result);
+        proxy_->callMethod("multiply").onInterface(INTERFACE_NAME).withArguments(a, b).storeResultsTo(result);
         return result;
     }
 
     void multiplyWithNoReply(const int64_t& a, const double& b)
     {
-        proxy_.callMethod("multiplyWithNoReply").onInterface(INTERFACE_NAME).withArguments(a, b).dontExpectReply();
+        proxy_->callMethod("multiplyWithNoReply").onInterface(INTERFACE_NAME).withArguments(a, b).dontExpectReply();
     }
 
     std::vector<int16_t> getInts16FromStruct(const sdbus::Struct<uint8_t, int16_t, double, std::string, std::vector<int16_t>>& arg0)
     {
         std::vector<int16_t> result;
-        proxy_.callMethod("getInts16FromStruct").onInterface(INTERFACE_NAME).withArguments(arg0).storeResultsTo(result);
+        proxy_->callMethod("getInts16FromStruct").onInterface(INTERFACE_NAME).withArguments(arg0).storeResultsTo(result);
         return result;
     }
 
     sdbus::Variant processVariant(const sdbus::Variant& variant)
     {
         sdbus::Variant result;
-        proxy_.callMethod("processVariant").onInterface(INTERFACE_NAME).withArguments(variant).storeResultsTo(result);
+        proxy_->callMethod("processVariant").onInterface(INTERFACE_NAME).withArguments(variant).storeResultsTo(result);
         return result;
     }
 
     std::map<int32_t, sdbus::Variant> getMapOfVariants(const std::vector<int32_t>& x, const sdbus::Struct<sdbus::Variant, sdbus::Variant>& y)
     {
         std::map<int32_t, sdbus::Variant> result;
-        proxy_.callMethod("getMapOfVariants").onInterface(INTERFACE_NAME).withArguments(x, y).storeResultsTo(result);
+        proxy_->callMethod("getMapOfVariants").onInterface(INTERFACE_NAME).withArguments(x, y).storeResultsTo(result);
         return result;
     }
 
     sdbus::Struct<std::string, sdbus::Struct<std::map<int32_t, int32_t>>> getStructInStruct()
     {
         sdbus::Struct<std::string, sdbus::Struct<std::map<int32_t, int32_t>>> result;
-        proxy_.callMethod("getStructInStruct").onInterface(INTERFACE_NAME).storeResultsTo(result);
+        proxy_->callMethod("getStructInStruct").onInterface(INTERFACE_NAME).storeResultsTo(result);
         return result;
     }
 
     int32_t sumStructItems(const sdbus::Struct<uint8_t, uint16_t>& arg0, const sdbus::Struct<int32_t, int64_t>& arg1)
     {
         int32_t result;
-        proxy_.callMethod("sumStructItems").onInterface(INTERFACE_NAME).withArguments(arg0, arg1).storeResultsTo(result);
+        proxy_->callMethod("sumStructItems").onInterface(INTERFACE_NAME).withArguments(arg0, arg1).storeResultsTo(result);
         return result;
     }
 
     uint32_t sumVectorItems(const std::vector<uint16_t>& arg0, const std::vector<uint64_t>& arg1)
     {
         uint32_t result;
-        proxy_.callMethod("sumVectorItems").onInterface(INTERFACE_NAME).withArguments(arg0, arg1).storeResultsTo(result);
+        proxy_->callMethod("sumVectorItems").onInterface(INTERFACE_NAME).withArguments(arg0, arg1).storeResultsTo(result);
         return result;
     }
 
     uint32_t doOperation(const uint32_t& arg0)
     {
         uint32_t result;
-        proxy_.callMethod("doOperation").onInterface(INTERFACE_NAME).withArguments(arg0).storeResultsTo(result);
+        proxy_->callMethod("doOperation").onInterface(INTERFACE_NAME).withArguments(arg0).storeResultsTo(result);
         return result;
     }
 
     uint32_t doOperationAsync(const uint32_t& arg0)
     {
         uint32_t result;
-        proxy_.callMethod("doOperationAsync").onInterface(INTERFACE_NAME).withArguments(arg0).storeResultsTo(result);
+        proxy_->callMethod("doOperationAsync").onInterface(INTERFACE_NAME).withArguments(arg0).storeResultsTo(result);
         return result;
     }
 
     sdbus::Signature getSignature()
     {
         sdbus::Signature result;
-        proxy_.callMethod("getSignature").onInterface(INTERFACE_NAME).storeResultsTo(result);
+        proxy_->callMethod("getSignature").onInterface(INTERFACE_NAME).storeResultsTo(result);
         return result;
     }
 
     sdbus::ObjectPath getObjPath()
     {
         sdbus::ObjectPath result;
-        proxy_.callMethod("getObjPath").onInterface(INTERFACE_NAME).storeResultsTo(result);
+        proxy_->callMethod("getObjPath").onInterface(INTERFACE_NAME).storeResultsTo(result);
         return result;
     }
 
     sdbus::UnixFd getUnixFd()
     {
         sdbus::UnixFd result;
-        proxy_.callMethod("getUnixFd").onInterface(INTERFACE_NAME).storeResultsTo(result);
+        proxy_->callMethod("getUnixFd").onInterface(INTERFACE_NAME).storeResultsTo(result);
         return result;
     }
 
     std::map<uint64_t, sdbus::Struct<std::map<uint8_t, std::vector<sdbus::Struct<sdbus::ObjectPath, bool, sdbus::Variant, std::map<int32_t, std::string>>>>, sdbus::Signature, std::string>> getComplex()
     {
         std::map<uint64_t, sdbus::Struct<std::map<uint8_t, std::vector<sdbus::Struct<sdbus::ObjectPath, bool, sdbus::Variant, std::map<int32_t, std::string>>>>, sdbus::Signature, std::string>> result;
-        proxy_.callMethod("getComplex").onInterface(INTERFACE_NAME).storeResultsTo(result);
+        proxy_->callMethod("getComplex").onInterface(INTERFACE_NAME).storeResultsTo(result);
         return result;
     }
 
     void throwError()
     {
-        proxy_.callMethod("throwError").onInterface(INTERFACE_NAME);
+        proxy_->callMethod("throwError").onInterface(INTERFACE_NAME);
     }
 
     void throwErrorWithNoReply()
     {
-        proxy_.callMethod("throwErrorWithNoReply").onInterface(INTERFACE_NAME).dontExpectReply();
+        proxy_->callMethod("throwErrorWithNoReply").onInterface(INTERFACE_NAME).dontExpectReply();
     }
 
     void doPrivilegedStuff()
     {
-        proxy_.callMethod("doPrivilegedStuff").onInterface(INTERFACE_NAME);
+        proxy_->callMethod("doPrivilegedStuff").onInterface(INTERFACE_NAME);
     }
 
     void emitTwoSimpleSignals()
     {
-        proxy_.callMethod("emitTwoSimpleSignals").onInterface(INTERFACE_NAME);
+        proxy_->callMethod("emitTwoSimpleSignals").onInterface(INTERFACE_NAME);
     }
 
     void unregisterSimpleSignalHandler()
     {
-        proxy_.muteSignal("simpleSignal").onInterface(INTERFACE_NAME);
+        proxy_->muteSignal("simpleSignal").onInterface(INTERFACE_NAME);
     }
 
     void reRegisterSimpleSignalHandler()
     {
-        proxy_.uponSignal("simpleSignal").onInterface(INTERFACE_NAME).call([this](){ this->onSimpleSignal(); });
-        proxy_.finishRegistration();
+        proxy_->uponSignal("simpleSignal").onInterface(INTERFACE_NAME).call([this](){ this->onSimpleSignal(); });
+        proxy_->finishRegistration();
     }
 
 public:
     uint32_t action()
     {
-        return proxy_.getProperty("action").onInterface(INTERFACE_NAME);
+        return proxy_->getProperty("action").onInterface(INTERFACE_NAME);
     }
 
     void action(const uint32_t& value)
     {
-        proxy_.setProperty("action").onInterface(INTERFACE_NAME).toValue(value);
+        proxy_->setProperty("action").onInterface(INTERFACE_NAME).toValue(value);
     }
 
     bool blocking()
     {
-        return proxy_.getProperty("blocking").onInterface(INTERFACE_NAME);
+        return proxy_->getProperty("blocking").onInterface(INTERFACE_NAME);
     }
 
     void blocking(const bool& value)
     {
-        proxy_.setProperty("blocking").onInterface(INTERFACE_NAME).toValue(value);
+        proxy_->setProperty("blocking").onInterface(INTERFACE_NAME).toValue(value);
     }
 
     std::string state()
     {
-        return proxy_.getProperty("state").onInterface(INTERFACE_NAME);
+        return proxy_->getProperty("state").onInterface(INTERFACE_NAME);
     }
 
 private:
-    sdbus::IProxy& proxy_;
+    sdbus::IProxy* proxy_;
 };
 
 }} // namespaces

--- a/tests/perftests/perftests-adaptor.h
+++ b/tests/perftests/perftests-adaptor.h
@@ -20,19 +20,24 @@ public:
 
 protected:
     perftests_adaptor(sdbus::IObject& object)
-        : object_(object)
+        : object_(&object)
     {
-        object_.registerMethod("sendDataSignals").onInterface(INTERFACE_NAME).withInputParamNames("numberOfSignals", "signalMsgSize").implementedAs([this](const uint32_t& numberOfSignals, const uint32_t& signalMsgSize){ return this->sendDataSignals(numberOfSignals, signalMsgSize); });
-        object_.registerMethod("concatenateTwoStrings").onInterface(INTERFACE_NAME).withInputParamNames("string1", "string2").withOutputParamNames("result").implementedAs([this](const std::string& string1, const std::string& string2){ return this->concatenateTwoStrings(string1, string2); });
-        object_.registerSignal("dataSignal").onInterface(INTERFACE_NAME).withParameters<std::string>("data");
+        object_->registerMethod("sendDataSignals").onInterface(INTERFACE_NAME).withInputParamNames("numberOfSignals", "signalMsgSize").implementedAs([this](const uint32_t& numberOfSignals, const uint32_t& signalMsgSize){ return this->sendDataSignals(numberOfSignals, signalMsgSize); });
+        object_->registerMethod("concatenateTwoStrings").onInterface(INTERFACE_NAME).withInputParamNames("string1", "string2").withOutputParamNames("result").implementedAs([this](const std::string& string1, const std::string& string2){ return this->concatenateTwoStrings(string1, string2); });
+        object_->registerSignal("dataSignal").onInterface(INTERFACE_NAME).withParameters<std::string>("data");
     }
+
+    perftests_adaptor(const perftests_adaptor&) = delete;
+    perftests_adaptor& operator=(const perftests_adaptor&) = delete;
+    perftests_adaptor(perftests_adaptor&&) = default;
+    perftests_adaptor& operator=(perftests_adaptor&&) = default;
 
     ~perftests_adaptor() = default;
 
 public:
     void emitDataSignal(const std::string& data)
     {
-        object_.emitSignal("dataSignal").onInterface(INTERFACE_NAME).withArguments(data);
+        object_->emitSignal("dataSignal").onInterface(INTERFACE_NAME).withArguments(data);
     }
 
 private:
@@ -40,7 +45,7 @@ private:
     virtual std::string concatenateTwoStrings(const std::string& string1, const std::string& string2) = 0;
 
 private:
-    sdbus::IObject& object_;
+    sdbus::IObject* object_;
 };
 
 }} // namespaces

--- a/tests/perftests/perftests-proxy.h
+++ b/tests/perftests/perftests-proxy.h
@@ -20,10 +20,15 @@ public:
 
 protected:
     perftests_proxy(sdbus::IProxy& proxy)
-        : proxy_(proxy)
+        : proxy_(&proxy)
     {
-        proxy_.uponSignal("dataSignal").onInterface(INTERFACE_NAME).call([this](const std::string& data){ this->onDataSignal(data); });
+        proxy_->uponSignal("dataSignal").onInterface(INTERFACE_NAME).call([this](const std::string& data){ this->onDataSignal(data); });
     }
+
+    perftests_proxy(const perftests_proxy&) = delete;
+    perftests_proxy& operator=(const perftests_proxy&) = delete;
+    perftests_proxy(perftests_proxy&&) = default;
+    perftests_proxy& operator=(perftests_proxy&&) = default;
 
     ~perftests_proxy() = default;
 
@@ -32,18 +37,18 @@ protected:
 public:
     void sendDataSignals(const uint32_t& numberOfSignals, const uint32_t& signalMsgSize)
     {
-        proxy_.callMethod("sendDataSignals").onInterface(INTERFACE_NAME).withArguments(numberOfSignals, signalMsgSize);
+        proxy_->callMethod("sendDataSignals").onInterface(INTERFACE_NAME).withArguments(numberOfSignals, signalMsgSize);
     }
 
     std::string concatenateTwoStrings(const std::string& string1, const std::string& string2)
     {
         std::string result;
-        proxy_.callMethod("concatenateTwoStrings").onInterface(INTERFACE_NAME).withArguments(string1, string2).storeResultsTo(result);
+        proxy_->callMethod("concatenateTwoStrings").onInterface(INTERFACE_NAME).withArguments(string1, string2).storeResultsTo(result);
         return result;
     }
 
 private:
-    sdbus::IProxy& proxy_;
+    sdbus::IProxy* proxy_;
 };
 
 }} // namespaces

--- a/tests/stresstests/celsius-thermometer-adaptor.h
+++ b/tests/stresstests/celsius-thermometer-adaptor.h
@@ -22,10 +22,15 @@ public:
 
 protected:
     thermometer_adaptor(sdbus::IObject& object)
-        : object_(object)
+        : object_(&object)
     {
-        object_.registerMethod("getCurrentTemperature").onInterface(INTERFACE_NAME).withOutputParamNames("result").implementedAs([this](){ return this->getCurrentTemperature(); });
+        object_->registerMethod("getCurrentTemperature").onInterface(INTERFACE_NAME).withOutputParamNames("result").implementedAs([this](){ return this->getCurrentTemperature(); });
     }
+
+    thermometer_adaptor(const thermometer_adaptor&) = delete;
+    thermometer_adaptor& operator=(const thermometer_adaptor&) = delete;
+    thermometer_adaptor(thermometer_adaptor&&) = default;
+    thermometer_adaptor& operator=(thermometer_adaptor&&) = default;
 
     ~thermometer_adaptor() = default;
 
@@ -33,7 +38,7 @@ private:
     virtual uint32_t getCurrentTemperature() = 0;
 
 private:
-    sdbus::IObject& object_;
+    sdbus::IObject* object_;
 };
 
 }}}} // namespaces

--- a/tests/stresstests/celsius-thermometer-proxy.h
+++ b/tests/stresstests/celsius-thermometer-proxy.h
@@ -22,9 +22,14 @@ public:
 
 protected:
     thermometer_proxy(sdbus::IProxy& proxy)
-        : proxy_(proxy)
+        : proxy_(&proxy)
     {
     }
+
+    thermometer_proxy(const thermometer_proxy&) = delete;
+    thermometer_proxy& operator=(const thermometer_proxy&) = delete;
+    thermometer_proxy(thermometer_proxy&&) = default;
+    thermometer_proxy& operator=(thermometer_proxy&&) = default;
 
     ~thermometer_proxy() = default;
 
@@ -32,12 +37,12 @@ public:
     uint32_t getCurrentTemperature()
     {
         uint32_t result;
-        proxy_.callMethod("getCurrentTemperature").onInterface(INTERFACE_NAME).storeResultsTo(result);
+        proxy_->callMethod("getCurrentTemperature").onInterface(INTERFACE_NAME).storeResultsTo(result);
         return result;
     }
 
 private:
-    sdbus::IProxy& proxy_;
+    sdbus::IProxy* proxy_;
 };
 
 }}}} // namespaces

--- a/tests/stresstests/concatenator-adaptor.h
+++ b/tests/stresstests/concatenator-adaptor.h
@@ -21,25 +21,30 @@ public:
 
 protected:
     concatenator_adaptor(sdbus::IObject& object)
-        : object_(object)
+        : object_(&object)
     {
-        object_.registerMethod("concatenate").onInterface(INTERFACE_NAME).withInputParamNames("params").withOutputParamNames("result").implementedAs([this](sdbus::Result<std::string>&& result, std::map<std::string, sdbus::Variant> params){ this->concatenate(std::move(result), std::move(params)); });
-        object_.registerSignal("concatenatedSignal").onInterface(INTERFACE_NAME).withParameters<std::string>("concatenatedString");
+        object_->registerMethod("concatenate").onInterface(INTERFACE_NAME).withInputParamNames("params").withOutputParamNames("result").implementedAs([this](sdbus::Result<std::string>&& result, std::map<std::string, sdbus::Variant> params){ this->concatenate(std::move(result), std::move(params)); });
+        object_->registerSignal("concatenatedSignal").onInterface(INTERFACE_NAME).withParameters<std::string>("concatenatedString");
     }
+
+    concatenator_adaptor(const concatenator_adaptor&) = delete;
+    concatenator_adaptor& operator=(const concatenator_adaptor&) = delete;
+    concatenator_adaptor(concatenator_adaptor&&) = default;
+    concatenator_adaptor& operator=(concatenator_adaptor&&) = default;
 
     ~concatenator_adaptor() = default;
 
 public:
     void emitConcatenatedSignal(const std::string& concatenatedString)
     {
-        object_.emitSignal("concatenatedSignal").onInterface(INTERFACE_NAME).withArguments(concatenatedString);
+        object_->emitSignal("concatenatedSignal").onInterface(INTERFACE_NAME).withArguments(concatenatedString);
     }
 
 private:
     virtual void concatenate(sdbus::Result<std::string>&& result, std::map<std::string, sdbus::Variant> params) = 0;
 
 private:
-    sdbus::IObject& object_;
+    sdbus::IObject* object_;
 };
 
 }}} // namespaces

--- a/tests/stresstests/concatenator-proxy.h
+++ b/tests/stresstests/concatenator-proxy.h
@@ -21,10 +21,15 @@ public:
 
 protected:
     concatenator_proxy(sdbus::IProxy& proxy)
-        : proxy_(proxy)
+        : proxy_(&proxy)
     {
-        proxy_.uponSignal("concatenatedSignal").onInterface(INTERFACE_NAME).call([this](const std::string& concatenatedString){ this->onConcatenatedSignal(concatenatedString); });
+        proxy_->uponSignal("concatenatedSignal").onInterface(INTERFACE_NAME).call([this](const std::string& concatenatedString){ this->onConcatenatedSignal(concatenatedString); });
     }
+
+    concatenator_proxy(const concatenator_proxy&) = delete;
+    concatenator_proxy& operator=(const concatenator_proxy&) = delete;
+    concatenator_proxy(concatenator_proxy&&) = default;
+    concatenator_proxy& operator=(concatenator_proxy&&) = default;
 
     ~concatenator_proxy() = default;
 
@@ -35,11 +40,11 @@ protected:
 public:
     sdbus::PendingAsyncCall concatenate(const std::map<std::string, sdbus::Variant>& params)
     {
-        return proxy_.callMethodAsync("concatenate").onInterface(INTERFACE_NAME).withArguments(params).uponReplyInvoke([this](const sdbus::Error* error, const std::string& result){ this->onConcatenateReply(result, error); });
+        return proxy_->callMethodAsync("concatenate").onInterface(INTERFACE_NAME).withArguments(params).uponReplyInvoke([this](const sdbus::Error* error, const std::string& result){ this->onConcatenateReply(result, error); });
     }
 
 private:
-    sdbus::IProxy& proxy_;
+    sdbus::IProxy* proxy_;
 };
 
 }}} // namespaces

--- a/tests/stresstests/fahrenheit-thermometer-adaptor.h
+++ b/tests/stresstests/fahrenheit-thermometer-adaptor.h
@@ -22,10 +22,15 @@ public:
 
 protected:
     thermometer_adaptor(sdbus::IObject& object)
-        : object_(object)
+        : object_(&object)
     {
-        object_.registerMethod("getCurrentTemperature").onInterface(INTERFACE_NAME).withOutputParamNames("result").implementedAs([this](){ return this->getCurrentTemperature(); });
+        object_->registerMethod("getCurrentTemperature").onInterface(INTERFACE_NAME).withOutputParamNames("result").implementedAs([this](){ return this->getCurrentTemperature(); });
     }
+
+    thermometer_adaptor(const thermometer_adaptor&) = delete;
+    thermometer_adaptor& operator=(const thermometer_adaptor&) = delete;
+    thermometer_adaptor(thermometer_adaptor&&) = default;
+    thermometer_adaptor& operator=(thermometer_adaptor&&) = default;
 
     ~thermometer_adaptor() = default;
 
@@ -33,7 +38,7 @@ private:
     virtual uint32_t getCurrentTemperature() = 0;
 
 private:
-    sdbus::IObject& object_;
+    sdbus::IObject* object_;
 };
 
 }}}} // namespaces
@@ -51,11 +56,16 @@ public:
 
 protected:
     factory_adaptor(sdbus::IObject& object)
-        : object_(object)
+        : object_(&object)
     {
-        object_.registerMethod("createDelegateObject").onInterface(INTERFACE_NAME).withOutputParamNames("delegate").implementedAs([this](sdbus::Result<sdbus::ObjectPath>&& result){ this->createDelegateObject(std::move(result)); });
-        object_.registerMethod("destroyDelegateObject").onInterface(INTERFACE_NAME).withInputParamNames("delegate").implementedAs([this](sdbus::Result<>&& result, sdbus::ObjectPath delegate){ this->destroyDelegateObject(std::move(result), std::move(delegate)); }).withNoReply();
+        object_->registerMethod("createDelegateObject").onInterface(INTERFACE_NAME).withOutputParamNames("delegate").implementedAs([this](sdbus::Result<sdbus::ObjectPath>&& result){ this->createDelegateObject(std::move(result)); });
+        object_->registerMethod("destroyDelegateObject").onInterface(INTERFACE_NAME).withInputParamNames("delegate").implementedAs([this](sdbus::Result<>&& result, sdbus::ObjectPath delegate){ this->destroyDelegateObject(std::move(result), std::move(delegate)); }).withNoReply();
     }
+
+    factory_adaptor(const factory_adaptor&) = delete;
+    factory_adaptor& operator=(const factory_adaptor&) = delete;
+    factory_adaptor(factory_adaptor&&) = default;
+    factory_adaptor& operator=(factory_adaptor&&) = default;
 
     ~factory_adaptor() = default;
 
@@ -64,7 +74,7 @@ private:
     virtual void destroyDelegateObject(sdbus::Result<>&& result, sdbus::ObjectPath delegate) = 0;
 
 private:
-    sdbus::IObject& object_;
+    sdbus::IObject* object_;
 };
 
 }}}}} // namespaces

--- a/tests/stresstests/fahrenheit-thermometer-proxy.h
+++ b/tests/stresstests/fahrenheit-thermometer-proxy.h
@@ -22,9 +22,14 @@ public:
 
 protected:
     thermometer_proxy(sdbus::IProxy& proxy)
-        : proxy_(proxy)
+        : proxy_(&proxy)
     {
     }
+
+    thermometer_proxy(const thermometer_proxy&) = delete;
+    thermometer_proxy& operator=(const thermometer_proxy&) = delete;
+    thermometer_proxy(thermometer_proxy&&) = default;
+    thermometer_proxy& operator=(thermometer_proxy&&) = default;
 
     ~thermometer_proxy() = default;
 
@@ -32,12 +37,12 @@ public:
     uint32_t getCurrentTemperature()
     {
         uint32_t result;
-        proxy_.callMethod("getCurrentTemperature").onInterface(INTERFACE_NAME).storeResultsTo(result);
+        proxy_->callMethod("getCurrentTemperature").onInterface(INTERFACE_NAME).storeResultsTo(result);
         return result;
     }
 
 private:
-    sdbus::IProxy& proxy_;
+    sdbus::IProxy* proxy_;
 };
 
 }}}} // namespaces
@@ -55,9 +60,14 @@ public:
 
 protected:
     factory_proxy(sdbus::IProxy& proxy)
-        : proxy_(proxy)
+        : proxy_(&proxy)
     {
     }
+
+    factory_proxy(const factory_proxy&) = delete;
+    factory_proxy& operator=(const factory_proxy&) = delete;
+    factory_proxy(factory_proxy&&) = default;
+    factory_proxy& operator=(factory_proxy&&) = default;
 
     ~factory_proxy() = default;
 
@@ -65,17 +75,17 @@ public:
     sdbus::ObjectPath createDelegateObject()
     {
         sdbus::ObjectPath result;
-        proxy_.callMethod("createDelegateObject").onInterface(INTERFACE_NAME).storeResultsTo(result);
+        proxy_->callMethod("createDelegateObject").onInterface(INTERFACE_NAME).storeResultsTo(result);
         return result;
     }
 
     void destroyDelegateObject(const sdbus::ObjectPath& delegate)
     {
-        proxy_.callMethod("destroyDelegateObject").onInterface(INTERFACE_NAME).withArguments(delegate).dontExpectReply();
+        proxy_->callMethod("destroyDelegateObject").onInterface(INTERFACE_NAME).withArguments(delegate).dontExpectReply();
     }
 
 private:
-    sdbus::IProxy& proxy_;
+    sdbus::IProxy* proxy_;
 };
 
 }}}}} // namespaces


### PR DESCRIPTION
Generated adaptor and proxy classes did (accidentally) not support move semantics, since they have explicitly defaulted constructor, which prohibited the compiler from providing move operations automatically. Now the implementation of these classes adheres to the Rule of Five (Rule of All or Nothing). Move semantics is enabled, copy semantics disabled. This allows these classes to be used in containers, in `std::variant`, etc.