### PR TITLE
fix: Add header for gcc-14 that isn't included by default anymore

### DIFF
--- a/include/sdbus-c++/Message.h
+++ b/include/sdbus-c++/Message.h
@@ -42,6 +42,7 @@
 #include <cassert>
 #include <functional>
 #include <sys/types.h>
+#include <algorithm>
 
 // Forward declarations
 namespace sdbus {


### PR DESCRIPTION
* https://gcc.gnu.org/gcc-14/porting_to.html

Couldn't discern patterns header includes other than newer additions being bottom from git-blame, so I followed the apparent precedent.

https://bugs.gentoo.org/917157