### PR TITLE
Force event loop to re-enter processing to handle queued messages

### DIFF
--- a/include/sdbus-c++/IConnection.h
+++ b/include/sdbus-c++/IConnection.h
@@ -67,10 +67,6 @@ namespace sdbus {
             /*!
              * The read fd to be monitored by the event loop.
              */
-            int event_fd;
-            /*!
-             * The read fd to be monitored by the event loop.
-             */
             int fd;
             /*!
              * The events to use for poll(2) alongside fd.
@@ -81,6 +77,11 @@ namespace sdbus {
              * Absolute timeout value in micro seconds and based of CLOCK_MONOTONIC.
              */
             uint64_t timeout_usec;
+
+            /*!
+             * The read fd to be monitored by the event loop.
+             */
+            int event_fd;
 
             /*!
              * Get the event poll timeout.

--- a/include/sdbus-c++/IConnection.h
+++ b/include/sdbus-c++/IConnection.h
@@ -67,6 +67,10 @@ namespace sdbus {
             /*!
              * The read fd to be monitored by the event loop.
              */
+            int event_fd;
+            /*!
+             * The read fd to be monitored by the event loop.
+             */
             int fd;
             /*!
              * The events to use for poll(2) alongside fd.

--- a/src/Connection.cpp
+++ b/src/Connection.cpp
@@ -146,7 +146,7 @@ Connection::PollData Connection::getEventLoopPollData() const
     auto r = iface_->sd_bus_get_poll_data(bus_.get(), &pollData);
     SDBUS_THROW_ERROR_IF(r < 0, "Failed to get bus poll data", -r);
 
-    return {eventFd_.fd, pollData.fd, pollData.events, pollData.timeout_usec};
+    return {pollData.fd, pollData.events, pollData.timeout_usec, eventFd_.fd};
 }
 
 const ISdBus& Connection::getSdBusInterface() const

--- a/src/Connection.h
+++ b/src/Connection.h
@@ -139,6 +139,7 @@ namespace sdbus::internal {
         void notifyEventLoop(int fd) const;
         void notifyEventLoopToExit() const;
         void clearEventLoopNotification(int fd) const;
+        void notifyEventLoop() const override;
         void notifyEventLoopNewTimeout() const override;
 
     private:

--- a/src/IConnection.h
+++ b/src/IConnection.h
@@ -90,6 +90,7 @@ namespace sdbus::internal {
                                                         , sd_bus_message_handler_t callback
                                                         , void* userData ) = 0;
 
+        virtual void notifyEventLoop() const = 0;
         virtual void notifyEventLoopNewTimeout() const = 0;
         virtual MethodReply tryCallMethodSynchronously(const MethodCall& message, uint64_t timeout) = 0;
     };

--- a/src/Message.cpp
+++ b/src/Message.cpp
@@ -782,6 +782,10 @@ MethodReply MethodCall::sendWithReply(uint64_t timeout) const
 
     SDBUS_THROW_ERROR_IF(r < 0, "Failed to call method", -r);
 
+    // Force event loop to re-enter processing to handle queued messages
+    SDBUS_THROW_ERROR_IF(connection_ == nullptr, "Invalid use of MethodCall API", ENOTSUP);
+    connection_->notifyEventLoop();
+
     return Factory::create<MethodReply>(sdbusReply, sdbus_, adopt_message);
 }
 
@@ -789,6 +793,10 @@ MethodReply MethodCall::sendWithNoReply() const
 {
     auto r = sdbus_->sd_bus_send(nullptr, (sd_bus_message*)msg_, nullptr);
     SDBUS_THROW_ERROR_IF(r < 0, "Failed to call method with no reply", -r);
+
+    // Force event loop to re-enter processing to handle queued messages
+    SDBUS_THROW_ERROR_IF(connection_ == nullptr, "Invalid use of MethodCall API", ENOTSUP);
+    connection_->notifyEventLoop();
 
     return Factory::create<MethodReply>(); // No reply
 }


### PR DESCRIPTION
Hi everyone.

Unfortunately, an external event loop can not handle some pending events(signals for example). This issue happens when library calls `sd_bus_call`. Function `sd_bus_call` reads all available data from sdbus file descriptor. As the result, the polling mechanism in external event loop can not detect changes on sdbus file descriptor.

Proposed fix forces event loop to re-enter processing to handle queued messages.

Cheers,
Taras