### PR TITLE
refactor: improve type extensibility and its safety

### DIFF
--- a/include/sdbus-c++/Message.h
+++ b/include/sdbus-c++/Message.h
@@ -158,6 +158,9 @@ namespace sdbus {
         Message& enterStruct(const std::string& signature);
         Message& exitStruct();
 
+        Message& appendArray(char type, const void *ptr, size_t size);
+        Message& readArray(char type, const void **ptr, size_t *size);
+
         explicit operator bool() const;
         void clearFlags();
 
@@ -198,9 +201,6 @@ namespace sdbus {
         void deserializeArraySlow(_Array& items);
         template <typename _Element, typename _Allocator>
         void deserializeArraySlow(std::vector<_Element, _Allocator>& items);
-
-        void appendArray(char type, const void *ptr, size_t size);
-        void readArray(char type, const void **ptr, size_t *size);
 
         template <typename _Dictionary>
         void serializeDictionary(const _Dictionary& items);
@@ -529,7 +529,6 @@ namespace sdbus {
         while (true)
         {
             _Element elem;
-            // TODO: Is there a way to find D-Bus message container size upfront? We could reserve space in vector upfront.
             if (*this >> elem)
                 items.emplace_back(std::move(elem));
             else

--- a/include/sdbus-c++/Types.h
+++ b/include/sdbus-c++/Types.h
@@ -56,7 +56,7 @@ namespace sdbus {
         Variant();
 
         template <typename _ValueType>
-        Variant(const _ValueType& value)
+        explicit Variant(const _ValueType& value)
             : Variant()
         {
             msg_.openVariant(signature_of<_ValueType>::str());

--- a/src/Message.cpp
+++ b/src/Message.cpp
@@ -226,10 +226,12 @@ Message& Message::operator<<(const UnixFd &item)
     return *this;
 }
 
-void Message::appendArray(char type, const void *ptr, size_t size)
+Message& Message::appendArray(char type, const void *ptr, size_t size)
 {
     auto r = sd_bus_message_append_array((sd_bus_message*)msg_, type, ptr, size);
     SDBUS_THROW_ERROR_IF(r < 0, "Failed to serialize an array", -r);
+
+    return *this;
 }
 
 Message& Message::operator>>(bool& item)
@@ -323,13 +325,15 @@ Message& Message::operator>>(uint64_t& item)
     return *this;
 }
 
-void Message::readArray(char type, const void **ptr, size_t *size)
+Message& Message::readArray(char type, const void **ptr, size_t *size)
 {
     auto r = sd_bus_message_read_array((sd_bus_message*)msg_, type, ptr, size);
     if (r == 0)
         ok_ = false;
 
     SDBUS_THROW_ERROR_IF(r < 0, "Failed to deserialize an array", -r);
+
+    return *this;
 }
 
 Message& Message::operator>>(double& item)

--- a/tests/integrationtests/DBusMethodsTests.cpp
+++ b/tests/integrationtests/DBusMethodsTests.cpp
@@ -103,7 +103,9 @@ TEST_F(SdbusTestObject, CallsMethodWithStructVariantsAndGetMapSuccesfully)
     std::vector<int32_t> x{-2, 0, 2};
     sdbus::Struct<sdbus::Variant, sdbus::Variant> y{false, true};
     auto mapOfVariants = m_proxy->getMapOfVariants(x, y);
-    decltype(mapOfVariants) res{{-2, false}, {0, false}, {2, true}};
+    decltype(mapOfVariants) res{ {sdbus::Variant{-2}, sdbus::Variant{false}}
+                               , {sdbus::Variant{0}, sdbus::Variant{false}}
+                               , {sdbus::Variant{2}, sdbus::Variant{true}}};
 
     ASSERT_THAT(mapOfVariants[-2].get<bool>(), Eq(res[-2].get<bool>()));
     ASSERT_THAT(mapOfVariants[0].get<bool>(), Eq(res[0].get<bool>()));

--- a/tests/integrationtests/DBusSignalsTests.cpp
+++ b/tests/integrationtests/DBusSignalsTests.cpp
@@ -104,7 +104,7 @@ TEST_F(SdbusTestObject, EmitsSignalWithLargeMapSuccesfully)
 TEST_F(SdbusTestObject, EmitsSignalWithVariantSuccesfully)
 {
     double d = 3.14;
-    m_adaptor->emitSignalWithVariant(d);
+    m_adaptor->emitSignalWithVariant(sdbus::Variant{d});
 
     ASSERT_TRUE(waitUntil(m_proxy->m_gotSignalWithVariant));
     ASSERT_THAT(m_proxy->m_variantFromSignal, DoubleEq(d));

--- a/tests/integrationtests/DBusStandardInterfacesTests.cpp
+++ b/tests/integrationtests/DBusStandardInterfacesTests.cpp
@@ -86,7 +86,7 @@ TEST_F(SdbusTestObject, SetsPropertyViaPropertiesInterface)
 {
     uint32_t newActionValue = 2345;
 
-    m_proxy->Set(INTERFACE_NAME, "action", newActionValue);
+    m_proxy->Set(INTERFACE_NAME, "action", sdbus::Variant{newActionValue});
 
     ASSERT_THAT(m_proxy->action(), Eq(newActionValue));
 }

--- a/tests/integrationtests/TestAdaptor.cpp
+++ b/tests/integrationtests/TestAdaptor.cpp
@@ -77,7 +77,7 @@ std::vector<int16_t> TestAdaptor::getInts16FromStruct(const sdbus::Struct<uint8_
 
 sdbus::Variant TestAdaptor::processVariant(const sdbus::Variant& v)
 {
-    sdbus::Variant res = static_cast<int32_t>(v.get<double>());
+    sdbus::Variant res{static_cast<int32_t>(v.get<double>())};
     return res;
 }
 

--- a/tests/stresstests/sdbus-c++-stress-tests.cpp
+++ b/tests/stresstests/sdbus-c++-stress-tests.cpp
@@ -427,8 +427,8 @@ int main(int argc, char *argv[])
                 while (!stopClients)
                 {
                     std::map<std::string, sdbus::Variant> param;
-                    param["key1"] = "sdbus-c++-stress-tests";
-                    param["key2"] = ++localCounter;
+                    param["key1"] = sdbus::Variant{"sdbus-c++-stress-tests"};
+                    param["key2"] = sdbus::Variant{++localCounter};
 
                     concatenator.concatenate(param);
 


### PR DESCRIPTION
* `Message::appendArray` and `Message::readArray` are made public so they can be used by clients for their custom array representations
* `Variant` converting constructor is made explicit, to exclude it from candidate list when compiler looks for insertion/extraction operators for custom client types

This is a follow-up to #346 and #347 