### PR TITLE
Fix race condition in Proxy::callMethod.

### DIFF
--- a/src/Proxy.cpp
+++ b/src/Proxy.cpp
@@ -123,10 +123,16 @@ PendingAsyncCall Proxy::callMethod(const MethodCall& message, async_reply_handle
     auto callData = std::make_shared<AsyncCalls::CallData>(AsyncCalls::CallData{*this, std::move(asyncReplyCallback), {}});
     auto weakData = std::weak_ptr<AsyncCalls::CallData>{callData};
 
-    callData->slot = message.send(callback, callData.get(), timeout);
-
-    auto slotPtr = callData->slot.get();
-    pendingAsyncCalls_.addCall(slotPtr, std::move(callData));
+    pendingAsyncCalls_.addCall(callData);
+    try
+    {
+        callData->slot = message.send(callback, callData.get(), timeout);
+    }
+    catch (...)
+    {
+        pendingAsyncCalls_.removeCall(callData.get());
+        throw;
+    }
 
     return {weakData};
 }
@@ -253,7 +259,6 @@ int Proxy::sdbus_async_reply_handler(sd_bus_message *sdbusMessage, void *userDat
     assert(asyncCallData != nullptr);
     assert(asyncCallData->callback);
     auto& proxy = asyncCallData->proxy;
-    auto slot = asyncCallData->slot.get();
 
     // We are removing the CallData item at the complete scope exit, after the callback has been invoked.
     // We can't do it earlier (before callback invocation for example), because CallBack data (slot release)
@@ -261,8 +266,7 @@ int Proxy::sdbus_async_reply_handler(sd_bus_message *sdbusMessage, void *userDat
     SCOPE_EXIT
     {
         // Remove call meta-data if it's a real async call (a sync call done in terms of async has slot == nullptr)
-        if (slot)
-            proxy.pendingAsyncCalls_.removeCall(slot);
+        proxy.pendingAsyncCalls_.removeCall(asyncCallData);
     };
 
     auto message = Message::Factory::create<MethodReply>(sdbusMessage, &proxy.connection_->getSdBusInterface());
@@ -334,7 +338,7 @@ void PendingAsyncCall::cancel()
     if (auto ptr = callData_.lock(); ptr != nullptr)
     {
         auto* callData = static_cast<internal::Proxy::AsyncCalls::CallData*>(ptr.get());
-        callData->proxy.pendingAsyncCalls_.removeCall(callData->slot.get());
+        callData->proxy.pendingAsyncCalls_.removeCall(callData);
 
         // At this point, the callData item is being deleted, leading to the release of the
         // sd-bus slot pointer. This release locks the global sd-bus mutex. If the async

--- a/src/Proxy.cpp
+++ b/src/Proxy.cpp
@@ -123,16 +123,9 @@ PendingAsyncCall Proxy::callMethod(const MethodCall& message, async_reply_handle
     auto callData = std::make_shared<AsyncCalls::CallData>(AsyncCalls::CallData{*this, std::move(asyncReplyCallback), {}});
     auto weakData = std::weak_ptr<AsyncCalls::CallData>{callData};
 
-    pendingAsyncCalls_.addCall(callData);
-    try
-    {
-        callData->slot = message.send(callback, callData.get(), timeout);
-    }
-    catch (...)
-    {
-        pendingAsyncCalls_.removeCall(callData.get());
-        throw;
-    }
+    callData->slot = message.send(callback, callData.get(), timeout);
+
+    pendingAsyncCalls_.addCall(std::move(callData));
 
     return {weakData};
 }

--- a/src/Proxy.h
+++ b/src/Proxy.h
@@ -33,7 +33,7 @@
 #include <string>
 #include <memory>
 #include <map>
-#include <unordered_map>
+#include <deque>
 #include <mutex>
 #include <atomic>
 #include <condition_variable>
@@ -183,7 +183,7 @@ namespace sdbus::internal {
 
         private:
             std::mutex mutex_;
-            std::vector<std::shared_ptr<CallData>> calls_;
+            std::deque<std::shared_ptr<CallData>> calls_;
         } pendingAsyncCalls_;
 
         std::atomic<const Message*> m_CurrentlyProcessedMessage{nullptr};


### PR DESCRIPTION
After calling message.send it is possible for the callback to be called before callData is added to pendingAsyncCalls_. This results in callData being added there after the callback is called and never being removed.

Signed-off-by: Anthony Brandon <anthony@amarulasolutions.com>