### PR TITLE
fix(tests): enable skipped test for Clang and FreeBSD

### DIFF
--- a/tests/integrationtests/DBusMethodsTests.cpp
+++ b/tests/integrationtests/DBusMethodsTests.cpp
@@ -275,10 +275,6 @@ TYPED_TEST(SdbusTestObject, CannotSetGeneralMethodTimeoutWithLibsystemdVersionLe
 
 TYPED_TEST(SdbusTestObject, CanCallMethodSynchronouslyWithoutAnEventLoopThread)
 {
-#if defined(__clang__) && defined(__FreeBSD__)
-    GTEST_SKIP() << "https://github.com/Kistler-Group/sdbus-cpp/issues/359";
-#endif
-
     auto proxy = std::make_unique<TestProxy>(BUS_NAME, OBJECT_PATH, sdbus::dont_run_event_loop_thread);
 
     auto multiplyRes = proxy->multiply(INT64_VALUE, DOUBLE_VALUE);


### PR DESCRIPTION
The test now works with Clang, libc++ and `-O2` optimization, since the underlying implementation has been completely re-designed and doesn't suffer from that problem anymore.