### PR TITLE
feat: Add support for peer-to-peer client connections

### DIFF
--- a/include/sdbus-c++/IConnection.h
+++ b/include/sdbus-c++/IConnection.h
@@ -458,6 +458,18 @@ namespace sdbus {
      * @throws sdbus::Error in case of failure
      */
     [[nodiscard]] std::unique_ptr<sdbus::IConnection> createRemoteSystemBusConnection(const std::string& host);
+
+    /*!
+     * @brief Creates/opens a peer-to-peer D-Bus connection at a custom address
+     *
+     * @param[in] address ";"-separated list of addresses to try to connect
+     * @return Connection instance
+     *
+     * @throws sdbus::Error in case of failure
+     *
+     * Consult manual pages for `sd_bus_set_address` of the underlying sd-bus library for more information.
+     */
+    [[nodiscard]] std::unique_ptr<sdbus::IConnection> createPeerToPeerConnectionWithAddress(const std::string& address);
 }
 
 #endif /* SDBUS_CXX_ICONNECTION_H_ */

--- a/src/Connection.cpp
+++ b/src/Connection.cpp
@@ -77,6 +77,11 @@ Connection::Connection(std::unique_ptr<ISdBus>&& interface, pseudo_bus_t)
     assert(iface_ != nullptr);
 }
 
+Connection::Connection(std::unique_ptr<ISdBus>&& interface, p2p_bus_t, const std::string& address)
+    : Connection(std::move(interface), [this, &address](sd_bus** bus){ return iface_->sd_bus_open_p2p_with_address(bus, address.c_str()); })
+{
+}
+
 Connection::~Connection()
 {
     Connection::leaveEventLoop();
@@ -669,6 +674,12 @@ std::unique_ptr<sdbus::IConnection> createRemoteSystemBusConnection(const std::s
 {
     auto interface = std::make_unique<sdbus::internal::SdBus>();
     return std::make_unique<sdbus::internal::Connection>(std::move(interface), Connection::remote_system_bus, host);
+}
+
+std::unique_ptr<sdbus::IConnection> createPeerToPeerConnectionWithAddress(const std::string& address)
+{
+    auto interface = std::make_unique<sdbus::internal::SdBus>();
+    return std::make_unique<sdbus::internal::Connection>(std::move(interface), Connection::p2p_bus, address);
 }
 
 } // namespace sdbus

--- a/src/Connection.h
+++ b/src/Connection.h
@@ -59,6 +59,8 @@ namespace sdbus::internal {
         inline static constexpr remote_system_bus_t remote_system_bus{};
         struct pseudo_bus_t{}; // A bus connection that is not really established with D-Bus daemon
         inline static constexpr pseudo_bus_t pseudo_bus{};
+        struct p2p_bus_t{}; // A connection to a peer that doesn't have a D-Bus daemon
+        inline static constexpr p2p_bus_t p2p_bus{};
 
         Connection(std::unique_ptr<ISdBus>&& interface, default_bus_t);
         Connection(std::unique_ptr<ISdBus>&& interface, system_bus_t);
@@ -66,6 +68,7 @@ namespace sdbus::internal {
         Connection(std::unique_ptr<ISdBus>&& interface, custom_session_bus_t, const std::string& address);
         Connection(std::unique_ptr<ISdBus>&& interface, remote_system_bus_t, const std::string& host);
         Connection(std::unique_ptr<ISdBus>&& interface, pseudo_bus_t);
+        Connection(std::unique_ptr<ISdBus>&& interface, p2p_bus_t, const std::string& host);
         ~Connection() override;
 
         void requestName(const std::string& name) override;

--- a/src/ISdBus.h
+++ b/src/ISdBus.h
@@ -71,6 +71,7 @@ namespace sdbus::internal {
         virtual int sd_bus_open_user(sd_bus **ret) = 0;
         virtual int sd_bus_open_user_with_address(sd_bus **ret, const char* address) = 0;
         virtual int sd_bus_open_system_remote(sd_bus **ret, const char* host) = 0;
+        virtual int sd_bus_open_p2p_with_address(sd_bus **ret, const char* address) = 0;
         virtual int sd_bus_request_name(sd_bus *bus, const char *name, uint64_t flags) = 0;
         virtual int sd_bus_release_name(sd_bus *bus, const char *name) = 0;
         virtual int sd_bus_get_unique_name(sd_bus *bus, const char **name) = 0;

--- a/src/SdBus.cpp
+++ b/src/SdBus.cpp
@@ -227,6 +227,27 @@ int SdBus::sd_bus_open_system_remote(sd_bus **ret, const char *host)
     return ::sd_bus_open_system_remote(ret, host);
 }
 
+int SdBus::sd_bus_open_p2p_with_address(sd_bus **ret, const char* address)
+{
+    sd_bus* bus = nullptr;
+
+    int r = sd_bus_new(&bus);
+    if (r < 0)
+        return r;
+
+    r = sd_bus_set_address(bus, address);
+    if (r < 0)
+        return r;
+
+    r = sd_bus_start(bus);
+    if (r < 0)
+        return r;
+
+    *ret = bus;
+
+    return 0;
+}
+
 int SdBus::sd_bus_request_name(sd_bus *bus, const char *name, uint64_t flags)
 {
     std::lock_guard lock(sdbusMutex_);

--- a/src/SdBus.h
+++ b/src/SdBus.h
@@ -63,6 +63,7 @@ public:
     virtual int sd_bus_open_user(sd_bus **ret) override;
     virtual int sd_bus_open_user_with_address(sd_bus **ret, const char* address) override;
     virtual int sd_bus_open_system_remote(sd_bus **ret, const char* hsot) override;
+    virtual int sd_bus_open_p2p_with_address(sd_bus **ret, const char* address) override;
     virtual int sd_bus_request_name(sd_bus *bus, const char *name, uint64_t flags) override;
     virtual int sd_bus_release_name(sd_bus *bus, const char *name) override;
     virtual int sd_bus_get_unique_name(sd_bus *bus, const char **name) override;


### PR DESCRIPTION
This is for programs that want to use the D-Bus protocol for their connections, but don't have a D-Bus daemon, ObjectManager, etc.

See https://dbus2.github.io/zbus/connection.html#peer-to-peer-connection for zbus's (brief) documentation of this technique.  sd_bus covers it at https://www.freedesktop.org/software/systemd/man/sd_bus_set_server.html#
