### PR TITLE
refactor: use optional for passing potential call errors

### DIFF
--- a/include/sdbus-c++/IProxy.h
+++ b/include/sdbus-c++/IProxy.h
@@ -343,7 +343,7 @@ namespace sdbus {
          * Example of use:
          * @code
          * std::future<sdbus::Variant> state = object.getPropertyAsync("state").onInterface("com.kistler.foo").getResultAsFuture();
-         * auto callback = [](const sdbus::Error* err, const sdbus::Variant& value){ ... };
+         * auto callback = [](std::optional<sdbus::Error> err, const sdbus::Variant& value){ ... };
          * object.getPropertyAsync("state").onInterface("com.kistler.foo").uponReplyInvoke(std::move(callback));
          * @endcode
          *
@@ -420,7 +420,7 @@ namespace sdbus {
          *
          * Example of use:
          * @code
-         * auto callback = [](const sdbus::Error* err, const std::map<std::string, Variant>>& properties){ ... };
+         * auto callback = [](std::optional<sdbus::Error> err, const std::map<std::string, Variant>>& properties){ ... };
          * auto props = object.getAllPropertiesAsync().onInterface("com.kistler.foo").uponReplyInvoke(std::move(callback));
          * @endcode
          *

--- a/tests/integrationtests/DBusAsyncMethodsTests.cpp
+++ b/tests/integrationtests/DBusAsyncMethodsTests.cpp
@@ -60,12 +60,12 @@ TYPED_TEST(AsyncSdbusTestObject, ThrowsTimeoutErrorWhenClientSideAsyncMethodTime
     {
         std::promise<uint32_t> promise;
         auto future = promise.get_future();
-        this->m_proxy->installDoOperationClientSideAsyncReplyHandler([&](uint32_t res, const sdbus::Error* err)
+        this->m_proxy->installDoOperationClientSideAsyncReplyHandler([&](uint32_t res, std::optional<sdbus::Error> err)
         {
-            if (err == nullptr)
+            if (!err)
                 promise.set_value(res);
             else
-                promise.set_exception(std::make_exception_ptr(*err));
+                promise.set_exception(std::make_exception_ptr(*std::move(err)));
         });
 
         start = std::chrono::steady_clock::now();
@@ -146,12 +146,12 @@ TYPED_TEST(AsyncSdbusTestObject, InvokesMethodAsynchronouslyOnClientSide)
 {
     std::promise<uint32_t> promise;
     auto future = promise.get_future();
-    this->m_proxy->installDoOperationClientSideAsyncReplyHandler([&](uint32_t res, const sdbus::Error* err)
+    this->m_proxy->installDoOperationClientSideAsyncReplyHandler([&](uint32_t res, std::optional<sdbus::Error> err)
     {
-        if (err == nullptr)
+        if (!err)
             promise.set_value(res);
         else
-            promise.set_exception(std::make_exception_ptr(*err));
+            promise.set_exception(std::make_exception_ptr(std::move(err)));
     });
 
     this->m_proxy->doOperationClientSideAsync(100);
@@ -179,7 +179,7 @@ TYPED_TEST(AsyncSdbusTestObject, InvokesMethodAsynchronouslyOnClientSideWithFutu
 
 TYPED_TEST(AsyncSdbusTestObject, AnswersThatAsyncCallIsPendingIfItIsInProgress)
 {
-    this->m_proxy->installDoOperationClientSideAsyncReplyHandler([&](uint32_t /*res*/, const sdbus::Error* /*err*/){});
+    this->m_proxy->installDoOperationClientSideAsyncReplyHandler([&](uint32_t /*res*/, std::optional<sdbus::Error> /*err*/){});
 
     auto call = this->m_proxy->doOperationClientSideAsync(100);
 
@@ -190,7 +190,7 @@ TYPED_TEST(AsyncSdbusTestObject, CancelsPendingAsyncCallOnClientSide)
 {
     std::promise<uint32_t> promise;
     auto future = promise.get_future();
-    this->m_proxy->installDoOperationClientSideAsyncReplyHandler([&](uint32_t /*res*/, const sdbus::Error* /*err*/){ promise.set_value(1); });
+    this->m_proxy->installDoOperationClientSideAsyncReplyHandler([&](uint32_t /*res*/, std::optional<sdbus::Error> /*err*/){ promise.set_value(1); });
     auto call = this->m_proxy->doOperationClientSideAsync(100);
 
     call.cancel();
@@ -202,7 +202,7 @@ TYPED_TEST(AsyncSdbusTestObject, AnswersThatAsyncCallIsNotPendingAfterItHasBeenC
 {
     std::promise<uint32_t> promise;
     auto future = promise.get_future();
-    this->m_proxy->installDoOperationClientSideAsyncReplyHandler([&](uint32_t /*res*/, const sdbus::Error* /*err*/){ promise.set_value(1); });
+    this->m_proxy->installDoOperationClientSideAsyncReplyHandler([&](uint32_t /*res*/, std::optional<sdbus::Error> /*err*/){ promise.set_value(1); });
     auto call = this->m_proxy->doOperationClientSideAsync(100);
 
     call.cancel();
@@ -214,7 +214,7 @@ TYPED_TEST(AsyncSdbusTestObject, AnswersThatAsyncCallIsNotPendingAfterItHasBeenC
 {
     std::promise<uint32_t> promise;
     auto future = promise.get_future();
-    this->m_proxy->installDoOperationClientSideAsyncReplyHandler([&](uint32_t /*res*/, const sdbus::Error* /*err*/){ promise.set_value(1); });
+    this->m_proxy->installDoOperationClientSideAsyncReplyHandler([&](uint32_t /*res*/, std::optional<sdbus::Error> /*err*/){ promise.set_value(1); });
 
     auto call = this->m_proxy->doOperationClientSideAsync(0);
     (void) future.get(); // Wait for the call to finish
@@ -242,12 +242,12 @@ TYPED_TEST(AsyncSdbusTestObject, ReturnsNonnullErrorWhenAsynchronousMethodCallFa
 {
     std::promise<uint32_t> promise;
     auto future = promise.get_future();
-    this->m_proxy->installDoOperationClientSideAsyncReplyHandler([&](uint32_t res, const sdbus::Error* err)
+    this->m_proxy->installDoOperationClientSideAsyncReplyHandler([&](uint32_t res, std::optional<sdbus::Error> err)
     {
-        if (err == nullptr)
+        if (!err)
             promise.set_value(res);
         else
-            promise.set_exception(std::make_exception_ptr(*err));
+            promise.set_exception(std::make_exception_ptr(*std::move(err)));
     });
 
     this->m_proxy->doErroneousOperationClientSideAsync();

--- a/tests/integrationtests/DBusStandardInterfacesTests.cpp
+++ b/tests/integrationtests/DBusStandardInterfacesTests.cpp
@@ -82,12 +82,12 @@ TYPED_TEST(SdbusTestObject, GetsPropertyAsynchronouslyViaPropertiesInterface)
     std::promise<std::string> promise;
     auto future = promise.get_future();
 
-    this->m_proxy->GetAsync(INTERFACE_NAME, "state", [&](const sdbus::Error* err, sdbus::Variant value)
+    this->m_proxy->GetAsync(INTERFACE_NAME, "state", [&](std::optional<sdbus::Error> err, sdbus::Variant value)
     {
-        if (err == nullptr)
+        if (!err)
            promise.set_value(value.get<std::string>());
         else
-           promise.set_exception(std::make_exception_ptr(*err));
+           promise.set_exception(std::make_exception_ptr(*std::move(err)));
     });
 
     ASSERT_THAT(future.get(), Eq(DEFAULT_STATE_VALUE));
@@ -115,12 +115,12 @@ TYPED_TEST(SdbusTestObject, SetsPropertyAsynchronouslyViaPropertiesInterface)
     std::promise<void> promise;
     auto future = promise.get_future();
 
-    this->m_proxy->SetAsync(INTERFACE_NAME, "action", sdbus::Variant{newActionValue}, [&](const sdbus::Error* err)
+    this->m_proxy->SetAsync(INTERFACE_NAME, "action", sdbus::Variant{newActionValue}, [&](std::optional<sdbus::Error> err)
     {
-        if (err == nullptr)
+        if (!err)
             promise.set_value();
         else
-            promise.set_exception(std::make_exception_ptr(*err));
+            promise.set_exception(std::make_exception_ptr(*std::move(err)));
     });
 
     ASSERT_NO_THROW(future.get());
@@ -152,12 +152,12 @@ TYPED_TEST(SdbusTestObject, GetsAllPropertiesAsynchronouslyViaPropertiesInterfac
     std::promise<std::map<std::string, sdbus::Variant>> promise;
     auto future = promise.get_future();
 
-    this->m_proxy->GetAllAsync(INTERFACE_NAME, [&](const sdbus::Error* err, std::map<std::string, sdbus::Variant> value)
+    this->m_proxy->GetAllAsync(INTERFACE_NAME, [&](std::optional<sdbus::Error> err, std::map<std::string, sdbus::Variant> value)
     {
-        if (err == nullptr)
+        if (!err)
             promise.set_value(std::move(value));
         else
-            promise.set_exception(std::make_exception_ptr(*err));
+            promise.set_exception(std::make_exception_ptr(*std::move(err)));
     });
     const auto properties = future.get();
 

--- a/tests/integrationtests/TestProxy.cpp
+++ b/tests/integrationtests/TestProxy.cpp
@@ -85,7 +85,7 @@ void TestProxy::onSignalWithoutRegistration(const sdbus::Struct<std::string, sdb
     m_gotSignalWithSignature = true;
 }
 
-void TestProxy::onDoOperationReply(uint32_t returnValue, const sdbus::Error* error)
+void TestProxy::onDoOperationReply(uint32_t returnValue, std::optional<sdbus::Error> error)
 {
     if (m_DoOperationClientSideAsyncReplyHandler)
         m_DoOperationClientSideAsyncReplyHandler(returnValue, error);
@@ -99,7 +99,7 @@ void TestProxy::onPropertiesChanged( const std::string& interfaceName
         m_onPropertiesChangedHandler(interfaceName, changedProperties, invalidatedProperties);
 }
 
-void TestProxy::installDoOperationClientSideAsyncReplyHandler(std::function<void(uint32_t res, const sdbus::Error* err)> handler)
+void TestProxy::installDoOperationClientSideAsyncReplyHandler(std::function<void(uint32_t res, std::optional<sdbus::Error> err)> handler)
 {
     m_DoOperationClientSideAsyncReplyHandler = std::move(handler);
 }
@@ -117,9 +117,9 @@ sdbus::PendingAsyncCall TestProxy::doOperationClientSideAsync(uint32_t param)
     return getProxy().callMethodAsync("doOperation")
                      .onInterface(sdbus::test::INTERFACE_NAME)
                      .withArguments(param)
-                     .uponReplyInvoke([this](const sdbus::Error* error, uint32_t returnValue)
+                     .uponReplyInvoke([this](std::optional<sdbus::Error> error, uint32_t returnValue)
                                       {
-                                          this->onDoOperationReply(returnValue, error);
+                                          this->onDoOperationReply(returnValue, std::move(error));
                                       });
 }
 
@@ -143,9 +143,9 @@ void TestProxy::doErroneousOperationClientSideAsync()
 {
     getProxy().callMethodAsync("throwError")
               .onInterface(sdbus::test::INTERFACE_NAME)
-              .uponReplyInvoke([this](const sdbus::Error* error)
+              .uponReplyInvoke([this](std::optional<sdbus::Error> error)
                                {
-                                   this->onDoOperationReply(0, error);
+                                   this->onDoOperationReply(0, std::move(error));
                                });
 }
 
@@ -163,9 +163,9 @@ void TestProxy::doOperationClientSideAsyncWithTimeout(const std::chrono::microse
               .onInterface(sdbus::test::INTERFACE_NAME)
               .withTimeout(timeout)
               .withArguments(param)
-              .uponReplyInvoke([this](const sdbus::Error* error, uint32_t returnValue)
+              .uponReplyInvoke([this](std::optional<sdbus::Error> error, uint32_t returnValue)
                                {
-                                   this->onDoOperationReply(returnValue, error);
+                                   this->onDoOperationReply(returnValue, std::move(error));
                                });
 }
 

--- a/tests/integrationtests/TestProxy.h
+++ b/tests/integrationtests/TestProxy.h
@@ -85,7 +85,7 @@ protected:
     void onSignalWithVariant(const sdbus::Variant& aVariant) override;
 
     void onSignalWithoutRegistration(const sdbus::Struct<std::string, sdbus::Struct<sdbus::Signature>>& s);
-    void onDoOperationReply(uint32_t returnValue, const sdbus::Error* error);
+    void onDoOperationReply(uint32_t returnValue, std::optional<sdbus::Error> error);
 
     // Signals of standard D-Bus interfaces
     void onPropertiesChanged( const std::string& interfaceName
@@ -93,7 +93,7 @@ protected:
                             , const std::vector<std::string>& invalidatedProperties ) override;
 
 public:
-    void installDoOperationClientSideAsyncReplyHandler(std::function<void(uint32_t res, const sdbus::Error* err)> handler);
+    void installDoOperationClientSideAsyncReplyHandler(std::function<void(uint32_t res, std::optional<sdbus::Error> err)> handler);
     uint32_t doOperationWithTimeout(const std::chrono::microseconds &timeout, uint32_t param);
     sdbus::PendingAsyncCall doOperationClientSideAsync(uint32_t param);
     std::future<uint32_t> doOperationClientSideAsync(uint32_t param, with_future_t);
@@ -116,7 +116,7 @@ public: // for tests
     std::atomic<bool> m_gotSignalWithSignature{false};
     std::map<std::string, std::string> m_signatureFromSignal;
 
-    std::function<void(uint32_t res, const sdbus::Error* err)> m_DoOperationClientSideAsyncReplyHandler;
+    std::function<void(uint32_t res, std::optional<sdbus::Error> err)> m_DoOperationClientSideAsyncReplyHandler;
     std::function<void(const std::string&, const std::map<std::string, sdbus::Variant>&, const std::vector<std::string>&)> m_onPropertiesChangedHandler;
 
     std::unique_ptr<const Message> m_signalMsg;
@@ -140,7 +140,7 @@ protected:
     void onSignalWithVariant(const sdbus::Variant&) override {}
 
     void onSignalWithoutRegistration(const sdbus::Struct<std::string, sdbus::Struct<sdbus::Signature>>&) {}
-    void onDoOperationReply(uint32_t, const sdbus::Error*) {}
+    void onDoOperationReply(uint32_t, std::optional<sdbus::Error>) {}
 
     // Signals of standard D-Bus interfaces
     void onPropertiesChanged( const std::string&, const std::map<std::string, sdbus::Variant>&, const std::vector<std::string>& ) override {}

--- a/tests/stresstests/concatenator-proxy.h
+++ b/tests/stresstests/concatenator-proxy.h
@@ -39,12 +39,12 @@ protected:
 
     virtual void onConcatenatedSignal(const std::string& concatenatedString) = 0;
 
-    virtual void onConcatenateReply(const std::string& result, const sdbus::Error* error) = 0;
+    virtual void onConcatenateReply(const std::string& result, std::optional<sdbus::Error> error) = 0;
 
 public:
     sdbus::PendingAsyncCall concatenate(const std::map<std::string, sdbus::Variant>& params)
     {
-        return proxy_->callMethodAsync("concatenate").onInterface(INTERFACE_NAME).withArguments(params).uponReplyInvoke([this](const sdbus::Error* error, const std::string& result){ this->onConcatenateReply(result, error); });
+        return proxy_->callMethodAsync("concatenate").onInterface(INTERFACE_NAME).withArguments(params).uponReplyInvoke([this](std::optional<sdbus::Error> error, const std::string& result){ this->onConcatenateReply(result, std::move(error)); });
     }
 
 private:

--- a/tests/stresstests/sdbus-c++-stress-tests.cpp
+++ b/tests/stresstests/sdbus-c++-stress-tests.cpp
@@ -309,9 +309,9 @@ public:
     }
 
 private:
-    virtual void onConcatenateReply(const std::string& result, [[maybe_unused]] const sdbus::Error* error) override
+    virtual void onConcatenateReply(const std::string& result, [[maybe_unused]] std::optional<sdbus::Error> error) override
     {
-        assert(error == nullptr);
+        assert(error == std::nullopt);
 
         std::stringstream str(result);
         std::string aString;

--- a/tools/xml2cpp-codegen/ProxyGenerator.cpp
+++ b/tools/xml2cpp-codegen/ProxyGenerator.cpp
@@ -251,11 +251,11 @@ std::tuple<std::string, std::string> ProxyGenerator::processMethods(const Nodes&
             }
             else // Async methods implemented through callbacks
             {
-                definitionSS << ".uponReplyInvoke([this](const sdbus::Error* error" << (outArgTypeStr.empty() ? "" : ", ") << outArgTypeStr << ")"
-                                                 "{ this->on" << nameBigFirst << "Reply(" << outArgStr << (outArgStr.empty() ? "" : ", ") << "error); })";
+                definitionSS << ".uponReplyInvoke([this](std::optional<sdbus::Error> error" << (outArgTypeStr.empty() ? "" : ", ") << outArgTypeStr << ")"
+                                                 "{ this->on" << nameBigFirst << "Reply(" << outArgStr << (outArgStr.empty() ? "" : ", ") << "std::move(error)); })";
 
                 asyncDeclarationSS << tab << "virtual void on" << nameBigFirst << "Reply("
-                                   << outArgTypeStr << (outArgTypeStr.empty() ? "" : ", ")  << "const sdbus::Error* error) = 0;" << endl;
+                                   << outArgTypeStr << (outArgTypeStr.empty() ? "" : ", ")  << "std::optional<sdbus::Error> error) = 0;" << endl;
             }
         }
         else if (outArgs.size() > 0)
@@ -359,11 +359,11 @@ std::tuple<std::string, std::string> ProxyGenerator::processProperties(const Nod
                 }
                 else // Async methods implemented through callbacks
                 {
-                    propertySS << ".uponReplyInvoke([this](const sdbus::Error* error, const sdbus::Variant& value)"
-                                                   "{ this->on" << nameBigFirst << "PropertyGetReply(value.get<" << propertyType << ">(), error); })";
+                    propertySS << ".uponReplyInvoke([this](std::optional<sdbus::Error> error, const sdbus::Variant& value)"
+                                                   "{ this->on" << nameBigFirst << "PropertyGetReply(value.get<" << propertyType << ">(), std::move(error)); })";
 
                     asyncDeclarationSS << tab << "virtual void on" << nameBigFirst << "PropertyGetReply("
-                                       << "const " << propertyType << "& value, const sdbus::Error* error) = 0;" << endl;
+                                       << "const " << propertyType << "& value, std::optional<sdbus::Error> error) = 0;" << endl;
                 }
             }
             propertySS << ";" << endl << tab << "}" << endl << endl;
@@ -391,11 +391,11 @@ std::tuple<std::string, std::string> ProxyGenerator::processProperties(const Nod
                 }
                 else // Async methods implemented through callbacks
                 {
-                    propertySS << ".uponReplyInvoke([this](const sdbus::Error* error)"
-                                  "{ this->on" << nameBigFirst << "PropertySetReply(error); })";
+                    propertySS << ".uponReplyInvoke([this](std::optional<sdbus::Error> error)"
+                                  "{ this->on" << nameBigFirst << "PropertySetReply(std::move(error)); })";
 
                     asyncDeclarationSS << tab << "virtual void on" << nameBigFirst << "PropertySetReply("
-                                       << "const sdbus::Error* error) = 0;" << endl;
+                                       << "std::optional<sdbus::Error> error) = 0;" << endl;
                 }
             }
 


### PR DESCRIPTION
This switches from a raw pointer to `std::optional` type to pass prospective call errors to the client (using `std::optional` was not possible years back when sdbus-c++ was based on C++14). This makes the API a little clearer, safer, idiomatically more expressive, and removes potential confusion associated with raw pointers (like ownership, lifetime questions, etc.). However, this is a *breaking* API change (for async users). The upcoming v2 release is a nice candidate to accommodate such a change.

@dleeds-cpi What are your thoughts about it?