### PR TITLE
fix: moving instead of copying std::string argument

### DIFF
--- a/include/sdbus-c++/ConvenienceApiClasses.h
+++ b/include/sdbus-c++/ConvenienceApiClasses.h
@@ -51,7 +51,7 @@ namespace sdbus {
     class MethodRegistrator
     {
     public:
-        MethodRegistrator(IObject& object, const std::string& methodName);
+        MethodRegistrator(IObject& object, std::string methodName);
         MethodRegistrator(MethodRegistrator&& other) = default;
         ~MethodRegistrator() noexcept(false);
 
@@ -67,7 +67,7 @@ namespace sdbus {
 
     private:
         IObject& object_;
-        const std::string& methodName_;
+        std::string methodName_;
         std::string interfaceName_;
         std::string inputSignature_;
         std::vector<std::string> inputParamNames_;
@@ -81,7 +81,7 @@ namespace sdbus {
     class SignalRegistrator
     {
     public:
-        SignalRegistrator(IObject& object, const std::string& signalName);
+        SignalRegistrator(IObject& object, std::string signalName);
         SignalRegistrator(SignalRegistrator&& other) = default;
         ~SignalRegistrator() noexcept(false);
 
@@ -93,7 +93,7 @@ namespace sdbus {
 
     private:
         IObject& object_;
-        const std::string& signalName_;
+        std::string signalName_;
         std::string interfaceName_;
         std::string signalSignature_;
         std::vector<std::string> paramNames_;

--- a/include/sdbus-c++/ConvenienceApiClasses.inl
+++ b/include/sdbus-c++/ConvenienceApiClasses.inl
@@ -45,9 +45,9 @@ namespace sdbus {
     /*** MethodRegistrator ***/
     /*** ----------------- ***/
 
-    inline MethodRegistrator::MethodRegistrator(IObject& object, const std::string& methodName)
+    inline MethodRegistrator::MethodRegistrator(IObject& object, std::string methodName)
         : object_(object)
-        , methodName_(methodName)
+        , methodName_(std::move(methodName))
         , exceptions_(std::uncaught_exceptions())
     {
     }
@@ -73,9 +73,9 @@ namespace sdbus {
         object_.registerMethod( interfaceName_
                               , std::move(methodName_)
                               , std::move(inputSignature_)
-                              , std::move(inputParamNames_)
+                              , inputParamNames_
                               , std::move(outputSignature_)
-                              , std::move(outputParamNames_)
+                              , outputParamNames_
                               , std::move(methodCallback_)
                               , std::move(flags_));
     }
@@ -177,9 +177,9 @@ namespace sdbus {
     /*** SignalRegistrator ***/
     /*** ----------------- ***/
 
-    inline SignalRegistrator::SignalRegistrator(IObject& object, const std::string& signalName)
+    inline SignalRegistrator::SignalRegistrator(IObject& object, std::string signalName)
         : object_(object)
-        , signalName_(signalName)
+        , signalName_(std::move(signalName))
         , exceptions_(std::uncaught_exceptions())
     {
     }
@@ -204,7 +204,7 @@ namespace sdbus {
         object_.registerSignal( interfaceName_
                               , std::move(signalName_)
                               , std::move(signalSignature_)
-                              , std::move(paramNames_)
+                              , paramNames_
                               , std::move(flags_) );
     }
 


### PR DESCRIPTION
This is a proper fix to #323. The argument shall be moved, that's OK, but the problem lies at the source object -- the source shall be a direct object, not a `const &` to it.