### PR TITLE
feat: add support for std::future-based async calls

### DIFF
--- a/include/sdbus-c++/ConvenienceApiClasses.h
+++ b/include/sdbus-c++/ConvenienceApiClasses.h
@@ -34,6 +34,7 @@
 #include <vector>
 #include <type_traits>
 #include <chrono>
+#include <future>
 #include <cstdint>
 
 // Forward declarations
@@ -195,6 +196,10 @@ namespace sdbus {
         AsyncMethodInvoker& withTimeout(const std::chrono::duration<_Rep, _Period>& timeout);
         template <typename... _Args> AsyncMethodInvoker& withArguments(_Args&&... args);
         template <typename _Function> PendingAsyncCall uponReplyInvoke(_Function&& callback);
+        // Returned future will be std::future<void> for no (void) D-Bus method return value
+        //                      or std::future<T> for single D-Bus method return value
+        //                      or std::future<std::tuple<...>> for multiple method return values
+        template <typename... _Args> std::future<future_return_t<_Args...>> getResultAsFuture();
 
     private:
         IProxy& proxy_;

--- a/include/sdbus-c++/IProxy.h
+++ b/include/sdbus-c++/IProxy.h
@@ -28,10 +28,12 @@
 #define SDBUS_CXX_IPROXY_H_
 
 #include <sdbus-c++/ConvenienceApiClasses.h>
+#include <sdbus-c++/TypeTraits.h>
 #include <string>
 #include <memory>
 #include <functional>
 #include <chrono>
+#include <future>
 
 // Forward declarations
 namespace sdbus {
@@ -322,6 +324,33 @@ namespace sdbus {
          * @return A pointer to the currently processed D-Bus message
          */
         virtual const Message* getCurrentlyProcessedMessage() const = 0;
+
+        /*!
+         * @brief Calls method on the proxied D-Bus object asynchronously
+         *
+         * @param[in] message Message representing an async method call
+         * @param[in] asyncReplyCallback Handler for the async reply
+         * @param[in] timeout Timeout for dbus call in microseconds
+         * @return Cookie for the the pending asynchronous call
+         *
+         * The call is non-blocking. It doesn't wait for the reply. Once the reply arrives,
+         * the provided async reply handler will get invoked from the context of the connection
+         * I/O event loop thread.
+         *
+         * Note: To avoid messing with messages, use higher-level API defined below.
+         *
+         * @throws sdbus::Error in case of failure
+         */
+        virtual std::future<MethodReply> callMethod(const MethodCall& message, with_future_t) = 0;
+        virtual std::future<MethodReply> callMethod(const MethodCall& message, uint64_t timeout, with_future_t) = 0;
+
+        /*!
+         * @copydoc IProxy::callMethod(const MethodCall&,uint64_t,with_future_t)
+         */
+        template <typename _Rep, typename _Period>
+        std::future<MethodReply> callMethod( const MethodCall& message
+                                           , const std::chrono::duration<_Rep, _Period>& timeout
+                                           , with_future_t );
     };
 
     /********************************************//**
@@ -382,6 +411,15 @@ namespace sdbus {
         return callMethod(message, std::move(asyncReplyCallback), microsecs.count());
     }
 
+    template <typename _Rep, typename _Period>
+    inline std::future<MethodReply> IProxy::callMethod( const MethodCall& message
+                                                      , const std::chrono::duration<_Rep, _Period>& timeout
+                                                      , with_future_t )
+    {
+        auto microsecs = std::chrono::duration_cast<std::chrono::microseconds>(timeout);
+        return callMethod(message, microsecs.count(), with_future);
+    }
+
     inline MethodInvoker IProxy::callMethod(const std::string& methodName)
     {
         return MethodInvoker(*this, methodName);
@@ -411,11 +449,6 @@ namespace sdbus {
     {
         return PropertySetter(*this, propertyName);
     }
-
-    // Tag specifying that the proxy shall not run an event loop thread on its D-Bus connection.
-    // Such proxies are typically created to carry out a simple synchronous D-Bus call(s) and then are destroyed.
-    struct dont_run_event_loop_thread_t { explicit dont_run_event_loop_thread_t() = default; };
-    inline constexpr dont_run_event_loop_thread_t dont_run_event_loop_thread{};
 
     /*!
      * @brief Creates a proxy object for a specific remote D-Bus object

--- a/include/sdbus-c++/TypeTraits.h
+++ b/include/sdbus-c++/TypeTraits.h
@@ -81,6 +81,13 @@ namespace sdbus {
     // Tag denoting the assumption that the caller has already obtained fd ownership
     struct adopt_fd_t { explicit adopt_fd_t() = default; };
     inline constexpr adopt_fd_t adopt_fd{};
+    // Tag specifying that the proxy shall not run an event loop thread on its D-Bus connection.
+    // Such proxies are typically created to carry out a simple synchronous D-Bus call(s) and then are destroyed.
+    struct dont_run_event_loop_thread_t { explicit dont_run_event_loop_thread_t() = default; };
+    inline constexpr dont_run_event_loop_thread_t dont_run_event_loop_thread{};
+    // Tag denoting an asynchronous call that returns std::future as a handle
+    struct with_future_t { explicit with_future_t() = default; };
+    inline constexpr with_future_t with_future{};
 
     // Template specializations for getting D-Bus signatures from C++ types
     template <typename _T>
@@ -539,6 +546,26 @@ namespace sdbus {
             return aggregate_signature<tuple_of_function_output_arg_types_t<_Function>>::str();
         }
     };
+
+
+    template <typename... _Args> struct future_return
+    {
+        typedef std::tuple<_Args...> type;
+    };
+
+    template <> struct future_return<>
+    {
+        typedef void type;
+    };
+
+    template <typename _Type> struct future_return<_Type>
+    {
+        typedef _Type type;
+    };
+
+    template <typename... _Args>
+    using future_return_t = typename future_return<_Args...>::type;
+
 
     namespace detail
     {

--- a/src/Proxy.h
+++ b/src/Proxy.h
@@ -58,6 +58,8 @@ namespace sdbus::internal {
         MethodCall createMethodCall(const std::string& interfaceName, const std::string& methodName) override;
         MethodReply callMethod(const MethodCall& message, uint64_t timeout) override;
         PendingAsyncCall callMethod(const MethodCall& message, async_reply_handler asyncReplyCallback, uint64_t timeout) override;
+        std::future<MethodReply> callMethod(const MethodCall& message, with_future_t) override;
+        std::future<MethodReply> callMethod(const MethodCall& message, uint64_t timeout, with_future_t) override;
 
         void registerSignalHandler( const std::string& interfaceName
                                   , const std::string& signalName

--- a/tests/integrationtests/DBusAsyncMethodsTests.cpp
+++ b/tests/integrationtests/DBusAsyncMethodsTests.cpp
@@ -161,6 +161,24 @@ TEST_F(SdbusTestObject, InvokesMethodAsynchronouslyOnClientSide)
     ASSERT_THAT(future.get(), Eq(100));
 }
 
+TEST_F(SdbusTestObject, InvokesMethodAsynchronouslyOnClientSideWithFuture)
+{
+    auto future = m_proxy->doOperationClientSideAsync(100, sdbus::with_future);
+
+    ASSERT_THAT(future.get(), Eq(100));
+}
+
+TEST_F(SdbusTestObject, InvokesMethodAsynchronouslyOnClientSideWithFutureOnBasicAPILevel)
+{
+    auto future = m_proxy->doOperationClientSideAsyncOnBasicAPILevel(100);
+
+    auto methodReply = future.get();
+    uint32_t returnValue{};
+    methodReply >> returnValue;
+
+    ASSERT_THAT(returnValue, Eq(100));
+}
+
 TEST_F(SdbusTestObject, AnswersThatAsyncCallIsPendingIfItIsInProgress)
 {
     m_proxy->installDoOperationClientSideAsyncReplyHandler([&](uint32_t /*res*/, const sdbus::Error* /*err*/){});
