### PR TITLE
refactor: add Async suffix to async callMethod functions

### DIFF
--- a/include/sdbus-c++/ConvenienceApiClasses.inl
+++ b/include/sdbus-c++/ConvenienceApiClasses.inl
@@ -257,7 +257,7 @@ namespace sdbus {
             sdbus::apply(callback, error, args);
         };
 
-        return proxy_.callMethod(method_, std::move(asyncReplyHandler), timeout_);
+        return proxy_.callMethodAsync(method_, std::move(asyncReplyHandler), timeout_);
     }
 
     template <typename... _Args>

--- a/include/sdbus-c++/IProxy.h
+++ b/include/sdbus-c++/IProxy.h
@@ -135,13 +135,17 @@ namespace sdbus {
          *
          * @throws sdbus::Error in case of failure
          */
-        virtual PendingAsyncCall callMethod(const MethodCall& message, async_reply_handler asyncReplyCallback, uint64_t timeout = 0) = 0;
+        virtual PendingAsyncCall callMethodAsync( const MethodCall& message
+                                                , async_reply_handler asyncReplyCallback
+                                                , uint64_t timeout = 0 ) = 0;
 
         /*!
          * @copydoc IProxy::callMethod(const MethodCall&,async_reply_handler,uint64_t)
          */
         template <typename _Rep, typename _Period>
-        PendingAsyncCall callMethod(const MethodCall& message, async_reply_handler asyncReplyCallback, const std::chrono::duration<_Rep, _Period>& timeout);
+        PendingAsyncCall callMethodAsync( const MethodCall& message
+                                        , async_reply_handler asyncReplyCallback
+                                        , const std::chrono::duration<_Rep, _Period>& timeout );
 
         /*!
          * @brief Calls method on the D-Bus object asynchronously
@@ -160,7 +164,7 @@ namespace sdbus {
          *
          * @throws sdbus::Error in case of failure
          */
-        virtual std::future<MethodReply> callMethod(const MethodCall& message, with_future_t) = 0;
+        virtual std::future<MethodReply> callMethodAsync(const MethodCall& message, with_future_t) = 0;
 
         /*!
          * @brief Calls method on the D-Bus object asynchronously, with custom timeout
@@ -180,15 +184,17 @@ namespace sdbus {
          *
          * @throws sdbus::Error in case of failure
          */
-        virtual std::future<MethodReply> callMethod(const MethodCall& message, uint64_t timeout, with_future_t) = 0;
+        virtual std::future<MethodReply> callMethodAsync( const MethodCall& message
+                                                        , uint64_t timeout
+                                                        , with_future_t ) = 0;
 
         /*!
          * @copydoc IProxy::callMethod(const MethodCall&,uint64_t,with_future_t)
          */
         template <typename _Rep, typename _Period>
-        std::future<MethodReply> callMethod( const MethodCall& message
-                                           , const std::chrono::duration<_Rep, _Period>& timeout
-                                           , with_future_t );
+        std::future<MethodReply> callMethodAsync( const MethodCall& message
+                                                , const std::chrono::duration<_Rep, _Period>& timeout
+                                                , with_future_t );
 
         /*!
          * @brief Registers a handler for the desired signal emitted by the D-Bus object
@@ -501,19 +507,21 @@ namespace sdbus {
     }
 
     template <typename _Rep, typename _Period>
-    inline PendingAsyncCall IProxy::callMethod(const MethodCall& message, async_reply_handler asyncReplyCallback, const std::chrono::duration<_Rep, _Period>& timeout)
+    inline PendingAsyncCall IProxy::callMethodAsync( const MethodCall& message
+                                                   , async_reply_handler asyncReplyCallback
+                                                   , const std::chrono::duration<_Rep, _Period>& timeout )
     {
         auto microsecs = std::chrono::duration_cast<std::chrono::microseconds>(timeout);
-        return callMethod(message, std::move(asyncReplyCallback), microsecs.count());
+        return callMethodAsync(message, std::move(asyncReplyCallback), microsecs.count());
     }
 
     template <typename _Rep, typename _Period>
-    inline std::future<MethodReply> IProxy::callMethod( const MethodCall& message
-                                                      , const std::chrono::duration<_Rep, _Period>& timeout
-                                                      , with_future_t )
+    inline std::future<MethodReply> IProxy::callMethodAsync( const MethodCall& message
+                                                           , const std::chrono::duration<_Rep, _Period>& timeout
+                                                           , with_future_t )
     {
         auto microsecs = std::chrono::duration_cast<std::chrono::microseconds>(timeout);
-        return callMethod(message, microsecs.count(), with_future);
+        return callMethodAsync(message, microsecs.count(), with_future);
     }
 
     inline MethodInvoker IProxy::callMethod(const std::string& methodName)

--- a/src/Proxy.cpp
+++ b/src/Proxy.cpp
@@ -93,7 +93,7 @@ MethodReply Proxy::callMethod(const MethodCall& message, uint64_t timeout)
     return connection_->callMethod(message, timeout);
 }
 
-PendingAsyncCall Proxy::callMethod(const MethodCall& message, async_reply_handler asyncReplyCallback, uint64_t timeout)
+PendingAsyncCall Proxy::callMethodAsync(const MethodCall& message, async_reply_handler asyncReplyCallback, uint64_t timeout)
 {
     SDBUS_THROW_ERROR_IF(!message.isValid(), "Invalid async method call message provided", EINVAL);
 
@@ -109,12 +109,12 @@ PendingAsyncCall Proxy::callMethod(const MethodCall& message, async_reply_handle
     return {weakData};
 }
 
-std::future<MethodReply> Proxy::callMethod(const MethodCall& message, with_future_t)
+std::future<MethodReply> Proxy::callMethodAsync(const MethodCall& message, with_future_t)
 {
-    return Proxy::callMethod(message, {}, with_future);
+    return Proxy::callMethodAsync(message, {}, with_future);
 }
 
-std::future<MethodReply> Proxy::callMethod(const MethodCall& message, uint64_t timeout, with_future_t)
+std::future<MethodReply> Proxy::callMethodAsync(const MethodCall& message, uint64_t timeout, with_future_t)
 {
     auto promise = std::make_shared<std::promise<MethodReply>>();
     auto future = promise->get_future();
@@ -127,7 +127,7 @@ std::future<MethodReply> Proxy::callMethod(const MethodCall& message, uint64_t t
             promise->set_exception(std::make_exception_ptr(*error));
     };
 
-    (void)Proxy::callMethod(message, std::move(asyncReplyCallback), timeout);
+    (void)Proxy::callMethodAsync(message, std::move(asyncReplyCallback), timeout);
 
     return future;
 }

--- a/src/Proxy.h
+++ b/src/Proxy.h
@@ -55,9 +55,9 @@ namespace sdbus::internal {
 
         MethodCall createMethodCall(const std::string& interfaceName, const std::string& methodName) override;
         MethodReply callMethod(const MethodCall& message, uint64_t timeout) override;
-        PendingAsyncCall callMethod(const MethodCall& message, async_reply_handler asyncReplyCallback, uint64_t timeout) override;
-        std::future<MethodReply> callMethod(const MethodCall& message, with_future_t) override;
-        std::future<MethodReply> callMethod(const MethodCall& message, uint64_t timeout, with_future_t) override;
+        PendingAsyncCall callMethodAsync(const MethodCall& message, async_reply_handler asyncReplyCallback, uint64_t timeout) override;
+        std::future<MethodReply> callMethodAsync(const MethodCall& message, with_future_t) override;
+        std::future<MethodReply> callMethodAsync(const MethodCall& message, uint64_t timeout, with_future_t) override;
 
         void registerSignalHandler( const std::string& interfaceName
                                   , const std::string& signalName

--- a/tests/integrationtests/TestProxy.cpp
+++ b/tests/integrationtests/TestProxy.cpp
@@ -136,7 +136,7 @@ std::future<MethodReply> TestProxy::doOperationClientSideAsyncOnBasicAPILevel(ui
     auto methodCall = getProxy().createMethodCall(sdbus::test::INTERFACE_NAME, "doOperation");
     methodCall << param;
 
-    return getProxy().callMethod(methodCall, sdbus::with_future);
+    return getProxy().callMethodAsync(methodCall, sdbus::with_future);
 }
 
 void TestProxy::doErroneousOperationClientSideAsync()


### PR DESCRIPTION
This makes naming consistent, so all asynchronously working functions have `Async` suffix.

Replaces #393 