### PR TITLE
Add hasProxy to ProxyObjectHolder

### DIFF
--- a/include/sdbus-c++/ProxyInterfaces.h
+++ b/include/sdbus-c++/ProxyInterfaces.h
@@ -69,6 +69,11 @@ namespace sdbus {
             return *proxy_;
         }
 
+        bool hasProxy()
+        {
+            return proxy_ == nullptr;
+        }
+
     private:
         std::unique_ptr<IProxy> proxy_;
     };


### PR DESCRIPTION
The held proxy object can be moved out of the unique_ptr so it is possible to point to null but there is no way to inspect if this is the case.