@@ -222,7 +240,7 @@ TEST_F(SdbusTestObject, SupportsAsyncCallCopyAssignment)
     ASSERT_TRUE(call.isPending());
 }
 
-TEST_F(SdbusTestObject, InvokesErroneousMethodAsynchronouslyOnClientSide)
+TEST_F(SdbusTestObject, ReturnsNonnullErrorWhenAsynchronousMethodCallFails)
 {
     std::promise<uint32_t> promise;
     auto future = promise.get_future();
@@ -235,6 +253,13 @@ TEST_F(SdbusTestObject, InvokesErroneousMethodAsynchronouslyOnClientSide)
     });
 
     m_proxy->doErroneousOperationClientSideAsync();
+
+    ASSERT_THROW(future.get(), sdbus::Error);
+}
+
+TEST_F(SdbusTestObject, ThrowsErrorWhenClientSideAsynchronousMethodCallWithFutureFails)
+{
+    auto future = m_proxy->doErroneousOperationClientSideAsync(sdbus::with_future);
 
     ASSERT_THROW(future.get(), sdbus::Error);
 }

--- a/tests/integrationtests/TestProxy.cpp
+++ b/tests/integrationtests/TestProxy.cpp
@@ -123,6 +123,22 @@ sdbus::PendingAsyncCall TestProxy::doOperationClientSideAsync(uint32_t param)
                                       });
 }
 
