### PR TITLE
fix: add cast to void to silence compiler warning in case of empty parameter list

### DIFF
--- a/include/sdbus-c++/MethodResult.h
+++ b/include/sdbus-c++/MethodResult.h
@@ -76,7 +76,7 @@ namespace sdbus {
     {
         assert(call_.isValid());
         auto reply = call_.createReply();
-        (reply << ... << results);
+        (void)(reply << ... << results);
         reply.send();
     }
 


### PR DESCRIPTION
when compiling with -Wall, compiler (at least gcc and clang) complains, that statement has no effect, when the parameter list is empty. When adding a void cast, this warning is silenced. In case of empty parameter list, it actually is intended, that this statement doesn't do anything.
Maybe this shouldn't be a compiler warning at all, IDK, but maybe there are situations, where this warning is appropriate even for an empty list.
(I guess (void) in https://github.com/Kistler-Group/sdbus-cpp/blob/c39bc637b8df7791c697c7e75f1376ac0a9b9678/include/sdbus-c%2B%2B/TypeTraits.h#L527 serves the same purpose)