### PR TITLE
refactor: simplify async D-Bus connection handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,12 +12,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04]
+        os: [ubuntu-20.04, ubuntu-22.04]
         compiler: [g++, clang]
         build: [shared-libsystemd]
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             compiler: g++
+            build: embedded-static-libsystemd
+          - os: ubuntu-22.04
+            compiler: clang
             build: embedded-static-libsystemd
     steps:
     - uses: actions/checkout@v3
@@ -60,7 +63,7 @@ jobs:
       run: |
         mkdir build
         cd build
-        cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_VERBOSE_MAKEFILE=ON -DBUILD_TESTS=ON -DENABLE_PERF_TESTS=ON -DENABLE_STRESS_TESTS=ON -DBUILD_CODE_GEN=ON -DBUILD_LIBSYSTEMD=ON -DLIBSYSTEMD_VERSION=244 ..
+        cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_VERBOSE_MAKEFILE=ON -DBUILD_TESTS=ON -DENABLE_PERF_TESTS=ON -DENABLE_STRESS_TESTS=ON -DBUILD_CODE_GEN=ON -DBUILD_LIBSYSTEMD=ON -DLIBSYSTEMD_VERSION=252 ..
     - name: make
       run: |
         cd build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,9 +16,9 @@ option(BUILD_LIBSYSTEMD "Build libsystemd static library and incorporate it into
 
 if(NOT BUILD_LIBSYSTEMD)
     find_package(PkgConfig REQUIRED)
-    pkg_check_modules(Systemd IMPORTED_TARGET GLOBAL libsystemd>=236)
+    pkg_check_modules(Systemd IMPORTED_TARGET GLOBAL libsystemd>=238)
     if(NOT TARGET PkgConfig::Systemd)
-        message(FATAL_ERROR "libsystemd of version at least 236 is required, but was not found "
+        message(FATAL_ERROR "libsystemd of version at least 238 is required, but was not found "
                             "(if you have systemd in your OS, you may want to install package containing pkgconfig "
                             " files for libsystemd library. On Ubuntu, that is libsystemd-dev. "
                             " Alternatively, you may turn BUILD_LIBSYSTEMD on for sdbus-c++ to download, build "

--- a/ChangeLog
+++ b/ChangeLog
@@ -216,3 +216,18 @@ v1.2.0
 - Add printer for std::chrono in googletest v1.11.0
 - Fix potential undefined behavior in creation of sdbus::Error
 - Additional little fixes and improvements in code, build system, and documentation
+
+v2.x
+- Breaking changes in API/ABI/behavior:
+   - In *synchronous* D-Bus calls, the proxy now **always** blocks the connection for concurrent use until the call finishes (with either a received reply,
+     an error, or time out). If this creates a connection contention issue in your multi-threaded design, use short-lived, light-weight proxies, or call
+     the method in an asynchronous way.
+   - The `PollData` struct has been extended with a new data member: `eventFd`. All hooks with external event loops shall be modified to poll on this fd as well.
+   - `PollData::timeout_usec` was renamed to `PollData::timeout` and its type has been changed to `std::chrono::microseconds`. This member now holds directly
+     what before had to be obtained through `PollData::getAbsoluteTimeout()` call.
+   - `PollData::getRelativeTimeout()` return type was changed to `std::chrono::microseconds`.
+   - `IConnection::processPendingRequest()` was renamed to `IConnection::processPendingEvent()`.
+- Systemd of at least v238 is required to compile sdbus-c++
+- A proper fix for timeout handling
+- Fix for external event loops in which the event loop thread ID was not correctly initialized (now fixed and simplified by not needing the thread ID anymore)
+- Other simplifications, improvements and fixes springing out from the above refactoring

--- a/docs/using-sdbus-c++.md
+++ b/docs/using-sdbus-c++.md
@@ -21,7 +21,8 @@ Using sdbus-c++ library
 16. [Standard D-Bus interfaces](#standard-d-bus-interfaces)
 17. [Using D-Bus Types](#using-d-bus-types)
 18. [Support for match rules](#support-for-match-rules)
-19. [Conclusion](#conclusion)
+19. [Using sdbus-c++ in external event loops](#using-sdbus-c-in-external-event-loops)
+20. [Conclusion](#conclusion)
 
 Introduction
 ------------
@@ -379,7 +380,7 @@ int main(int argc, char *argv[])
 }
 ```
 
-In simple cases, we don't need to create D-Bus connection explicitly for our proxies. Unless a connection is provided to a proxy object explicitly via factory parameter, the proxy will create a connection of his own, and it will be a system bus connection. This is the case in the example above. (This approach is not scalable and resource-saving if we have plenty of proxies; see section [Working with D-Bus connections](#working-with-d-bus-connections-in-sdbus-c) for elaboration.) So, in the example, we create a proxy for object `/org/sdbuscpp/concatenator` publicly available at bus `org.sdbuscpp.concatenator`. We register signal handlers, if any, and finish the registration, making the proxy ready for use.
+In simple cases, we don't need to create D-Bus connection explicitly for our proxies. Unless a connection is provided to a proxy object explicitly via factory parameter, the proxy will create a connection of his own (unless it is a light-weight, short-lived proxy created with `dont_run_event_loop_thread_t`), and it will be a system bus connection. This is the case in the example above. (This approach is not scalable and resource-saving if we have plenty of proxies; see section [Working with D-Bus connections](#working-with-d-bus-connections-in-sdbus-c) for elaboration.) So, in the example, we create a proxy for object `/org/sdbuscpp/concatenator` publicly available at bus `org.sdbuscpp.concatenator`. We register signal handlers, if any, and finish the registration, making the proxy ready for use.
 
 The callback for a D-Bus signal handler on this level is any callable of signature `void(sdbus::Signal& signal)`. The one and only parameter `signal` is the incoming signal message. We need to deserialize arguments from it, and then we can do our business logic with it.
 
@@ -395,41 +396,51 @@ How shall we use connections in relation to D-Bus objects and object proxies?
 
 A D-Bus connection is represented by a `IConnection` instance. Each connection needs an event loop being run upon it. So it needs a thread handling the event loop. This thread serves all incoming and outgoing messages and all communication towards D-Bus daemon. One process can have one but also multiple D-Bus connections (we just have to make certain that the connections with assigned bus names don't share a common name; the name must be unique).
 
-A typical use case for most services is **one** D-Bus connection in the application. The application runs event loop on that connection. When creating objects or proxies, the application provides reference of that connection to those objects and proxies. This means all these objects and proxies share the same connection. This is nicely scalable, because with whatever number of objects or proxies, there is only one connection and one event loop thread. Yet, services that provide objects at various bus names have to create and maintain multiple D-Bus connections, each with the unique bus name.
+A typical use case for most services is **one** D-Bus connection in the application. The application runs an (internal or external, see below) event loop on that connection. When creating objects or proxies, the application provides reference of that connection to those objects and proxies. This means all these objects and proxies share the same connection. This is nicely scalable, because with whatever number of objects or proxies, there is only one connection and one event loop thread. Yet, services that provide objects at various bus names have to create and maintain multiple D-Bus connections, each with the unique bus name.
 
-The connection is thread-safe and objects and proxies can invoke operations on it from multiple threads simultaneously, but the operations are serialized. This means, for example, that if an object's callback for an incoming remote method call is going to be invoked in an event loop thread, and in another thread we use a proxy to call remote method in another process, the threads are contending and only one can go on while the other must wait and can only proceed after the first one has finished, because both are using a shared resource -- the connection.
+The connection is thread-safe and objects and proxies can invoke operations on it from multiple threads simultaneously, but the operations are serialized. Access to the connection is mutually exclusive. This means, for example, that if an object's callback for an incoming remote method call is going to be invoked in an event loop thread, and in another thread we use a proxy to call remote method in another process, the threads are contending and only one can go on while the other must wait and can only proceed after the first one has finished, because both are using a shared resource -- the connection.
 
-We should bear that in mind when designing more complex, multi-threaded services with high parallelism. If we have undesired contention on a connection, creating a specific, dedicated connection for a hot spot helps to increase concurrency. sdbus-c++ provides us freedom to create as many connections as we want and assign objects and proxies to those connections at our will. We, as application developers, choose whatever approach is more suitable to us at quite a fine granularity.
+When a `poll()` sleeps upon the connection, the connection can be used by other threads without blocking. When calling a D-Bus method through a proxy synchronously, the proxy blocks the connection from concurrent use until it gets from the peer a reply (or an error, the call times out). Async D-Bus method calls don't block the connection while the call is pending (the connection is only "locked" while the call message is sent out and while the reply handler is executed for an already arrived reply message, but not in between while the call is pending). See doxygen documentation for `IProxy::callMethod()` overloads for more details.
+
+We should bear these design aspects of sdbus-c++ in mind when designing more complex, multi-threaded services with high parallelism. If we have undesired contention on a connection, creating a separate, dedicated connection for a hot spot helps to increase concurrency. sdbus-c++ provides us freedom to create as many connections as we want and assign objects and proxies to those connections at our will. We, as application developers, choose whatever approach is more suitable to us at quite a fine granularity.
 
 So, more technically, how can we use connections from the server and the client perspective?
 
 #### Using D-Bus connections on the server side
 
-On the **server** side, we generally need to create D-Bus objects and publish their APIs. For that we first need a connection with a unique bus name. We need to create the D-Bus connection manually ourselves, request bus name on it, and manually launch its event loop:
+On the **server** side, we generally need to create D-Bus objects and publish their APIs. For that we first need a connection with a unique bus name. We need to create the D-Bus connection manually ourselves, request bus name on it, and manually launch:
 
-  * either in a blocking way, through `enterEventLoop()`,
-  * or in a non-blocking async way, through `enterEventLoopAsync()`,
-  * or, when we have our own implementation of an event loop (e.g. we are using sd-event event loop), we can ask the connection for its underlying fd, I/O events and timeouts through `getEventLoopPollData()` and use that data in our event loop mechanism.
+  * its internal event loop
+    * either in a blocking way, through `enterEventLoop()`,
+    * or in a non-blocking async way, through `enterEventLoopAsync()`,
+  * or an external event loop. This is suitable if we use in our application an event loop implementation of our choice (e.g., GLib Event Loop, boost::asio, ...) and we want to hook up our sdbus-c++ connections with it. See [Using sdbus-c++ in external event loops](#using-sdbus-c-in-external-event-loops) section for more information.
 
-The object takes the D-Bus connection as a reference in its constructor. This is the only way to wire connection and object together. We must make sure the connection exists as long as objects using it exist. 
+The object takes the D-Bus connection as a reference in its constructor. This is the only way to wire the connection and the object together. We must make sure the connection exists as long as objects using it exist.
 
 Of course, at any time before or after running the event loop on the connection, we can create and "hook", as well as remove, objects and proxies upon that connection.
+
+*Note:* There may be both objects and proxies hooked to a single connection, of course. A D-Bus server application may also be a client to another D-Bus server application, and share one D-Bus connection for the D-Bus interface it exports as well as for the proxies towards other D-Bus interfaces.
 
 #### Using D-Bus connections on the client side
 
 On the **client** side we likewise need a connection -- just that unlike on the server side, we don't need to request a unique bus name on it. We have more options here when creating a proxy:
 
-  * Pass an already existing connection as a reference. This is the typical approach when the application already maintains a D-Bus connection (maybe it provide D-Bus API on it, and/or it already has some proxies hooked on it). The proxy will share the connection with others. With this approach we must of course ensure that the connection exists as long as the proxy exists.
+  * Pass an already existing connection as a reference. This is the typical approach when the application already maintains a D-Bus connection (maybe it provide D-Bus API on it, and/or it already has some proxies hooked on it). The proxy will share the connection with others. With this approach we must of course ensure that the connection exists as long as the proxy exists. For discussion on options for running an event loop on that connection, see above section [Using D-Bus connections on the server side](#using-d-bus-connections-on-the-server-side).
 
-  * Or -- and this is typical when we have a simple D-Bus client application -- we have another option: we let the proxy maintain its own connection (and potentially an associated event loop thread, see below):
+  * Or -- and this is a simpler approach for  simple D-Bus client applications -- we have another option: we let the proxy maintain its own connection (and potentially an associated event loop thread, see below). We have two options here:
 
-    * We either create the connection ourselves and `std::move` it to the proxy object factory. The proxy becomes an owner of this connection, and will run the event loop on that connection. This had the advantage that we may choose the type of connection (system, session, remote).
+    * We either create the connection ourselves and `std::move` it to the proxy object factory. The proxy becomes an owner of this connection, and it will be his dedicated connection. This has the advantage that we may choose the type of connection (system, session, remote). Additionally,
 
-    * Or we don't bother about any connection at all when creating a proxy (the factory overload with no connection parameter). Under the hood, the proxy creates its own *system bus* connection, creates a separate thread and runs an event loop in it. Quite **simple**, but as you can see, this hurts scalability in case of many proxies, as each would spawn and maintain its own event loop thread (see discussion higher above). But we don't necessarily need an event loop thread, in case our proxy doesn't need to listen to signals or async method call replies. Read on. 
+      * when created **without** `dont_run_event_loop_thread_t` tag, the proxy **will start** a dedicated event loop thread on that connection;
+      * or, when created **with** `dont_run_event_loop_thread_t` tag, the proxy will start **no** event loop thread on that connection.
 
-    It's also possible in this case to instruct the proxy to **not spawn an event loop thread** for its connection. There are many situations that we want to quickly create a proxy, carry out one or a few (synchronous) D-Bus calls, and let go of proxy. We call them light-weight proxies. For that purpose, spawning a new event loop thread comes with time and resource penalty, for nothing. To create such **a light-weight proxy**, use the factory/constructor overload with `dont_run_event_loop_thread_t`. All in above two bullet sub-points holds; the proxy just won't spawn a thread with an event loop in it. Note that such a proxy can be used only for synchronous D-Bus calls; it may not receive signals or async call replies. 
+    * Or we don't care about connnections at all (proxy factory overloads with no connection parameter). Under the hood, the proxy creates its own *system bus* connection. Additionally:
+      * when created **without** `dont_run_event_loop_thread_t` tag, the proxy **will start** a dedicated event loop thread on that connection;
+      * or, when created **with** `dont_run_event_loop_thread_t` tag, the proxy will start **no** event loop thread on that connection.
 
-#### Stopping I/O event loops graciously
+    Proxy needs an event loop if it's a "**long-lived**" proxy that listens on incoming messages like signals, async call replies, atc. Sharing one connection with its one event loop is more scalable. Starting a dedicated event loop in a proxy is simpler from API perspective, but comes at a performance and resource cost for each proxy creation/destruction, and it hurts scalability. A simple and scalable option are "**short-lived, light-weight**" proxies. Quite a typical use case is that we occasionally need to carry out one or a few D-Bus calls and that's it. We may create a proxy, do the calls, and let go of proxy. Such a light-weight proxy is created when `dont_run_event_loop_thread_t` tag is passed to the proxy factory. Such a proxy **does not spawn** an event loop thread. It only support synchronous D-Bus calls (no signals, no async calls...), and is meant to be created, used right away, and then destroyed immediately.
+
+#### Stopping internal I/O event loops graciously
 
 A connection with an asynchronous event loop (i.e. one initiated through `enterEventLoopAsync()`) will stop and join its event loop thread automatically in its destructor. An event loop that blocks in the synchronous `enterEventLoop()` call can be unblocked through `leaveEventLoop()` call on the respective bus connection issued from a different thread or from an OS signal handler.
 
@@ -1344,6 +1355,21 @@ Support for match rules
 -----------------------
 
 `IConnection` class provides `addMatch` method that you can use to install match rules. An associated callback handler will be called upon an incoming message matching given match rule. There is support for both client-owned and floating (library-owned) match rules. Consult `IConnection` header or sdbus-c++ doxygen documentation for more information.
+
+Using sdbus-c++ in external event loops
+---------------------------------------
+
+sdbus-c++ connections can be hooked up with an external (like GMainLoop, boost::asio, etc.) or manual event loop involving `poll()` or a similar I/O polling call. The following describes how to integrate it correctly:
+
+Before **each** invocation of the I/O polling call, `IConnection::getEventLoopPollData()` function should be invoked. Returned `PollData::fd` file descriptor should be polled for the events indicated by `PollData::events`, and the I/O call should block up to the returned `PollData::timeout`. Additionally, returned `PollData::eventFd` should be polled for POLLIN events.
+
+After each I/O polling call (for both `PollData::fd` and `PollData::eventFd` events), the `IConnection::processPendingEvent()` method should be invoked. This enables the bus connection to process any incoming or outgoing D-Bus messages.
+
+Note that the returned timeout should be considered only a maximum sleeping time. It is permissible (and even expected) that shorter timeouts are used by the calling program, in case other event sources are polled in the same event loop. Note that the returned time-value is absolute, based of `CLOCK_MONOTONIC` and specified in microseconds. Use `PollData::getPollTimeout()` to have the timeout value converted into a form that can be passed to `poll()`.
+
+`PollData::fd` is a bus I/O fd. `PollData::eventFd` is an sdbus-c++ internal fd for communicating important changes from other threads to the event loop thread, so the event loop retrieves new poll data (with updated timeout, for example) and, potentially, processes pending D-Bus messages (like signals that came in during a blocking synchronous call from other thread, or queued outgoing messages that are very big to be able to have been sent in one shot from another thread), before the next poll.
+
+Consult `IConnection::PollData` and `IConnection::getEventLoopPollData()` documentation for more potentially more information.
 
 Conclusion
 ----------

--- a/include/sdbus-c++/IConnection.h
+++ b/include/sdbus-c++/IConnection.h
@@ -49,62 +49,7 @@ namespace sdbus {
     class IConnection
     {
     public:
-        /*!
-         * Poll Data for external event loop implementations.
-         *
-         * To integrate sdbus with your app's own custom event handling system
-         * you can use this method to query which file descriptors, poll events
-         * and timeouts you should add to your app's poll(2), or select(2)
-         * call in your main event loop.
-         *
-         * If you are unsure what this all means then use
-         * enterEventLoop() or enterEventLoopAsync() instead.
-         *
-         * See: getEventLoopPollData()
-         */
-        struct PollData
-        {
-            /*!
-             * The read fd to be monitored by the event loop.
-             */
-            int fd;
-            /*!
-             * The events to use for poll(2) alongside fd.
-             */
-            short int events;
-
-            /*!
-             * Absolute timeout value in micro seconds and based of CLOCK_MONOTONIC.
-             */
-            uint64_t timeout_usec;
-
-            /*!
-             * Get the event poll timeout.
-             *
-             * The timeout is an absolute value based of CLOCK_MONOTONIC.
-             *
-             * @return a duration since the CLOCK_MONOTONIC epoch started.
-             */
-            [[nodiscard]] std::chrono::microseconds getAbsoluteTimeout() const
-            {
-                return std::chrono::microseconds(timeout_usec);
-            }
-
-            /*!
-             * Get the timeout as relative value from now
-             *
-             * @return std::nullopt if the timeout is indefinite. A duration otherwise.
-             */
-            [[nodiscard]] std::optional<std::chrono::microseconds> getRelativeTimeout() const;
-
-            /*!
-             * Get a converted, relative timeout which can be passed as argument 'timeout' to poll(2)
-             *
-             * @return -1 if the timeout is indefinite. 0 if the poll(2) shouldn't block. An integer in milli
-             * seconds otherwise.
-             */
-            [[nodiscard]] int getPollTimeout() const;
-        };
+        struct PollData;
 
         virtual ~IConnection() = default;
 
@@ -127,7 +72,7 @@ namespace sdbus {
         virtual void releaseName(const std::string& name) = 0;
 
         /*!
-         * @brief Retrieve the unique name of a connection. E.g. ":1.xx"
+         * @brief Retrieves the unique name of a connection. E.g. ":1.xx"
          *
          * @throws sdbus::Error in case of failure
          */
@@ -178,44 +123,57 @@ namespace sdbus {
         [[deprecated("Use one of other addObjectManager overloads")]] virtual void addObjectManager(const std::string& objectPath) = 0;
 
         /*!
-         * @brief Returns fd, I/O events and timeout data you can pass to poll
+         * @brief Returns fd's, I/O events and timeout data to be used in an external event loop
          *
-         * To integrate sdbus with your app's own custom event handling system
-         * (without the requirement of an extra thread), you can use this
-         * method to query which file descriptors, poll events and timeouts you
-         * should add to your app's poll call in your main event loop. If these
-         * file descriptors signal, then you should call processPendingRequest
-         * to process the event. This means that all of sdbus's callbacks will
-         * arrive on your app's main event thread (opposed to on a thread created
-         * by sdbus-c++). If you are unsure what this all means then use
-         * enterEventLoop() or enterEventLoopAsync() instead.
+         * This function is useful to hook up a bus connection object with an
+         * external (like GMainLoop, boost::asio, etc.) or manual event loop
+         * involving poll() or a similar I/O polling call.
          *
-         * To integrate sdbus-c++ into a gtk app, pass the file descriptor returned
-         * by this method to g_main_context_add_poll.
+         * Before **each** invocation of the I/O polling call, this function
+         * should be invoked. Returned PollData::fd file descriptor should
+         * be polled for the events indicated by PollData::events, and the I/O
+         * call should block for that up to the returned PollData::timeout.
+         *
+         * Additionally, returned PollData::eventFd should be polled for POLLIN
+         * events.
+         *
+         * After each I/O polling call the bus connection needs to process
+         * incoming or outgoing data, by invoking processPendingEvent().
+         *
+         * Note that the returned timeout should be considered only a maximum
+         * sleeping time. It is permissible (and even expected) that shorter
+         * timeouts are used by the calling program, in case other event sources
+         * are polled in the same event loop. Note that the returned time-value
+         * is absolute, based of CLOCK_MONOTONIC and specified in microseconds.
+         * Use PollData::getPollTimeout() to have the timeout value converted
+         * in a form that can be passed to poll(2).
          *
          * @throws sdbus::Error in case of failure
          */
-        virtual PollData getEventLoopPollData() const = 0;
+        [[nodiscard]] virtual PollData getEventLoopPollData() const = 0;
 
         /*!
-         * @brief Process a pending request
+         * @brief Processes a pending event
          *
-         * @returns true if an event was processed, false if poll should be called
+         * @returns True if an event was processed, false if no operations were pending
          *
-         * Processes a single dbus event. All of sdbus-c++'s callbacks will be called
-         * from within this method. This method should ONLY be used in conjuction
-         * with getEventLoopPollData().
-         * This method returns true if an I/O message was processed. This you can try
-         * to call this method again before going to poll on I/O events. The method
-         * returns false if no operations were pending, and the caller should then
-         * poll for I/O events before calling this method again.
-         * enterEventLoop() and enterEventLoopAsync() will call this method for you,
-         * so there is no need to call it when using these. If you are unsure what
-         * this all means then don't use this method.
+         * This function drives the D-Bus connection. It processes pending I/O events.
+         * Queued outgoing messages (or parts thereof) are sent out. Queued incoming
+         * messages are dispatched to registered callbacks. Timeouts are recalculated.
+         *
+         * It returns false when no operations were pending and true if a message was
+         * processed. When false is returned the caller should synchronously poll for
+         * I/O events before calling into processPendingEvent() again.
+         * Don't forget to call getEventLoopPollData() each time before the next poll.
+         *
+         * You don't need to directly call this method or getEventLoopPollData() method
+         * when using convenient, internal bus connection event loops through
+         * enterEventLoop() or enterEventLoopAsync() calls.
+         * It is invoked automatically when necessary.
          *
          * @throws sdbus::Error in case of failure
          */
-        virtual bool processPendingRequest() = 0;
+        virtual bool processPendingEvent() = 0;
 
         /*!
          * @brief Sets general method call timeout
@@ -332,6 +290,55 @@ namespace sdbus {
          * @deprecated This function has been replaced by getEventLoopPollData()
          */
         [[deprecated("This function has been replaced by getEventLoopPollData()")]] PollData getProcessLoopPollData() const;
+
+        /*!
+         * @struct PollData
+         *
+         * Carries poll data needed for integration with external event loop implementations.
+         *
+         * See getEventLoopPollData() for more info.
+         */
+        struct PollData
+        {
+            /*!
+             * The read fd to be monitored by the event loop.
+             */
+            int fd;
+
+            /*!
+             * The events to use for poll(2) alongside fd.
+             */
+            short int events;
+
+            /*!
+             * Absolute timeout value in microseconds, based of CLOCK_MONOTONIC.
+             *
+             * Call getPollTimeout() to get timeout recalculated to relative timeout that can be passed to poll(2).
+             */
+            std::chrono::microseconds timeout;
+
+            /*!
+             * An additional event fd to be monitored by the event loop for POLLIN events.
+             */
+            int eventFd;
+
+            /*!
+             * Returns the timeout as relative value from now.
+             *
+             * Returned value is std::chrono::microseconds::max() if the timeout is indefinite.
+             *
+             * @return Relative timeout as a time duration
+             */
+            [[nodiscard]] std::chrono::microseconds getRelativeTimeout() const;
+
+            /*!
+             * Returns relative timeout in the form which can be passed as argument 'timeout' to poll(2)
+             *
+             * @return -1 if the timeout is indefinite. 0 if the poll(2) shouldn't block.
+             *         An integer in milliseconds otherwise.
+             */
+            [[nodiscard]] int getPollTimeout() const;
+        };
     };
 
     template <typename _Rep, typename _Period>

--- a/include/sdbus-c++/IProxy.h
+++ b/include/sdbus-c++/IProxy.h
@@ -81,20 +81,29 @@ namespace sdbus {
         virtual MethodCall createMethodCall(const std::string& interfaceName, const std::string& methodName) = 0;
 
         /*!
-         * @brief Calls method on the proxied D-Bus object
+         * @brief Calls method on the remote D-Bus object
          *
          * @param[in] message Message representing a method call
          * @param[in] timeout Timeout for dbus call in microseconds
          * @return A method reply message
          *
-         * Normally, the call is blocking, i.e. it waits for the remote method to finish with either
-         * a return value or an error.
+         * The call does not block if the method call has dont-expect-reply flag set. In that case,
+         * the call returns immediately and the return value is an empty, invalid method reply.
          *
-         * If the method call argument is set to not expect reply, the call will not wait for the remote
-         * method to finish, i.e. the call will be non-blocking, and the function will return an empty,
-         * invalid MethodReply object (representing void).
+         * The call blocks otherwise, waiting for the remote peer to send back a reply, or an error,
+         * or until the call times out.
          *
-         * Note: To avoid messing with messages, use higher-level API defined below.
+         * While blocking, other concurrent operations (in other threads) on the underlying bus
+         * connection are stalled until the call returns. This is not an issue in vast majority of
+         * (simple, single-threaded) applications. In asynchronous, multi-threaded designs involving
+         * shared bus connections, this may be an issue. It is advised to instead use an asynchronous
+         * callMethod() function overload, which does not block the bus connection, or do the synchronous
+         * call from another Proxy instance created just before the call and then destroyed (which is
+         * anyway quite a typical approach in D-Bus implementations). Such proxy instance must have
+         * its own bus connection. Slim proxies created with `dont_run_event_loop_thread` tag are
+         * designed for exactly that purpose.
+         *
+         * Note: To avoid messing with messages, use API on a higher level of abstraction defined below.
          *
          * @throws sdbus::Error in case of failure
          */
@@ -115,10 +124,10 @@ namespace sdbus {
          * @return Cookie for the the pending asynchronous call
          *
          * The call is non-blocking. It doesn't wait for the reply. Once the reply arrives,
-         * the provided async reply handler will get invoked from the context of the connection
-         * I/O event loop thread.
+         * the provided async reply handler will get invoked from the context of the bus
+         * connection I/O event loop thread.
          *
-         * Note: To avoid messing with messages, use higher-level API defined below.
+         * Note: To avoid messing with messages, use API on a higher level of abstraction defined below.
          *
          * @throws sdbus::Error in case of failure
          */

--- a/include/sdbus-c++/Message.h
+++ b/include/sdbus-c++/Message.h
@@ -48,7 +48,6 @@ namespace sdbus {
     class MethodReply;
     namespace internal {
         class ISdBus;
-        class IConnection;
     }
 }
 
@@ -187,12 +186,11 @@ namespace sdbus {
         bool doesntExpectReply() const;
 
     protected:
-        MethodCall(void *msg, internal::ISdBus* sdbus, const internal::IConnection* connection, adopt_message_t) noexcept;
+        MethodCall(void *msg, internal::ISdBus* sdbus, adopt_message_t) noexcept;
 
     private:
         MethodReply sendWithReply(uint64_t timeout = 0) const;
         MethodReply sendWithNoReply() const;
-        const internal::IConnection* connection_{};
     };
 
     class MethodReply : public Message

--- a/src/Connection.cpp
+++ b/src/Connection.cpp
@@ -35,46 +35,47 @@
 #include <unistd.h>
 #include <poll.h>
 #include <sys/eventfd.h>
+#include <cstdint>
 
 namespace sdbus::internal {
 
 Connection::Connection(std::unique_ptr<ISdBus>&& interface, const BusFactory& busFactory)
-    : iface_(std::move(interface))
+    : sdbus_(std::move(interface))
     , bus_(openBus(busFactory))
 {
-    assert(iface_ != nullptr);
+    assert(sdbus_ != nullptr);
 }
 
 Connection::Connection(std::unique_ptr<ISdBus>&& interface, default_bus_t)
-    : Connection(std::move(interface), [this](sd_bus** bus){ return iface_->sd_bus_open(bus); })
+    : Connection(std::move(interface), [this](sd_bus** bus){ return sdbus_->sd_bus_open(bus); })
 {
 }
 
 Connection::Connection(std::unique_ptr<ISdBus>&& interface, system_bus_t)
-    : Connection(std::move(interface), [this](sd_bus** bus){ return iface_->sd_bus_open_system(bus); })
+    : Connection(std::move(interface), [this](sd_bus** bus){ return sdbus_->sd_bus_open_system(bus); })
 {
 }
 
 Connection::Connection(std::unique_ptr<ISdBus>&& interface, session_bus_t)
-    : Connection(std::move(interface), [this](sd_bus** bus){ return iface_->sd_bus_open_user(bus); })
+    : Connection(std::move(interface), [this](sd_bus** bus){ return sdbus_->sd_bus_open_user(bus); })
 {
 }
 
 Connection::Connection(std::unique_ptr<ISdBus>&& interface, custom_session_bus_t, const std::string& address)
-        : Connection(std::move(interface), [&](sd_bus** bus) { return iface_->sd_bus_open_user_with_address(bus, address.c_str()); })
+        : Connection(std::move(interface), [&](sd_bus** bus) { return sdbus_->sd_bus_open_user_with_address(bus, address.c_str()); })
 {
 }
 
 Connection::Connection(std::unique_ptr<ISdBus>&& interface, remote_system_bus_t, const std::string& host)
-    : Connection(std::move(interface), [this, &host](sd_bus** bus){ return iface_->sd_bus_open_system_remote(bus, host.c_str()); })
+    : Connection(std::move(interface), [this, &host](sd_bus** bus){ return sdbus_->sd_bus_open_system_remote(bus, host.c_str()); })
 {
 }
 
 Connection::Connection(std::unique_ptr<ISdBus>&& interface, pseudo_bus_t)
-    : iface_(std::move(interface))
+    : sdbus_(std::move(interface))
     , bus_(openPseudoBus())
 {
-    assert(iface_ != nullptr);
+    assert(sdbus_ != nullptr);
 }
 
 Connection::~Connection()
@@ -86,38 +87,34 @@ void Connection::requestName(const std::string& name)
 {
     SDBUS_CHECK_SERVICE_NAME(name);
 
-    auto r = iface_->sd_bus_request_name(bus_.get(), name.c_str(), 0);
+    auto r = sdbus_->sd_bus_request_name(bus_.get(), name.c_str(), 0);
     SDBUS_THROW_ERROR_IF(r < 0, "Failed to request bus name", -r);
 }
 
 void Connection::releaseName(const std::string& name)
 {
-    auto r = iface_->sd_bus_release_name(bus_.get(), name.c_str());
+    auto r = sdbus_->sd_bus_release_name(bus_.get(), name.c_str());
     SDBUS_THROW_ERROR_IF(r < 0, "Failed to release bus name", -r);
 }
 
 std::string Connection::getUniqueName() const
 {
     const char* unique = nullptr;
-    auto r = iface_->sd_bus_get_unique_name(bus_.get(), &unique);
+    auto r = sdbus_->sd_bus_get_unique_name(bus_.get(), &unique);
     SDBUS_THROW_ERROR_IF(r < 0 || unique == nullptr, "Failed to get unique bus name", -r);
     return unique;
 }
 
 void Connection::enterEventLoop()
 {
-    loopThreadId_ = std::this_thread::get_id();
-    SCOPE_EXIT{ loopThreadId_ = std::thread::id{}; };
-
-    std::lock_guard guard(loopMutex_);
-
     while (true)
     {
-        auto processed = processPendingRequest();
-        if (processed)
-            continue; // Process next one
+        // Process one pending event
+        (void)processPendingEvent();
 
-        auto success = waitForNextRequest();
+        // And go to poll(), which wakes us up right away
+        // if there's another pending event, or sleeps otherwise.
+        auto success = waitForNextEvent();
         if (!success)
             break; // Exit I/O event loop
     }
@@ -138,20 +135,24 @@ void Connection::leaveEventLoop()
 Connection::PollData Connection::getEventLoopPollData() const
 {
     ISdBus::PollData pollData{};
-    auto r = iface_->sd_bus_get_poll_data(bus_.get(), &pollData);
+    auto r = sdbus_->sd_bus_get_poll_data(bus_.get(), &pollData);
     SDBUS_THROW_ERROR_IF(r < 0, "Failed to get bus poll data", -r);
 
-    return {pollData.fd, pollData.events, pollData.timeout_usec};
+    assert(eventFd_.fd >= 0);
+
+    auto timeout = pollData.timeout_usec == UINT64_MAX ? std::chrono::microseconds::max() : std::chrono::microseconds(pollData.timeout_usec);
+
+    return {pollData.fd, pollData.events, timeout, eventFd_.fd};
 }
 
 const ISdBus& Connection::getSdBusInterface() const
 {
-    return *iface_.get();
+    return *sdbus_.get();
 }
 
 ISdBus& Connection::getSdBusInterface()
 {
-    return *iface_.get();
+    return *sdbus_.get();
 }
 
 void Connection::addObjectManager(const std::string& objectPath)
@@ -161,7 +162,7 @@ void Connection::addObjectManager(const std::string& objectPath)
 
 void Connection::addObjectManager(const std::string& objectPath, floating_slot_t)
 {
-    auto r = iface_->sd_bus_add_object_manager(bus_.get(), nullptr, objectPath.c_str());
+    auto r = sdbus_->sd_bus_add_object_manager(bus_.get(), nullptr, objectPath.c_str());
 
     SDBUS_THROW_ERROR_IF(r < 0, "Failed to add object manager", -r);
 }
@@ -170,16 +171,16 @@ Slot Connection::addObjectManager(const std::string& objectPath, request_slot_t)
 {
     sd_bus_slot *slot{};
 
-    auto r = iface_->sd_bus_add_object_manager(bus_.get(), &slot, objectPath.c_str());
+    auto r = sdbus_->sd_bus_add_object_manager(bus_.get(), &slot, objectPath.c_str());
 
     SDBUS_THROW_ERROR_IF(r < 0, "Failed to add object manager", -r);
 
-    return {slot, [this](void *slot){ iface_->sd_bus_slot_unref((sd_bus_slot*)slot); }};
+    return {slot, [this](void *slot){ sdbus_->sd_bus_slot_unref((sd_bus_slot*)slot); }};
 }
 
 void Connection::setMethodCallTimeout(uint64_t timeout)
 {
-    auto r = iface_->sd_bus_set_method_call_timeout(bus_.get(), timeout);
+    auto r = sdbus_->sd_bus_set_method_call_timeout(bus_.get(), timeout);
 
     SDBUS_THROW_ERROR_IF(r < 0, "Failed to set method call timeout", -r);
 }
@@ -188,7 +189,7 @@ uint64_t Connection::getMethodCallTimeout() const
 {
     uint64_t timeout;
 
-    auto r = iface_->sd_bus_get_method_call_timeout(bus_.get(), &timeout);
+    auto r = sdbus_->sd_bus_get_method_call_timeout(bus_.get(), &timeout);
 
     SDBUS_THROW_ERROR_IF(r < 0, "Failed to get method call timeout", -r);
 
@@ -207,13 +208,13 @@ Slot Connection::addMatch(const std::string& match, message_handler callback)
         return 0;
     };
 
-    auto r = iface_->sd_bus_add_match(bus_.get(), &matchInfo->slot, match.c_str(), std::move(messageHandler), matchInfo.get());
+    auto r = sdbus_->sd_bus_add_match(bus_.get(), &matchInfo->slot, match.c_str(), std::move(messageHandler), matchInfo.get());
     SDBUS_THROW_ERROR_IF(r < 0, "Failed to add match", -r);
 
     return {matchInfo.release(), [this](void *ptr)
     {
         auto* matchInfo = static_cast<MatchInfo*>(ptr);
-        iface_->sd_bus_slot_unref(matchInfo->slot);
+        sdbus_->sd_bus_slot_unref(matchInfo->slot);
         std::default_delete<MatchInfo>{}(matchInfo);
     }};
 }
@@ -230,7 +231,7 @@ Slot Connection::addObjectVTable( const std::string& objectPath
 {
     sd_bus_slot *slot{};
 
-    auto r = iface_->sd_bus_add_object_vtable( bus_.get()
+    auto r = sdbus_->sd_bus_add_object_vtable(bus_.get()
                                              , &slot
                                              , objectPath.c_str()
                                              , interfaceName.c_str()
@@ -239,18 +240,18 @@ Slot Connection::addObjectVTable( const std::string& objectPath
 
     SDBUS_THROW_ERROR_IF(r < 0, "Failed to register object vtable", -r);
 
-    return {slot, [this](void *slot){ iface_->sd_bus_slot_unref((sd_bus_slot*)slot); }};
+    return {slot, [this](void *slot){ sdbus_->sd_bus_slot_unref((sd_bus_slot*)slot); }};
 }
 
 PlainMessage Connection::createPlainMessage() const
 {
     sd_bus_message* sdbusMsg{};
 
-    auto r = iface_->sd_bus_message_new(bus_.get(), &sdbusMsg, _SD_BUS_MESSAGE_TYPE_INVALID);
+    auto r = sdbus_->sd_bus_message_new(bus_.get(), &sdbusMsg, _SD_BUS_MESSAGE_TYPE_INVALID);
 
     SDBUS_THROW_ERROR_IF(r < 0, "Failed to create a plain message", -r);
 
-    return Message::Factory::create<PlainMessage>(sdbusMsg, iface_.get(), adopt_message);
+    return Message::Factory::create<PlainMessage>(sdbusMsg, sdbus_.get(), adopt_message);
 }
 
 MethodCall Connection::createMethodCall( const std::string& destination
@@ -260,7 +261,7 @@ MethodCall Connection::createMethodCall( const std::string& destination
 {
     sd_bus_message *sdbusMsg{};
 
-    auto r = iface_->sd_bus_message_new_method_call( bus_.get()
+    auto r = sdbus_->sd_bus_message_new_method_call(bus_.get()
                                                    , &sdbusMsg
                                                    , destination.c_str()
                                                    , objectPath.c_str()
@@ -269,7 +270,7 @@ MethodCall Connection::createMethodCall( const std::string& destination
 
     SDBUS_THROW_ERROR_IF(r < 0, "Failed to create method call", -r);
 
-    return Message::Factory::create<MethodCall>(sdbusMsg, iface_.get(), this, adopt_message);
+    return Message::Factory::create<MethodCall>(sdbusMsg, sdbus_.get(), adopt_message);
 }
 
 Signal Connection::createSignal( const std::string& objectPath
@@ -278,7 +279,7 @@ Signal Connection::createSignal( const std::string& objectPath
 {
     sd_bus_message *sdbusMsg{};
 
-    auto r = iface_->sd_bus_message_new_signal( bus_.get()
+    auto r = sdbus_->sd_bus_message_new_signal(bus_.get()
                                               , &sdbusMsg
                                               , objectPath.c_str()
                                               , interfaceName.c_str()
@@ -286,7 +287,51 @@ Signal Connection::createSignal( const std::string& objectPath
 
     SDBUS_THROW_ERROR_IF(r < 0, "Failed to create signal", -r);
 
-    return Message::Factory::create<Signal>(sdbusMsg, iface_.get(), adopt_message);
+    return Message::Factory::create<Signal>(sdbusMsg, sdbus_.get(), adopt_message);
+}
+
+MethodReply Connection::callMethod(const MethodCall& message, uint64_t timeout)
+{
+    // If the call expects reply, this call will block the bus connection from
+    // serving other messages until the reply arrives or the call times out.
+    auto reply = message.send(timeout);
+
+    // Some messages may have arrived while waiting for the call reply. They were set aside while waiting.
+    // In case an event loop is inside a poll in another thread, or an external event loop polls in the
+    // same thread but as an unrelated event source, then we need to wake up the poll explicitly so the
+    // event loop 1. processes all messages in the read queue, 2. updates poll timeout before next poll.
+    if (arePendingMessagesInReadQueue())
+        notifyEventLoopToWakeUpFromPoll();
+
+    return reply;
+}
+
+void Connection::callMethod(const MethodCall& message, void* callback, void* userData, uint64_t timeout, floating_slot_t)
+{
+    // TODO: Think of ways of optimizing these three locking/unlocking of sdbus mutex (merge into one call?)
+    auto timeoutBefore = getEventLoopPollData().timeout;
+    message.send(callback, userData, timeout, floating_slot);
+    auto timeoutAfter = getEventLoopPollData().timeout;
+
+    // An event loop may wait in poll with timeout `t1', while in another thread an async call is made with
+    // timeout `t2'. If `t2' < `t1', then we have to wake up the event loop thread to update its poll timeout.
+    if (timeoutAfter < timeoutBefore)
+        notifyEventLoopToWakeUpFromPoll();
+}
+
+Slot Connection::callMethod(const MethodCall& message, void* callback, void* userData, uint64_t timeout)
+{
+    // TODO: Think of ways of optimizing these three locking/unlocking of sdbus mutex (merge into one call?)
+    auto timeoutBefore = getEventLoopPollData().timeout;
+    auto slot = message.send(callback, userData, timeout);
+    auto timeoutAfter = getEventLoopPollData().timeout;
+
+    // An event loop may wait in poll with timeout `t1', while in another thread an async call is made with
+    // timeout `t2'. If `t2' < `t1', then we have to wake up the event loop thread to update its poll timeout.
+    if (timeoutAfter < timeoutBefore)
+        notifyEventLoopToWakeUpFromPoll();
+
+    return slot;
 }
 
 void Connection::emitPropertiesChangedSignal( const std::string& objectPath
@@ -295,7 +340,7 @@ void Connection::emitPropertiesChangedSignal( const std::string& objectPath
 {
     auto names = to_strv(propNames);
 
-    auto r = iface_->sd_bus_emit_properties_changed_strv( bus_.get()
+    auto r = sdbus_->sd_bus_emit_properties_changed_strv(bus_.get()
                                                         , objectPath.c_str()
                                                         , interfaceName.c_str()
                                                         , propNames.empty() ? nullptr : &names[0] );
@@ -305,7 +350,7 @@ void Connection::emitPropertiesChangedSignal( const std::string& objectPath
 
 void Connection::emitInterfacesAddedSignal(const std::string& objectPath)
 {
-    auto r = iface_->sd_bus_emit_object_added(bus_.get(), objectPath.c_str());
+    auto r = sdbus_->sd_bus_emit_object_added(bus_.get(), objectPath.c_str());
 
     SDBUS_THROW_ERROR_IF(r < 0, "Failed to emit InterfacesAdded signal for all registered interfaces", -r);
 }
@@ -315,7 +360,7 @@ void Connection::emitInterfacesAddedSignal( const std::string& objectPath
 {
     auto names = to_strv(interfaces);
 
-    auto r = iface_->sd_bus_emit_interfaces_added_strv( bus_.get()
+    auto r = sdbus_->sd_bus_emit_interfaces_added_strv(bus_.get()
                                                       , objectPath.c_str()
                                                       , interfaces.empty() ? nullptr : &names[0] );
 
@@ -324,7 +369,7 @@ void Connection::emitInterfacesAddedSignal( const std::string& objectPath
 
 void Connection::emitInterfacesRemovedSignal(const std::string& objectPath)
 {
-    auto r = iface_->sd_bus_emit_object_removed(bus_.get(), objectPath.c_str());
+    auto r = sdbus_->sd_bus_emit_object_removed(bus_.get(), objectPath.c_str());
 
     SDBUS_THROW_ERROR_IF(r < 0, "Failed to emit InterfacesRemoved signal for all registered interfaces", -r);
 }
@@ -334,7 +379,7 @@ void Connection::emitInterfacesRemovedSignal( const std::string& objectPath
 {
     auto names = to_strv(interfaces);
 
-    auto r = iface_->sd_bus_emit_interfaces_removed_strv( bus_.get()
+    auto r = sdbus_->sd_bus_emit_interfaces_removed_strv(bus_.get()
                                                         , objectPath.c_str()
                                                         , interfaces.empty() ? nullptr : &names[0] );
 
@@ -354,40 +399,11 @@ Slot Connection::registerSignalHandler( const std::string& sender
     // https://www.freedesktop.org/software/systemd/man/sd_bus_add_match.html .
     // But this would require libsystemd v237 or higher.
     auto filter = composeSignalMatchFilter(sender, objectPath, interfaceName, signalName);
-    auto r = iface_->sd_bus_add_match(bus_.get(), &slot, filter.c_str(), callback, userData);
+    auto r = sdbus_->sd_bus_add_match(bus_.get(), &slot, filter.c_str(), callback, userData);
 
     SDBUS_THROW_ERROR_IF(r < 0, "Failed to register signal handler", -r);
 
-    return {slot, [this](void *slot){ iface_->sd_bus_slot_unref((sd_bus_slot*)slot); }};
-}
-
-MethodReply Connection::tryCallMethodSynchronously(const MethodCall& message, uint64_t timeout)
-{
-    auto loopThreadId = loopThreadId_.load(std::memory_order_relaxed);
-
-    // Is the loop not yet on? => Go make synchronous call
-    while (loopThreadId == std::thread::id{})
-    {
-        // Did the loop begin in the meantime? Or try_lock() failed spuriously?
-        if (!loopMutex_.try_lock())
-        {
-            loopThreadId = loopThreadId_.load(std::memory_order_relaxed);
-            continue;
-        }
-
-        // Synchronous D-Bus call
-        std::lock_guard guard(loopMutex_, std::adopt_lock);
-        return message.send(timeout);
-    }
-
-    // Is the loop on and we are in the same thread? => Go for synchronous call
-    if (loopThreadId == std::this_thread::get_id())
-    {
-        assert(!loopMutex_.try_lock());
-        return message.send(timeout);
-    }
-
-    return {};
+    return {slot, [this](void *slot){ sdbus_->sd_bus_slot_unref((sd_bus_slot*)slot); }};
 }
 
 Connection::BusPtr Connection::openBus(const BusFactory& busFactory)
@@ -396,7 +412,7 @@ Connection::BusPtr Connection::openBus(const BusFactory& busFactory)
     int r = busFactory(&bus);
     SDBUS_THROW_ERROR_IF(r < 0, "Failed to open bus", -r);
 
-    BusPtr busPtr{bus, [this](sd_bus* bus){ return iface_->sd_bus_flush_close_unref(bus); }};
+    BusPtr busPtr{bus, [this](sd_bus* bus){ return sdbus_->sd_bus_flush_close_unref(bus); }};
     finishHandshake(busPtr.get());
     return busPtr;
 }
@@ -405,17 +421,17 @@ Connection::BusPtr Connection::openPseudoBus()
 {
     sd_bus* bus{};
 
-    int r = iface_->sd_bus_new(&bus);
+    int r = sdbus_->sd_bus_new(&bus);
     SDBUS_THROW_ERROR_IF(r < 0, "Failed to open pseudo bus", -r);
 
-    (void)iface_->sd_bus_start(bus);
+    (void)sdbus_->sd_bus_start(bus);
     // It is expected that sd_bus_start has failed here, returning -EINVAL, due to having
     // not set a bus address, but it will leave the bus in an OPENING state, which enables
     // us to create plain D-Bus messages as a local data storage (for Variant, for example),
     // without dependency on real IPC communication with the D-Bus broker daemon.
     SDBUS_THROW_ERROR_IF(r < 0 && r != -EINVAL, "Failed to start pseudo bus", -r);
 
-    return {bus, [this](sd_bus* bus){ return iface_->sd_bus_close_unref(bus); }};
+    return {bus, [this](sd_bus* bus){ return sdbus_->sd_bus_close_unref(bus); }};
 }
 
 void Connection::finishHandshake(sd_bus* bus)
@@ -426,43 +442,19 @@ void Connection::finishHandshake(sd_bus* bus)
 
     assert(bus != nullptr);
 
-    auto r = iface_->sd_bus_flush(bus);
+    auto r = sdbus_->sd_bus_flush(bus);
 
     SDBUS_THROW_ERROR_IF(r < 0, "Failed to flush bus on opening", -r);
 }
 
-void Connection::notifyEventLoop(int fd) const
+void Connection::notifyEventLoopToExit()
 {
-    assert(fd >= 0);
-
-    uint64_t value = 1;
-    auto r = write(fd, &value, sizeof(value));
-    SDBUS_THROW_ERROR_IF(r < 0, "Failed to notify event loop", -errno);
+    loopExitFd_.notify();
 }
 
-void Connection::notifyEventLoopToExit() const
+void Connection::notifyEventLoopToWakeUpFromPoll()
 {
-    notifyEventLoop(loopExitFd_.fd);
-}
-
-void Connection::notifyEventLoopNewTimeout() const
-{
-    // The extra notifications for new timeouts are only needed if calls are made asynchronously to the event loop.
-    // Are we in the same thread as the event loop? Note that it's ok to fail this check because the event loop isn't yet started.
-    if (loopThreadId_.load(std::memory_order_relaxed) == std::this_thread::get_id())
-        return;
-
-    // Get the new timeout from sd-bus
-    auto sdbusPollData = getEventLoopPollData();
-    if (sdbusPollData.timeout_usec < activeTimeout_.load(std::memory_order_relaxed))
-        notifyEventLoop(eventFd_.fd);
-}
-
-void Connection::clearEventLoopNotification(int fd) const
-{
-    uint64_t value{};
-    auto r = read(fd, &value, sizeof(value));
-    SDBUS_THROW_ERROR_IF(r < 0, "Failed to read from the event descriptor", -errno);
+    eventFd_.notify();
 }
 
 void Connection::joinWithEventLoop()
@@ -471,32 +463,36 @@ void Connection::joinWithEventLoop()
         asyncLoopThread_.join();
 }
 
-bool Connection::processPendingRequest()
+bool Connection::processPendingEvent()
 {
     auto bus = bus_.get();
     assert(bus != nullptr);
 
-    int r = iface_->sd_bus_process(bus, nullptr);
+    int r = sdbus_->sd_bus_process(bus, nullptr);
     SDBUS_THROW_ERROR_IF(r < 0, "Failed to process bus requests", -r);
+
+    // In correct use of sdbus-c++ API, r can be 0 only when processPendingEvent()
+    // is called from an external event loop as a reaction to event fd being signalled.
+    // If there are no more D-Bus messages to process, we know we have to clear event fd.
+    if (r == 0)
+        eventFd_.clear();
 
     return r > 0;
 }
 
-bool Connection::waitForNextRequest()
+bool Connection::waitForNextEvent()
 {
     assert(bus_ != nullptr);
+    assert(loopExitFd_.fd >= 0);
     assert(eventFd_.fd >= 0);
 
     auto sdbusPollData = getEventLoopPollData();
-    struct pollfd fds[] = {
-            {sdbusPollData.fd, sdbusPollData.events, 0},
-            {eventFd_.fd, POLLIN, 0},
-            {loopExitFd_.fd, POLLIN, 0}
-    };
-    auto fdsCount = sizeof(fds)/sizeof(fds[0]);
+    struct pollfd fds[] = { {sdbusPollData.fd, sdbusPollData.events, 0}
+                          , {eventFd_.fd, POLLIN, 0}
+                          , {loopExitFd_.fd, POLLIN, 0} };
+    constexpr auto fdsCount = sizeof(fds)/sizeof(fds[0]);
 
     auto timeout = sdbusPollData.getPollTimeout();
-    activeTimeout_.store(sdbusPollData.timeout_usec, std::memory_order_relaxed);
     auto r = poll(fds, fdsCount, timeout);
 
     if (r < 0 && errno == EINTR)
@@ -504,19 +500,33 @@ bool Connection::waitForNextRequest()
 
     SDBUS_THROW_ERROR_IF(r < 0, "Failed to wait on the bus", -errno);
 
-    // new timeout notification
+    // Wake up notification, in order that we re-enter poll with freshly read PollData (namely, new poll timeout thereof)
     if (fds[1].revents & POLLIN)
     {
-        clearEventLoopNotification(fds[1].fd);
+        auto cleared = eventFd_.clear();
+        SDBUS_THROW_ERROR_IF(!cleared, "Failed to read from the event descriptor", -errno);
+        // Go poll() again, but with up-to-date timeout (which will wake poll() up right away if there are messages to process)
+        return waitForNextEvent();
     }
-    // loop exit notification
+    // Loop exit notification
     if (fds[2].revents & POLLIN)
     {
-        clearEventLoopNotification(fds[2].fd);
+        auto cleared = loopExitFd_.clear();
+        SDBUS_THROW_ERROR_IF(!cleared, "Failed to read from the loop exit descriptor", -errno);
         return false;
     }
 
     return true;
+}
+
+bool Connection::arePendingMessagesInReadQueue() const
+{
+    uint64_t readQueueSize{};
+
+    auto r = sdbus_->sd_bus_get_n_queued_read(bus_.get(), &readQueueSize);
+    SDBUS_THROW_ERROR_IF(r < 0, "Failed to get number of pending messages in read queue", -r);
+
+    return readQueueSize > 0;
 }
 
 std::string Connection::composeSignalMatchFilter( const std::string &sender
@@ -556,33 +566,48 @@ Connection::EventFd::~EventFd()
     close(fd);
 }
 
+void Connection::EventFd::notify()
+{
+    assert(fd >= 0);
+    auto r = eventfd_write(fd, 1);
+    SDBUS_THROW_ERROR_IF(r < 0, "Failed to notify event descriptor", -errno);
+}
+
+bool Connection::EventFd::clear()
+{
+    assert(fd >= 0);
+
+    uint64_t value{};
+    auto r = eventfd_read(fd, &value);
+    return r >= 0;
+}
+
 } // namespace sdbus::internal
 
 namespace sdbus {
 
-std::optional<std::chrono::microseconds> IConnection::PollData::getRelativeTimeout() const
+std::chrono::microseconds IConnection::PollData::getRelativeTimeout() const
 {
     constexpr auto zero = std::chrono::microseconds::zero();
-    if (timeout_usec == 0)
-        return zero;
-    else if (timeout_usec == UINT64_MAX)
-        return std::nullopt;
+    constexpr auto max = std::chrono::microseconds::max();
+    using internal::now;
 
-    // We need C so that we use the same clock as the underlying sd-bus lib.
-    // We use POSIX's clock_gettime in favour of std::chrono::steady_clock to ensure this.
-    struct timespec ts{};
-    auto r = clock_gettime(CLOCK_MONOTONIC, &ts);
-    SDBUS_THROW_ERROR_IF(r < 0, "clock_gettime failed: ", -errno);
-    auto now = std::chrono::nanoseconds(ts.tv_nsec) + std::chrono::seconds(ts.tv_sec);
-    auto absTimeout = std::chrono::microseconds(timeout_usec);
-    auto result = std::chrono::duration_cast<std::chrono::microseconds>(absTimeout - now);
-    return std::max(result, zero);
+    if (timeout == zero)
+        return zero;
+    else if (timeout == max)
+        return max;
+    else
+        return std::max(std::chrono::duration_cast<std::chrono::microseconds>(timeout - now()), zero);
 }
 
 int IConnection::PollData::getPollTimeout() const
 {
-    auto timeout = getRelativeTimeout();
-    return timeout ? static_cast<int>(std::chrono::ceil<std::chrono::milliseconds>(timeout.value()).count()) : -1;
+    const auto relativeTimeout = getRelativeTimeout();
+
+    if (relativeTimeout == decltype(relativeTimeout)::max())
+        return -1;
+    else
+        return static_cast<int>(std::chrono::ceil<std::chrono::milliseconds>(relativeTimeout).count());
 }
 
 } // namespace sdbus

--- a/src/IConnection.h
+++ b/src/IConnection.h
@@ -28,6 +28,7 @@
 #define SDBUS_CXX_INTERNAL_ICONNECTION_H_
 
 #include <sdbus-c++/IConnection.h>
+#include <sdbus-c++/TypeTraits.h>
 #include <systemd/sd-bus.h>
 #include <string>
 #include <memory>
@@ -70,6 +71,10 @@ namespace sdbus::internal {
                                    , const std::string& interfaceName
                                    , const std::string& signalName ) const = 0;
 
+        virtual MethodReply callMethod(const MethodCall& message, uint64_t timeout) = 0;
+        virtual void callMethod(const MethodCall& message, void* callback, void* userData, uint64_t timeout, floating_slot_t) = 0;
+        virtual Slot callMethod(const MethodCall& message, void* callback, void* userData, uint64_t timeout) = 0;
+
         virtual void emitPropertiesChangedSignal( const std::string& objectPath
                                                 , const std::string& interfaceName
                                                 , const std::vector<std::string>& propNames ) = 0;
@@ -89,9 +94,6 @@ namespace sdbus::internal {
                                                         , const std::string& signalName
                                                         , sd_bus_message_handler_t callback
                                                         , void* userData ) = 0;
-
-        virtual void notifyEventLoopNewTimeout() const = 0;
-        virtual MethodReply tryCallMethodSynchronously(const MethodCall& message, uint64_t timeout) = 0;
     };
 
     [[nodiscard]] std::unique_ptr<sdbus::internal::IConnection> createConnection();

--- a/src/ISdBus.h
+++ b/src/ISdBus.h
@@ -84,7 +84,7 @@ namespace sdbus::internal {
 
         virtual int sd_bus_process(sd_bus *bus, sd_bus_message **r) = 0;
         virtual int sd_bus_get_poll_data(sd_bus *bus, PollData* data) = 0;
-
+        virtual int sd_bus_get_n_queued_read(sd_bus *bus, uint64_t *ret) = 0;
         virtual int sd_bus_flush(sd_bus *bus) = 0;
         virtual sd_bus *sd_bus_flush_close_unref(sd_bus *bus) = 0;
         virtual sd_bus *sd_bus_close_unref(sd_bus *bus) = 0;

--- a/src/MessageUtils.h
+++ b/src/MessageUtils.h
@@ -57,12 +57,6 @@ namespace sdbus
         {
             return _Msg{msg, sdbus, adopt_message};
         }
-
-        template<typename _Msg>
-        static _Msg create(void *msg, internal::ISdBus* sdbus, const internal::IConnection* connection, adopt_message_t)
-        {
-            return _Msg{msg, sdbus, connection, adopt_message};
-        }
     };
 
     PlainMessage createPlainMessage();

--- a/src/Proxy.cpp
+++ b/src/Proxy.cpp
@@ -88,31 +88,9 @@ MethodCall Proxy::createMethodCall(const std::string& interfaceName, const std::
 
 MethodReply Proxy::callMethod(const MethodCall& message, uint64_t timeout)
 {
-    // Sending method call synchronously is the only operation that blocks, waiting for the method
-    // reply message among the incoming messages on the sd-bus connection socket. But typically there
-    // already is somebody that generally handles incoming D-Bus messages -- the connection event loop
-    // running typically in its own thread. We have to avoid polling on socket from several threads.
-    // So we have to branch here: either we are within the context of the event loop thread, then we
-    // can send the message simply via sd_bus_call, which blocks. Or we are in another thread, then
-    // we can perform the send operation of the method call message from here (because that is thread-
-    // safe like other sd-bus API accesses), but the incoming reply we have to get through the event
-    // loop thread, because this is the only rightful listener on the sd-bus connection socket.
-    // So, technically, we use async means to wait here for reply received by the event loop thread.
-
     SDBUS_THROW_ERROR_IF(!message.isValid(), "Invalid method call message provided", EINVAL);
 
-    // If we don't need to wait for any reply, we can send the message now irrespective of the context
-    if (message.doesntExpectReply())
-        return message.send(timeout);
-
-    // If we are in the context of event loop thread, we can send the D-Bus call synchronously
-    // and wait blockingly for the reply, because we are the exclusive listeners on the socket
-    auto reply = connection_->tryCallMethodSynchronously(message, timeout);
-    if (reply.isValid())
-        return reply;
-
-    // Otherwise we send the call asynchronously and do blocking wait for the reply from the event loop thread
-    return sendMethodCallMessageAndWaitForReply(message, timeout);
+    return connection_->callMethod(message, timeout);
 }
 
 PendingAsyncCall Proxy::callMethod(const MethodCall& message, async_reply_handler asyncReplyCallback, uint64_t timeout)
@@ -123,55 +101,13 @@ PendingAsyncCall Proxy::callMethod(const MethodCall& message, async_reply_handle
     auto callData = std::make_shared<AsyncCalls::CallData>(AsyncCalls::CallData{*this, std::move(asyncReplyCallback), {}});
     auto weakData = std::weak_ptr<AsyncCalls::CallData>{callData};
 
-    callData->slot = message.send(callback, callData.get(), timeout);
+    callData->slot = connection_->callMethod(message, callback, callData.get(), timeout);
 
     auto slotPtr = callData->slot.get();
     pendingAsyncCalls_.addCall(slotPtr, std::move(callData));
 
+    // TODO: Instead of PendingAsyncCall consider using Slot implementation for simplicity and consistency
     return {weakData};
-}
-
-MethodReply Proxy::sendMethodCallMessageAndWaitForReply(const MethodCall& message, uint64_t timeout)
-{
-    /*thread_local*/ SyncCallReplyData syncCallReplyData;
-
-    async_reply_handler asyncReplyCallback = [&syncCallReplyData](MethodReply& reply, const Error* error)
-    {
-        syncCallReplyData.sendMethodReplyToWaitingThread(reply, error);
-    };
-    auto callback = (void*)&Proxy::sdbus_async_reply_handler;
-    AsyncCalls::CallData callData{*this, std::move(asyncReplyCallback), {}};
-
-    message.send(callback, &callData, timeout, floating_slot);
-
-    return syncCallReplyData.waitForMethodReply();
-}
-
-void Proxy::SyncCallReplyData::sendMethodReplyToWaitingThread(MethodReply& reply, const Error* error)
-{
-    std::unique_lock lock{mutex_};
-    SCOPE_EXIT{ cond_.notify_one(); }; // This must happen before unlocking the mutex to avoid potential data race on spurious wakeup in the waiting thread
-    SCOPE_EXIT{ arrived_ = true; };
-
-    //error_ = nullptr; // Necessary if SyncCallReplyData instance is thread_local
-
-    if (error == nullptr)
-        reply_ = std::move(reply);
-    else
-        error_ = std::make_unique<Error>(*error);
-}
-
-MethodReply Proxy::SyncCallReplyData::waitForMethodReply()
-{
-    std::unique_lock lock{mutex_};
-    cond_.wait(lock, [this](){ return arrived_; });
-
-    //arrived_ = false; // Necessary if SyncCallReplyData instance is thread_local
-
-    if (error_)
-        throw *error_;
-
-    return std::move(reply_);
 }
 
 void Proxy::registerSignalHandler( const std::string& interfaceName

--- a/src/Proxy.h
+++ b/src/Proxy.h
@@ -73,21 +73,6 @@ namespace sdbus::internal {
         const Message* getCurrentlyProcessedMessage() const override;
 
     private:
-        class SyncCallReplyData
-        {
-        public:
-            void sendMethodReplyToWaitingThread(MethodReply& reply, const Error* error);
-            MethodReply waitForMethodReply();
-
-        private:
-            std::mutex mutex_;
-            std::condition_variable cond_;
-            bool arrived_{};
-            MethodReply reply_;
-            std::unique_ptr<Error> error_;
-        };
-
-        MethodReply sendMethodCallMessageAndWaitForReply(const MethodCall& message, uint64_t timeout);
         void registerSignalHandlers(sdbus::internal::IConnection& connection);
         static int sdbus_async_reply_handler(sd_bus_message *sdbusMessage, void *userData, sd_bus_error *retError);
         static int sdbus_signal_handler(sd_bus_message *sdbusMessage, void *userData, sd_bus_error *retError);

--- a/src/SdBus.cpp
+++ b/src/SdBus.cpp
@@ -53,6 +53,8 @@ int SdBus::sd_bus_send(sd_bus *bus, sd_bus_message *m, uint64_t *cookie)
         return r;
 
     // Make sure long messages are not only stored in outgoing queues but also really sent out
+    // TODO: This is a workaround. We should not block here until everything is physically sent out.
+    //   Refactor: if sd_bus_get_n_queued_write() > 0 then wake up event loop through event fd
     ::sd_bus_flush(bus != nullptr ? bus : ::sd_bus_message_get_bus(m));
 
     return r;
@@ -74,6 +76,8 @@ int SdBus::sd_bus_call_async(sd_bus *bus, sd_bus_slot **slot, sd_bus_message *m,
       return r;
 
     // Make sure long messages are not only stored in outgoing queues but also really sent out
+    // TODO: This is a workaround. We should not block here until everything is physically sent out.
+    //   Refactor: if sd_bus_get_n_queued_write() > 0 then wake up event loop through event fd
     ::sd_bus_flush(bus != nullptr ? bus : ::sd_bus_message_get_bus(m));
 
     return r;
@@ -309,6 +313,13 @@ int SdBus::sd_bus_get_poll_data(sd_bus *bus, PollData* data)
     r = ::sd_bus_get_timeout(bus, &data->timeout_usec);
 
     return r;
+}
+
+int SdBus::sd_bus_get_n_queued_read(sd_bus *bus, uint64_t *ret)
+{
+    std::lock_guard lock(sdbusMutex_);
+
+    return ::sd_bus_get_n_queued_read(bus, ret);
 }
 
 int SdBus::sd_bus_flush(sd_bus *bus)

--- a/src/SdBus.h
+++ b/src/SdBus.h
@@ -76,7 +76,7 @@ public:
 
     virtual int sd_bus_process(sd_bus *bus, sd_bus_message **r) override;
     virtual int sd_bus_get_poll_data(sd_bus *bus, PollData* data) override;
-
+    virtual int sd_bus_get_n_queued_read(sd_bus *bus, uint64_t *ret) override;
     virtual int sd_bus_flush(sd_bus *bus) override;
     virtual sd_bus *sd_bus_flush_close_unref(sd_bus *bus) override;
     virtual sd_bus *sd_bus_close_unref(sd_bus *bus) override;

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -50,4 +50,19 @@
 #define SDBUS_CHECK_MEMBER_NAME(_NAME)
 #endif
 
+namespace sdbus::internal {
+
+    // Returns time since epoch based of POSIX CLOCK_MONOTONIC,
+    // so we use the very same clock as underlying sd-bus library.
+    [[nodiscard]] inline auto now()
+    {
+        struct timespec ts{};
+        auto r = clock_gettime(CLOCK_MONOTONIC, &ts);
+        SDBUS_THROW_ERROR_IF(r < 0, "clock_gettime failed: ", -errno);
+
+        return std::chrono::nanoseconds(ts.tv_nsec) + std::chrono::seconds(ts.tv_sec);
+    }
+
+}
+
 #endif /* SDBUS_CXX_INTERNAL_UTILS_H_ */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -50,6 +50,7 @@ set(UNITTESTS_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/unittests)
 set(UNITTESTS_SRCS
     ${UNITTESTS_SOURCE_DIR}/sdbus-c++-unit-tests.cpp
     ${UNITTESTS_SOURCE_DIR}/Message_test.cpp
+    ${UNITTESTS_SOURCE_DIR}/PollData_test.cpp
     ${UNITTESTS_SOURCE_DIR}/Types_test.cpp
     ${UNITTESTS_SOURCE_DIR}/TypeTraits_test.cpp
     ${UNITTESTS_SOURCE_DIR}/Connection_test.cpp

--- a/tests/integrationtests/DBusConnectionTests.cpp
+++ b/tests/integrationtests/DBusConnectionTests.cpp
@@ -41,7 +41,6 @@
 
 using ::testing::Eq;
 using namespace sdbus::test;
-using namespace std::chrono_literals;
 
 /*-------------------------------------*/
 /* --          TEST CASES           -- */
@@ -80,7 +79,7 @@ TEST(Connection, CannotReleaseNonrequestedName)
     ASSERT_THROW(connection->releaseName("some.random.nonrequested.name"), sdbus::Error);
 }
 
-TEST(Connection, CanEnterAndLeaveEventLoop)
+TEST(Connection, CanEnterAndLeaveInternalEventLoop)
 {
     auto connection = sdbus::createConnection();
     connection->requestName(BUS_NAME);
@@ -89,45 +88,4 @@ TEST(Connection, CanEnterAndLeaveEventLoop)
     connection->leaveEventLoop();
 
     t.join();
-}
-
-TEST(Connection, PollDataGetZeroTimeout)
-{
-    sdbus::IConnection::PollData pd{};
-    pd.timeout_usec = 0;
-    ASSERT_TRUE(pd.getRelativeTimeout().has_value());
-    EXPECT_THAT(pd.getRelativeTimeout().value(), Eq(std::chrono::microseconds::zero()));
-    EXPECT_THAT(pd.getPollTimeout(), Eq(0));
-}
-
-TEST(Connection, PollDataGetInfiniteTimeout)
-{
-    sdbus::IConnection::PollData pd{};
-    pd.timeout_usec = UINT64_MAX;
-    ASSERT_FALSE(pd.getRelativeTimeout().has_value());
-    EXPECT_THAT(pd.getPollTimeout(), Eq(-1));
-}
-
-TEST(Connection, PollDataGetZeroRelativeTimeoutForPast)
-{
-    sdbus::IConnection::PollData pd{};
-    auto past = std::chrono::steady_clock::now() - 10s;
-    pd.timeout_usec = std::chrono::duration_cast<std::chrono::microseconds>(past.time_since_epoch()).count();
-    ASSERT_TRUE(pd.getRelativeTimeout().has_value());
-    EXPECT_THAT(pd.getRelativeTimeout().value(), Eq(0us));
-    EXPECT_THAT(pd.getPollTimeout(), Eq(0));
-}
-
-TEST(Connection, PollDataGetRelativeTimeoutInTolerance)
-{
-    sdbus::IConnection::PollData pd{};
-    constexpr auto TIMEOUT = 1s;
-    constexpr auto TOLERANCE = 100ms;
-    auto future = std::chrono::steady_clock::now() + TIMEOUT;
-    pd.timeout_usec = std::chrono::duration_cast<std::chrono::microseconds>(future.time_since_epoch()).count();
-    ASSERT_TRUE(pd.getRelativeTimeout().has_value());
-    EXPECT_GE(pd.getRelativeTimeout().value(), TIMEOUT - TOLERANCE);
-    EXPECT_LE(pd.getRelativeTimeout().value(), TIMEOUT + TOLERANCE);
-    EXPECT_GE(pd.getPollTimeout(), 900);
-    EXPECT_LE(pd.getPollTimeout(), 1100);
 }

--- a/tests/integrationtests/TestProxy.cpp
+++ b/tests/integrationtests/TestProxy.cpp
@@ -2,7 +2,7 @@
  * (C) 2016 - 2021 KISTLER INSTRUMENTE AG, Winterthur, Switzerland
  * (C) 2016 - 2022 Stanislav Angelovic <stanislav.angelovic@protonmail.com>
  *
- * @file TestAdaptor.cpp
+ * @file TestProxy.cpp
  *
  * Created on: May 23, 2020
  * Project: sdbus-c++

--- a/tests/integrationtests/TestProxy.h
+++ b/tests/integrationtests/TestProxy.h
@@ -2,7 +2,7 @@
  * (C) 2016 - 2021 KISTLER INSTRUMENTE AG, Winterthur, Switzerland
  * (C) 2016 - 2022 Stanislav Angelovic <stanislav.angelovic@protonmail.com>
  *
- * @file TestAdaptor.h
+ * @file TestProxy.h
  *
  * Created on: Jan 2, 2017
  * Project: sdbus-c++

--- a/tests/unittests/PollData_test.cpp
+++ b/tests/unittests/PollData_test.cpp
@@ -1,0 +1,125 @@
+/**
+ * (C) 2016 - 2021 KISTLER INSTRUMENTE AG, Winterthur, Switzerland
+ * (C) 2016 - 2022 Stanislav Angelovic <stanislav.angelovic@protonmail.com>
+ *
+ * @file PollData_test.cpp
+ *
+ * Created on: Jan 19, 2023
+ * Project: sdbus-c++
+ * Description: High-level D-Bus IPC C++ library based on sd-bus
+ *
+ * This file is part of sdbus-c++.
+ *
+ * sdbus-c++ is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * sdbus-c++ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with sdbus-c++. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <sdbus-c++/IConnection.h>
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include <chrono>
+
+using ::testing::Eq;
+using ::testing::Ge;
+using ::testing::Le;
+using ::testing::AllOf;
+using namespace std::string_literals;
+using namespace std::chrono_literals;
+
+/*-------------------------------------*/
+/* --          TEST CASES           -- */
+/*-------------------------------------*/
+
+TEST(PollData, ReturnsZeroRelativeTimeoutForZeroAbsoluteTimeout)
+{
+    sdbus::IConnection::PollData pd;
+    pd.timeout = std::chrono::microseconds::zero();
+
+    auto relativeTimeout = pd.getRelativeTimeout();
+
+    EXPECT_THAT(relativeTimeout, Eq(std::chrono::microseconds::zero()));
+}
+
+TEST(PollData, ReturnsZeroPollTimeoutForZeroAbsoluteTimeout)
+{
+    sdbus::IConnection::PollData pd;
+    pd.timeout = std::chrono::microseconds::zero();
+
+    auto pollTimeout = pd.getPollTimeout();
+
+    EXPECT_THAT(pollTimeout, Eq(0));
+}
+
+TEST(PollData, ReturnsInfiniteRelativeTimeoutForInfiniteAbsoluteTimeout)
+{
+    sdbus::IConnection::PollData pd;
+    pd.timeout = std::chrono::microseconds::max();
+
+    auto relativeTimeout = pd.getRelativeTimeout();
+
+    EXPECT_THAT(relativeTimeout, Eq(std::chrono::microseconds::max()));
+}
+
+TEST(PollData, ReturnsNegativePollTimeoutForInfiniteAbsoluteTimeout)
+{
+    sdbus::IConnection::PollData pd;
+    pd.timeout = std::chrono::microseconds::max();
+
+    auto pollTimeout = pd.getPollTimeout();
+
+    EXPECT_THAT(pollTimeout, Eq(-1));
+}
+
+TEST(PollData, ReturnsZeroRelativeTimeoutForPastAbsoluteTimeout)
+{
+    sdbus::IConnection::PollData pd;
+    auto past = std::chrono::steady_clock::now() - 10s;
+    pd.timeout = std::chrono::duration_cast<std::chrono::microseconds>(past.time_since_epoch());
+
+    auto relativeTimeout = pd.getRelativeTimeout();
+
+    EXPECT_THAT(relativeTimeout, Eq(0us));
+}
+
+TEST(PollData, ReturnsZeroPollTimeoutForPastAbsoluteTimeout)
+{
+    sdbus::IConnection::PollData pd;
+    auto past = std::chrono::steady_clock::now() - 10s;
+    pd.timeout = std::chrono::duration_cast<std::chrono::microseconds>(past.time_since_epoch());
+
+    auto pollTimeout = pd.getPollTimeout();
+
+    EXPECT_THAT(pollTimeout, Eq(0));
+}
+
+TEST(PollData, ReturnsCorrectRelativeTimeoutForFutureAbsoluteTimeout)
+{
+    sdbus::IConnection::PollData pd;
+    auto future = std::chrono::steady_clock::now() + 1s;
+    pd.timeout = std::chrono::duration_cast<std::chrono::microseconds>(future.time_since_epoch());
+
+    auto relativeTimeout = pd.getRelativeTimeout();
+
+    EXPECT_THAT(relativeTimeout, AllOf(Ge(900ms), Le(1100ms)));
+}
+
+TEST(PollData, ReturnsCorrectPollTimeoutForFutureAbsoluteTimeout)
+{
+    sdbus::IConnection::PollData pd;
+    auto future = std::chrono::steady_clock::now() + 1s;
+    pd.timeout = std::chrono::duration_cast<std::chrono::microseconds>(future.time_since_epoch());
+
+    auto pollTimeout = pd.getPollTimeout();
+
+    EXPECT_THAT(pollTimeout, AllOf(Ge(900), Le(1100)));
+}

--- a/tests/unittests/mocks/SdBusMock.h
+++ b/tests/unittests/mocks/SdBusMock.h
@@ -75,7 +75,7 @@ public:
 
     MOCK_METHOD2(sd_bus_process, int(sd_bus *bus, sd_bus_message **r));
     MOCK_METHOD2(sd_bus_get_poll_data, int(sd_bus *bus, PollData* data));
-
+    MOCK_METHOD2(sd_bus_get_n_queued_read, int(sd_bus *bus, uint64_t *ret));
     MOCK_METHOD1(sd_bus_flush, int(sd_bus *bus));
     MOCK_METHOD1(sd_bus_flush_close_unref, sd_bus *(sd_bus *bus));
     MOCK_METHOD1(sd_bus_close_unref, sd_bus *(sd_bus *bus));


### PR DESCRIPTION
This is the first one in the planned series of PR's with features/refactorings/fixes requiring breaking changes in API/ABI/behavior, leading to new sdbus-c++ v2. A new feature branch `release/v2.0` has been created for accumulating these PRs before it's merged to master.

Changes in this MR are conceptually a re-design of various areas with the focus on async D-Bus connection handling. There are simplifications, fixes for async handling (finally #88 is solved properly and completely, issue with thread id is fixed in #141) and external event loop integration. And this PR is a necessary pre-requisite the upcoming PR with sd-event integration.

Fixes #88 #141 

List of changes (see ChangeLog for more detailed listing):

* In *synchronous* D-Bus calls, the proxy now **always** blocks the connection for concurrent use until the call finishes (with either a received reply, an error, or time out). Recently added short-lived, light-weight proxies, or calling methods in an asynchronous way, are the remedy for potential connection contention issues.
* The `PollData` struct has been extended with a new data member: `eventFd`. All hooks with external event loops shall be modified to poll on this fd as well.
* `PollData::timeout_usec` was renamed to `PollData::timeout` and its type has been changed to `std::chrono::microseconds`. This member now holds directly what before had to be obtained through `PollData::getAbsoluteTimeout()` call.
* `PollData::getRelativeTimeout()` return type was changed to `std::chrono::microseconds`.
* `IConnection::processPendingRequest()` was renamed to `IConnection::processPendingEvent()`.
* Systemd of at least v238 is now required to compile sdbus-c++.
* A proper fix for timeout handling
* Fix for external event loops in which the event loop thread ID was not correctly initialized (now fixed and simplified by not needing the thread ID anymore)
* Other simplifications, improvements and fixes springing out from the above refactoring.