+std::future<uint32_t> TestProxy::doOperationClientSideAsync(uint32_t param, with_future_t)
+{
+    return getProxy().callMethodAsync("doOperation")
+                     .onInterface(sdbus::test::INTERFACE_NAME)
+                     .withArguments(param)
+                     .getResultAsFuture<uint32_t>();
+}
+
+std::future<MethodReply> TestProxy::doOperationClientSideAsyncOnBasicAPILevel(uint32_t param)
+{
+    auto methodCall = getProxy().createMethodCall(sdbus::test::INTERFACE_NAME, "doOperation");
+    methodCall << param;
+
+    return getProxy().callMethod(methodCall, sdbus::with_future);
+}
+
 void TestProxy::doErroneousOperationClientSideAsync()
 {
     getProxy().callMethodAsync("throwError")
@@ -131,6 +147,13 @@ void TestProxy::doErroneousOperationClientSideAsync()
                                {
                                    this->onDoOperationReply(0, error);
                                });
+}
+
+std::future<void> TestProxy::doErroneousOperationClientSideAsync(with_future_t)
+{
+    return getProxy().callMethodAsync("throwError")
+                     .onInterface(sdbus::test::INTERFACE_NAME)
+                     .getResultAsFuture<>();;
 }
 
 void TestProxy::doOperationClientSideAsyncWithTimeout(const std::chrono::microseconds &timeout, uint32_t param)

--- a/tests/integrationtests/TestProxy.h
+++ b/tests/integrationtests/TestProxy.h
@@ -32,6 +32,7 @@
 #include <thread>
 #include <chrono>
 #include <atomic>
+#include <future>
 
 namespace sdbus { namespace test {
 
@@ -94,6 +95,9 @@ public:
     void installDoOperationClientSideAsyncReplyHandler(std::function<void(uint32_t res, const sdbus::Error* err)> handler);
     uint32_t doOperationWithTimeout(const std::chrono::microseconds &timeout, uint32_t param);
     sdbus::PendingAsyncCall doOperationClientSideAsync(uint32_t param);
+    std::future<uint32_t> doOperationClientSideAsync(uint32_t param, with_future_t);
+    std::future<MethodReply> doOperationClientSideAsyncOnBasicAPILevel(uint32_t param);
+    std::future<void> doErroneousOperationClientSideAsync(with_future_t);
     void doErroneousOperationClientSideAsync();
     void doOperationClientSideAsyncWithTimeout(const std::chrono::microseconds &timeout, uint32_t param);
     int32_t callNonexistentMethod();


### PR DESCRIPTION
In addition to the existing callback-based asynchronous D-Bus method calls, for more convenience, sdbus-c++ API is now extended to also support `std::future`-based async method calls.