### PR TITLE
chore(tests): unbreak release/v2.0 on FreeBSD

### DIFF
--- a/tests/integrationtests/DBusMethodsTests.cpp
+++ b/tests/integrationtests/DBusMethodsTests.cpp
@@ -180,7 +180,7 @@ TEST_F(SdbusTestObject, ThrowsTimeoutErrorWhenMethodTimesOut)
     catch (const sdbus::Error& e)
     {
         ASSERT_THAT(e.getName(), AnyOf("org.freedesktop.DBus.Error.Timeout", "org.freedesktop.DBus.Error.NoReply"));
-        ASSERT_THAT(e.getMessage(), AnyOf("Connection timed out", "Method call timed out"));
+        ASSERT_THAT(e.getMessage(), AnyOf("Connection timed out", "Operation timed out", "Method call timed out"));
         auto measuredTimeout = std::chrono::steady_clock::now() - start;
         ASSERT_THAT(measuredTimeout, Le(50ms));
     }


### PR DESCRIPTION
- glibc, bionic expand `ETIMEDOUT` to `Connection timed out`
- BSD libc and [musl >= 0.9.10](https://git.musl-libc.org/cgit/musl/commit/?id=d75348ddda4e) expand `ETIMEDOUT` to `Operation timed out`
- POSIX [1997](https://pubs.opengroup.org/onlinepubs/7908799/xsh/errors.html) and [2018](https://pubs.opengroup.org/onlinepubs/9699919799/functions/V2_chap02.html) support both `Connection timed out` and `Operation timed out`
- According to [unix-history-repo](https://github.com/dspinellis/unix-history-repo) `ETIMEDOUT` appeared in BSD 4.1c (1982) as `Connection timed out` but with 4.4-Lite1 (1994) changed to `Operation timed out`