### PR TITLE
docs: strip absolute paths from doxygen documentation

### DIFF
--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -162,7 +162,7 @@ FULL_PATH_NAMES        = YES
 # will be relative from the directory where doxygen is started.
 # This tag requires that the tag FULL_PATH_NAMES is set to YES.
 
-STRIP_FROM_PATH        =
+STRIP_FROM_PATH        = @PROJECT_SOURCE_DIR@ @PROJECT_BINARY_DIR@
 
 # The STRIP_FROM_INC_PATH tag can be used to strip a user-defined part of the
 # path mentioned in the documentation of a class, which tells the reader which

--- a/include/sdbus-c++/IConnection.h
+++ b/include/sdbus-c++/IConnection.h
@@ -293,7 +293,6 @@ namespace sdbus {
          *
          * @param[in] match Match expression to filter incoming D-Bus message
          * @param[in] callback Callback handler to be called upon incoming D-Bus message matching the rule
-         * @param[in] Floating slot tag
          *
          * The method installs a floating match rule for messages received on the specified bus connection.
          * Floating means that the bus connection object owns the match rule, i.e. lifetime of the match rule
@@ -314,21 +313,21 @@ namespace sdbus {
         [[deprecated("This function has been replaced by enterEventLoop()")]] void enterProcessingLoop();
 
         /*!
-         * @copydoc IConnection::enterProcessingLoopAsync()
+         * @copydoc IConnection::enterEventLoopAsync()
          *
          * @deprecated This function has been replaced by enterEventLoopAsync()
          */
         [[deprecated("This function has been replaced by enterEventLoopAsync()")]] void enterProcessingLoopAsync();
 
         /*!
-         * @copydoc IConnection::leaveProcessingLoop()
+         * @copydoc IConnection::leaveEventLoop()
          *
          * @deprecated This function has been replaced by leaveEventLoop()
          */
         [[deprecated("This function has been replaced by leaveEventLoop()")]] void leaveProcessingLoop();
 
         /*!
-         * @copydoc IConnection::getProcessLoopPollData()
+         * @copydoc IConnection::getEventLoopPollData()
          *
          * @deprecated This function has been replaced by getEventLoopPollData()
          */

--- a/include/sdbus-c++/IProxy.h
+++ b/include/sdbus-c++/IProxy.h
@@ -469,7 +469,6 @@ namespace sdbus {
      * @param[in] connection D-Bus connection to be used by the proxy object
      * @param[in] destination Bus name that provides the remote D-Bus object
      * @param[in] objectPath Path of the remote D-Bus object
-     * @param[in] dont_run_event_loop_thread tag to specify the behavior regarding running an event loop thread
      * @return Pointer to the object proxy instance
      *
      * The provided connection will be used by the proxy to issue calls against the object.
@@ -513,7 +512,6 @@ namespace sdbus {
      *
      * @param[in] destination Bus name that provides the remote D-Bus object
      * @param[in] objectPath Path of the remote D-Bus object
-     * @param[in] dont_run_event_loop_thread tag to specify the behavior regarding running an event loop thread
      * @return Pointer to the object proxy instance
      *
      * No D-Bus connection is provided here, so the object proxy will create and manage

--- a/include/sdbus-c++/ProxyInterfaces.h
+++ b/include/sdbus-c++/ProxyInterfaces.h
@@ -114,7 +114,6 @@ namespace sdbus {
          *
          * @param[in] destination Bus name that provides a D-Bus object
          * @param[in] objectPath Path of the D-Bus object
-         * @param[in] dont_run_event_loop_thread tag to specify the behavior regarding running an event loop thread
          *
          * This constructor overload creates a proxy that manages its own D-Bus connection(s).
          * For more information on its behavior, consult @ref createProxy(std::string,std::string,sdbus::dont_run_event_loop_thread_t)
@@ -163,7 +162,6 @@ namespace sdbus {
          * @param[in] connection D-Bus connection to be used by the proxy object
          * @param[in] destination Bus name that provides a D-Bus object
          * @param[in] objectPath Path of the D-Bus object
-         * @param[in] dont_run_event_loop_thread tag to specify the behavior regarding running an event loop thread
          *
          * The proxy created this way becomes an owner of the connection.
          * For more information on its behavior, consult @ref createProxy(std::unique_ptr<sdbus::IConnection>&&,std::string,std::string,sdbus::dont_run_event_loop_thread_t)


### PR DESCRIPTION
Fixes #288 