### PR TITLE
fix: Use-after-return in synchronous calls

### DIFF
--- a/src/Proxy.cpp
+++ b/src/Proxy.cpp
@@ -120,7 +120,7 @@ PendingAsyncCall Proxy::callMethod(const MethodCall& message, async_reply_handle
     SDBUS_THROW_ERROR_IF(!message.isValid(), "Invalid async method call message provided", EINVAL);
 
     auto callback = (void*)&Proxy::sdbus_async_reply_handler;
-    auto callData = std::make_shared<AsyncCalls::CallData>(AsyncCalls::CallData{*this, std::move(asyncReplyCallback), {}, AsyncCalls::CallData::STATE_RUNNING});
+    auto callData = std::make_shared<AsyncCalls::CallData>(AsyncCalls::CallData{*this, std::move(asyncReplyCallback), {}, AsyncCalls::CallData::State::RUNNING});
     auto weakData = std::weak_ptr<AsyncCalls::CallData>{callData};
 
     callData->slot = message.send(callback, callData.get(), timeout);
@@ -162,7 +162,7 @@ MethodReply Proxy::sendMethodCallMessageAndWaitForReply(const MethodCall& messag
         syncCallReplyData.sendMethodReplyToWaitingThread(reply, error);
     };
     auto callback = (void*)&Proxy::sdbus_async_reply_handler;
-    AsyncCalls::CallData callData{*this, std::move(asyncReplyCallback), {}, AsyncCalls::CallData::STATE_NOT_ASYNC};
+    AsyncCalls::CallData callData{*this, std::move(asyncReplyCallback), {}, AsyncCalls::CallData::State::NOT_ASYNC};
 
     message.send(callback, &callData, timeout, floating_slot);
 
@@ -283,7 +283,7 @@ int Proxy::sdbus_async_reply_handler(sd_bus_message *sdbusMessage, void *userDat
     SCOPE_EXIT
     {
         // Remove call meta-data if it's a real async call (a sync call done in terms of async has STATE_NOT_ASYNC)
-        if (state != AsyncCalls::CallData::STATE_NOT_ASYNC)
+        if (state != AsyncCalls::CallData::State::NOT_ASYNC)
             proxy.pendingAsyncCalls_.removeCall(asyncCallData);
     };
 

--- a/src/Proxy.h
+++ b/src/Proxy.h
@@ -135,14 +135,16 @@ namespace sdbus::internal {
         public:
             struct CallData
             {
-                static const uint8_t STATE_NOT_ASYNC = 0;
-                static const uint8_t STATE_RUNNING = 1;
-                static const uint8_t STATE_FINISHED = 2;
+                enum class State
+                {   NOT_ASYNC
+                ,   RUNNING
+                ,   FINISHED
+                };
 
                 Proxy& proxy;
                 async_reply_handler callback;
                 Slot slot;
-                uint8_t state;
+                State state;
             };
 
             ~AsyncCalls()
@@ -153,14 +155,14 @@ namespace sdbus::internal {
             void addCall(std::shared_ptr<CallData> asyncCallData)
             {
                 std::lock_guard lock(mutex_);
-                if (asyncCallData->state != CallData::STATE_FINISHED) // The call may have finished in the mean time
+                if (asyncCallData->state != CallData::State::FINISHED) // The call may have finished in the meantime
                     calls_.emplace_back(std::move(asyncCallData));
             }
 
             void removeCall(CallData* data)
             {
                 std::unique_lock lock(mutex_);
-                data->state = CallData::STATE_FINISHED;
+                data->state = CallData::State::FINISHED;
                 if (auto it = std::find_if(calls_.begin(), calls_.end(), [data](auto const& entry){ return entry.get() == data; }); it != calls_.end())
                 {
                     auto callData = std::move(*it);


### PR DESCRIPTION
This bug was introduced by c39bc637b8df7791 and can be reproduced by configuring with

  cmake -S . -B build -DBUILD_TESTS=yes -DCMAKE_CXX_COMPILER=clang++ \
    -DCMAKE_CXX_FLAGS="-Wno-error=deprecated-copy -fno-omit-frame-pointer -fsanitize=address -fsanitize-address-use-after-scope"

and running `cmake --buid build && cmake --build build -t test` or `build/tests/sdbus-c++-integration-tests --gtest_filter=SdbusTestObject.HandlesCorrectlyABulkOfParallelServerSideAsyncMethods`

The issue is that `sdbus_async_reply_handler` can call `removeCall`, which writes to `data->finished`, but `data` can point to the stack of `sendMethodCallMessageAndWaitForReply`, which can return as soon as `asyncCallData->callback` is called.

As a fix, I restored some of the logic removed in c39bc637b8df7791. Specifically, in `sdbus_async_reply_handler`, I make a copy of some data from `asyncCallData` (a new `state` field instead of `slot`), and in the `SCOPE_GUARD`, I don't call `removeCall` if the call was actually synchronous.