### PR TITLE
feat: support std::future-based async methods in codegen tool

### DIFF
--- a/tests/integrationtests/TestProxy.cpp
+++ b/tests/integrationtests/TestProxy.cpp
@@ -153,7 +153,7 @@ std::future<void> TestProxy::doErroneousOperationClientSideAsync(with_future_t)
 {
     return getProxy().callMethodAsync("throwError")
                      .onInterface(sdbus::test::INTERFACE_NAME)
-                     .getResultAsFuture<>();;
+                     .getResultAsFuture<>();
 }
 
 void TestProxy::doOperationClientSideAsyncWithTimeout(const std::chrono::microseconds &timeout, uint32_t param)

--- a/tools/xml2cpp-codegen/AdaptorGenerator.cpp
+++ b/tools/xml2cpp-codegen/AdaptorGenerator.cpp
@@ -192,7 +192,7 @@ std::tuple<std::string, std::string> AdaptorGenerator::processMethods(const Node
             }
             else if (annotationName == "org.freedesktop.DBus.Method.Async")
             {
-                if (annotationValue == "server" || annotationValue == "clientserver")
+                if (annotationValue == "server" || annotationValue == "clientserver" || annotationValue == "client-server")
                     async = true;
             }
             else if (annotationName == "org.freedesktop.systemd1.Privileged")


### PR DESCRIPTION
Some time ago, in #311, support for `std::future`-based async calls was introduced on basic as well as convenience API level. Now, the support is also introduced on the generated code level.

Closes https://github.com/Kistler-Group/sdbus-cpp/discussions/317