### PR TITLE
refactor: simplify async call state flag

### DIFF
--- a/src/Proxy.cpp
+++ b/src/Proxy.cpp
@@ -98,7 +98,7 @@ PendingAsyncCall Proxy::callMethod(const MethodCall& message, async_reply_handle
     SDBUS_THROW_ERROR_IF(!message.isValid(), "Invalid async method call message provided", EINVAL);
 
     auto callback = (void*)&Proxy::sdbus_async_reply_handler;
-    auto callData = std::make_shared<AsyncCalls::CallData>(AsyncCalls::CallData{*this, std::move(asyncReplyCallback), {}, AsyncCalls::CallData::State::RUNNING});
+    auto callData = std::make_shared<AsyncCalls::CallData>(AsyncCalls::CallData{*this, std::move(asyncReplyCallback)});
     auto weakData = std::weak_ptr<AsyncCalls::CallData>{callData};
 
     callData->slot = connection_->callMethod(message, callback, callData.get(), timeout);
@@ -211,16 +211,13 @@ int Proxy::sdbus_async_reply_handler(sd_bus_message *sdbusMessage, void *userDat
     assert(asyncCallData != nullptr);
     assert(asyncCallData->callback);
     auto& proxy = asyncCallData->proxy;
-    auto state = asyncCallData->state;
 
     // We are removing the CallData item at the complete scope exit, after the callback has been invoked.
     // We can't do it earlier (before callback invocation for example), because CallBack data (slot release)
     // is the synchronization point between callback invocation and Proxy::unregister.
     SCOPE_EXIT
     {
-        // Remove call meta-data if it's a real async call (a sync call done in terms of async has STATE_NOT_ASYNC)
-        if (state != AsyncCalls::CallData::State::NOT_ASYNC)
-            proxy.pendingAsyncCalls_.removeCall(asyncCallData);
+        proxy.pendingAsyncCalls_.removeCall(asyncCallData);
     };
 
     auto message = Message::Factory::create<MethodReply>(sdbusMessage, &proxy.connection_->getSdBusInterface());


### PR DESCRIPTION
Since synchronous D-Bus calls are simplified in v2.0 and no more implemented in terms of an async call, the issue reported in #362 is no more relevant, and we can return to the simple boolean flag for indicating a finished call.