### PR TITLE
Prevent installing a time event, when there's no need for a timeout (cont.)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 cmake_minimum_required(VERSION 3.14)
 
-project(sdbus-c++ VERSION 1.2.0 LANGUAGES C CXX)
+project(sdbus-c++ VERSION 2.0.0 LANGUAGES C CXX)
 
 include(GNUInstallDirs) # Installation directories for `install` command and pkgconfig file
 

--- a/src/Connection.cpp
+++ b/src/Connection.cpp
@@ -382,7 +382,10 @@ int Connection::onSdEventPrepare(sd_event_source */*s*/, void *userdata)
     auto* sdTimeEventSource = static_cast<sd_event_source*>(connection->sdEvent_->sdTimeEventSource.get());
     r = sd_event_source_set_time(sdTimeEventSource, static_cast<uint64_t>(sdbusPollData.timeout.count()));
     SDBUS_THROW_ERROR_IF(r < 0, "Failed to set timeout for time event source", -r);
-    r = sd_event_source_set_enabled(sdTimeEventSource, SD_EVENT_ON);
+    // In case the timeout is infinite, we disable the timer in the sd_event loop.
+    // This prevents a syscall error, where `timerfd_settime` returns `EINVAL`,
+    // because the value is too big. See #324 for details
+    r = sd_event_source_set_enabled(sdTimeEventSource, sdbusPollData.timeout != sdbusPollData.timeout.max() ? SD_EVENT_ONESHOT : SD_EVENT_OFF);
     SDBUS_THROW_ERROR_IF(r < 0, "Failed to enable time event source", -r);
 
     return 1;

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 cmake_minimum_required(VERSION 3.5)
 
-project(sdbus-c++-tools VERSION 1.2.0)
+project(sdbus-c++-tools VERSION 2.0.0)
 
 include(GNUInstallDirs)
 


### PR DESCRIPTION
I accidentally closed the other issue by wrongly deleting my branch... github is somewhat picky about that...

Fixes #324

Continues #325 

