### PR TITLE
chore(ci): remove ubuntu-18.04 container image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04]
+        os: [ubuntu-20.04, ubuntu-22.04]
         compiler: [g++, clang]
         build: [shared-libsystemd]
         include:
@@ -50,7 +50,7 @@ jobs:
         cd build
         cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS="-O0 -g -W -Wextra -Wall -Wnon-virtual-dtor -Werror" -DCMAKE_VERBOSE_MAKEFILE=ON -DBUILD_TESTS=ON -DENABLE_PERF_TESTS=ON -DENABLE_STRESS_TESTS=ON -DBUILD_CODE_GEN=ON ..
     - name: configure-release
-      if: matrix.build == 'shared-libsystemd' && (matrix.os == 'ubuntu-18.04' || matrix.os == 'ubuntu-22.04')
+      if: matrix.build == 'shared-libsystemd' && matrix.os == 'ubuntu-22.04'
       run: |
         mkdir build
         cd build


### PR DESCRIPTION
Ubuntu 18.04 seems to be no longer supported by GitHub CI.