### PR TITLE
refactor: rename and re-organize CMake options

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,19 +63,19 @@ jobs:
       run: |
         mkdir build
         cd build
-        cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX:PATH=/usr -DCMAKE_CXX_FLAGS="-O0 -g -W -Wextra -Wall -Wnon-virtual-dtor -Werror" -DCMAKE_VERBOSE_MAKEFILE=ON -DBUILD_TESTS=ON -DINSTALL_TESTS=ON -DENABLE_PERF_TESTS=ON -DENABLE_STRESS_TESTS=ON -DBUILD_CODE_GEN=ON ..
+        cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX:PATH=/usr -DCMAKE_CXX_FLAGS="-O0 -g -W -Wextra -Wall -Wnon-virtual-dtor -Werror" -DCMAKE_VERBOSE_MAKEFILE=ON -DSDBUSCPP_INSTALL=ON -DBUILD_TESTS=ON -DSDBUSCPP_BUILD_PERF_TESTS=ON -DSDBUSCPP_BUILD_STRESS_TESTS=ON -DBUILD_CODE_GEN=ON ..
     - name: configure-release
       if: matrix.build == 'shared-libsystemd' && matrix.os == 'ubuntu-22.04'
       run: |
         mkdir build
         cd build
-        cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX:PATH=/usr -DCMAKE_CXX_FLAGS="-O3 -DNDEBUG -W -Wextra -Wall -Wnon-virtual-dtor -Werror" -DCMAKE_VERBOSE_MAKEFILE=ON -DBUILD_TESTS=ON -DINSTALL_TESTS=ON -DENABLE_PERF_TESTS=ON -DENABLE_STRESS_TESTS=ON -DBUILD_CODE_GEN=ON ..
+        cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX:PATH=/usr -DCMAKE_CXX_FLAGS="-O3 -DNDEBUG -W -Wextra -Wall -Wnon-virtual-dtor -Werror" -DCMAKE_VERBOSE_MAKEFILE=ON -DSDBUSCPP_INSTALL=ON -DBUILD_TESTS=ON -DSDBUSCPP_BUILD_PERF_TESTS=ON -DSDBUSCPP_BUILD_STRESS_TESTS=ON -DBUILD_CODE_GEN=ON ..
     - name: configure-with-embedded-libsystemd
       if: matrix.build == 'embedded-static-libsystemd'
       run: |
         mkdir build
         cd build
-        cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX:PATH=/usr -DCMAKE_VERBOSE_MAKEFILE=ON -DBUILD_TESTS=ON -DINSTALL_TESTS=ON -DENABLE_PERF_TESTS=ON -DENABLE_STRESS_TESTS=ON -DBUILD_CODE_GEN=ON -DBUILD_LIBSYSTEMD=ON -DLIBSYSTEMD_VERSION=252 ..
+        cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX:PATH=/usr -DCMAKE_VERBOSE_MAKEFILE=ON -DSDBUSCPP_INSTALL=ON -DBUILD_TESTS=ON -DSDBUSCPP_BUILD_PERF_TESTS=ON -DSDBUSCPP_BUILD_STRESS_TESTS=ON -DBUILD_CODE_GEN=ON -DSDBUSCPP_BUILD_LIBSYSTEMD=ON -DSDBUSCPP_LIBSYSTEMD_VERSION=252 ..
     - name: make
       run: |
         cd build
@@ -112,7 +112,7 @@ jobs:
         prepare: |
           pkg install -y cmake ninja pkgconf basu expat googletest
         run: |
-          cmake -B _build -G Ninja -DBUILD_CODE_GEN=ON -DBUILD_TESTS=ON -DINSTALL_TESTS=ON -DENABLE_PERF_TESTS=ON -DENABLE_STRESS_TESTS=ON
+          cmake -B _build -G Ninja -DSDBUSCPP_INSTALL=ON -DBUILD_CODE_GEN=ON -DBUILD_TESTS=ON -DENABLE_PERF_TESTS=ON -DSDBUSCPP_BUILD_STRESS_TESTS=ON
           cmake --build _build
           cmake --install _build
           pkg install -y dbus

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,67 @@ project(sdbus-c++ VERSION 2.0.0 LANGUAGES C CXX)
 
 include(GNUInstallDirs) # Installation directories for `install` command and pkgconfig file
 
+# -------------------------------
+# CONFIGURATION OPTIONS
+# -------------------------------
+
+option(SDBUSCPP_BUILD_LIBSYSTEMD "Fetch & build libsystemd static library and make it part of libsdbus-c++, instead of searching for libsystemd in the system" OFF)
+if(SDBUSCPP_BUILD_LIBSYSTEMD)
+    set(SDBUSCPP_LIBSYSTEMD_VERSION "242" CACHE STRING "libsystemd version (>=239) to build and incorporate into libsdbus-c++")
+    set(SDBUSCPP_LIBSYSTEMD_EXTRA_CONFIG_OPTS "" CACHE STRING "Additional configuration options to be passed as-is to libsystemd build system")
+endif()
+option(SDBUSCPP_INSTALL "Enable installation of sdbus-c++ (downstream projects embedding sdbus-c++ may want to turn this OFF)" ON)  #TODO: new, honor
+# TODO: Continue here with search&replace old names with new names
+option(SDBUSCPP_BUILD_TESTS "Build tests" OFF)
+if (SDBUSCPP_BUILD_TESTS)
+    option(SDBUSCPP_BUILD_PERF_TESTS "Build also sdbus-c++ performance tests" OFF) # tranferred from tests/cmake
+    option(SDBUSCPP_BUILD_STRESS_TESTS "Build also sdbus-c++ stress tests" OFF) # tranferred from tests/cmake
+    set(SDBUSCPP_TESTS_INSTALL_PATH "tests/${PROJECT_NAME}" CACHE STRING "Specifies where the test binaries will be installed")  # tranferred from tests/cmake
+    set(SDBUSCPP_GOOGLETEST_VERSION 1.10.0 CACHE STRING "Version of gmock library to use") # tranferred from tests/cmake
+    set(SDBUSCPP_GOOGLETEST_GIT_REPO "https://github.com/google/googletest.git" CACHE STRING "A git repo to clone and build googletest from if gmock is not found in the system") # tranferred from tests/cmake
+endif()
+# TODO: add more embedded options from sub=-cmakefiles
+option(SDBUSCPP_BUILD_CODEGEN "Build generator tool for C++ native bindings" OFF)
+option(SDBUSCPP_BUILD_EXAMPLES "Build example programs" OFF)
+option(SDBUSCPP_BUILD_DOCS "Build documentation for sdbus-c++" ON) # TODO: renamed
+if(SDBUSCPP_BUILD_DOCS)
+    option(SDBUSCPP_BUILD_DOXYGEN_DOCS "Build doxygen documentation for sdbus-c++ API" OFF)
+endif()
+#option(SDBUSCPP_CLANG_TIDY "Co-compile with clang-tidy static analyzer" OFF)
+#option(SDBUSCPP_COVERAGE "Build sdbus-c++ with code coverage instrumentation" OFF)
+# We promote the BUILD_SHARED_LIBS flag to a (global) option only if we are the main project
+if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
+    option(BUILD_SHARED_LIBS "Build shared libraries (.so) instead of static ones (.a)" ON)
+endif()
+
+message(STATUS "")
+message(STATUS "  *******************************************")
+message(STATUS "  *         SDBUS-C++ CONFIGURATION         *")
+message(STATUS "  *******************************************")
+message(STATUS "")
+message(STATUS "  SDBUSCPP_BUILD_LIBSYSTEMD: ${SDBUSCPP_BUILD_LIBSYSTEMD}")
+if(SDBUSCPP_BUILD_LIBSYSTEMD)
+    message(STATUS "    SDBUSCPP_LIBSYSTEMD_VERSION: ${SDBUSCPP_LIBSYSTEMD_VERSION}")
+    message(STATUS "    SDBUSCPP_LIBSYSTEMD_EXTRA_CONFIG_OPTS: ${SDBUSCPP_LIBSYSTEMD_EXTRA_CONFIG_OPTS}")
+endif()
+message(STATUS "  SDBUSCPP_INSTALL: ${SDBUSCPP_INSTALL}")
+message(STATUS "  SDBUSCPP_BUILD_TESTS: ${SDBUSCPP_BUILD_TESTS}")
+if(SDBUSCPP_BUILD_TESTS)
+    message(STATUS "    SDBUSCPP_BUILD_PERF_TESTS: ${SDBUSCPP_BUILD_PERF_TESTS}")
+    message(STATUS "    SDBUSCPP_BUILD_STRESS_TESTS: ${SDBUSCPP_BUILD_STRESS_TESTS}")
+    message(STATUS "    SDBUSCPP_TESTS_INSTALL_PATH: ${SDBUSCPP_TESTS_INSTALL_PATH}")
+    message(STATUS "    SDBUSCPP_GOOGLETEST_VERSION: ${SDBUSCPP_GOOGLETEST_VERSION}")
+    message(STATUS "    SDBUSCPP_GOOGLETEST_GIT_REPO: ${SDBUSCPP_GOOGLETEST_GIT_REPO}")
+endif()
+message(STATUS "  SDBUSCPP_BUILD_CODEGEN: ${SDBUSCPP_BUILD_CODEGEN}")
+message(STATUS "  SDBUSCPP_BUILD_EXAMPLES: ${SDBUSCPP_BUILD_EXAMPLES}")
+message(STATUS "  SDBUSCPP_BUILD_DOCS: ${SDBUSCPP_BUILD_DOCS}")
+if(SDBUSCPP_BUILD_DOCS)
+    message(STATUS "    SDBUSCPP_BUILD_DOXYGEN_DOCS: ${SDBUSCPP_BUILD_DOXYGEN_DOCS}")
+endif()
+message(STATUS "  BUILD_SHARED_LIBS: ${BUILD_SHARED_LIBS}")
+message(STATUS "")
+
 #-------------------------------
 # PERFORMING CHECKS & PREPARING THE DEPENDENCIES
 #-------------------------------
@@ -15,9 +76,7 @@ include(GNUInstallDirs) # Installation directories for `install` command and pkg
 set(LIBSYSTEMD_IMPL "systemd")
 set(LIBSYSTEMD_LIB "libsystemd")
 
-option(BUILD_LIBSYSTEMD "Build libsystemd static library and incorporate it into libsdbus-c++" OFF)
-
-if(NOT BUILD_LIBSYSTEMD)
+if(NOT SDBUSCPP_BUILD_LIBSYSTEMD)
     find_package(PkgConfig REQUIRED)
     pkg_check_modules(Systemd IMPORTED_TARGET GLOBAL libsystemd>=238)
     if(NOT TARGET PkgConfig::Systemd)
@@ -41,13 +100,13 @@ if(NOT BUILD_LIBSYSTEMD)
         message(FATAL_ERROR "libsystemd of version at least 238 is required, but was not found "
                             "(if you have systemd in your OS, you may want to install package containing pkgconfig "
                             " files for libsystemd library. On Ubuntu, that is libsystemd-dev. "
-                            " Alternatively, you may turn BUILD_LIBSYSTEMD on for sdbus-c++ to download, build "
-                            "and incorporate libsystemd as embedded library within sdbus-c++)")
+                            " Alternatively, you may turn SDBUSCPP_BUILD_LIBSYSTEMD on for sdbus-c++ to download, "
+                            " build and incorporate libsystemd as embedded library within sdbus-c++)")
     endif()
     add_library(Systemd::Libsystemd ALIAS PkgConfig::Systemd)
     string(REGEX MATCHALL "([0-9]+)" SYSTEMD_VERSION_LIST "${Systemd_VERSION}")
-    list(GET SYSTEMD_VERSION_LIST 0 LIBSYSTEMD_VERSION)
-    message(STATUS "Building with libsystemd v${LIBSYSTEMD_VERSION}")
+    list(GET SYSTEMD_VERSION_LIST 0 SDBUSCPP_LIBSYSTEMD_VERSION)
+    message(STATUS "Building with libsystemd v${SDBUSCPP_LIBSYSTEMD_VERSION}")
 else()
     # Build static libsystemd library as an external project
     include(cmake/LibsystemdExternalProject.cmake)
@@ -120,16 +179,11 @@ set(CMAKE_CXX_STANDARD 17)
 set(SDBUSCPP_VERSION_MAJOR "${PROJECT_VERSION_MAJOR}")
 set(SDBUSCPP_VERSION "${PROJECT_VERSION}")
 
-# We promote the BUILD_SHARED_LIBS flag to a (global) option only if we are the main project
-if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
-    option(BUILD_SHARED_LIBS "Build shared libraries (.so) instead of static ones (.a)" ON)
-endif()
-
 # Having an object target allows unit tests to reuse already built sources without re-building
 add_library(sdbus-c++-objlib OBJECT ${SDBUSCPP_SRCS})
 target_compile_definitions(sdbus-c++-objlib PRIVATE
     BUILD_LIB=1
-    LIBSYSTEMD_VERSION=${LIBSYSTEMD_VERSION}
+    LIBSYSTEMD_VERSION=${SDBUSCPP_LIBSYSTEMD_VERSION}
     SDBUS_${LIBSYSTEMD_IMPL}
     SDBUS_HEADER=<${LIBSYSTEMD_IMPL}/sd-bus.h>)
 target_include_directories(sdbus-c++-objlib PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
@@ -137,7 +191,7 @@ target_include_directories(sdbus-c++-objlib PUBLIC $<BUILD_INTERFACE:${CMAKE_CUR
 if(BUILD_SHARED_LIBS)
     set_target_properties(sdbus-c++-objlib PROPERTIES POSITION_INDEPENDENT_CODE ON)
 endif()
-if(BUILD_LIBSYSTEMD)
+if(SDBUSCPP_BUILD_LIBSYSTEMD)
     add_dependencies(sdbus-c++-objlib LibsystemdBuildProject)
 endif()
 target_link_libraries(sdbus-c++-objlib
@@ -156,27 +210,10 @@ set_target_properties(sdbus-c++
 target_link_libraries(sdbus-c++ PRIVATE sdbus-c++-objlib)
 
 #----------------------------------
-# INSTALLATION
-#----------------------------------
-set(EXPORT_SET sdbus-c++)
-if(NOT BUILD_SHARED_LIBS)
-    list(APPEND EXPORT_SET "sdbus-c++-objlib")
-endif()
-
-install(TARGETS ${EXPORT_SET}
-        EXPORT sdbus-c++-targets
-        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT runtime
-        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT runtime NAMELINK_COMPONENT dev
-        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT dev
-        PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${SDBUSCPP_INCLUDE_SUBDIR} COMPONENT dev)
-
-#----------------------------------
 # TESTS
 #----------------------------------
 
-option(BUILD_TESTS "Build tests (default OFF)" OFF)
-
-if(BUILD_TESTS)
+if(SDBUSCPP_BUILD_TESTS)
     message(STATUS "Building with tests")
     enable_testing()
     add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/tests")
@@ -186,9 +223,7 @@ endif()
 # UTILS
 #----------------------------------
 
-option(BUILD_CODE_GEN "Build and install interface stub code generator (default OFF)" OFF)
-
-if(BUILD_CODE_GEN)
+if(SDBUSCPP_BUILD_CODEGEN)
     message(STATUS "Building with code generator tool")
     add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/tools")
 endif()
@@ -197,9 +232,7 @@ endif()
 # EXAMPLES
 #----------------------------------
 
-option(BUILD_EXAMPLES "Build example programs (default OFF)" OFF)
-
-if(BUILD_EXAMPLES)
+if(SDBUSCPP_BUILD_EXAMPLES)
     message(STATUS "Building with examples")
     add_subdirectory(examples)
 endif()
@@ -208,13 +241,9 @@ endif()
 # DOCUMENTATION
 #----------------------------------
 
-option(BUILD_DOC "Build documentation for sdbus-c++" ON)
-
-if(BUILD_DOC)
+if(SDBUSCPP_BUILD_DOCS)
     message(STATUS "Building with documentation")
-    option(BUILD_DOXYGEN_DOC "Build doxygen documentation for sdbus-c++ API" OFF)
     add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/docs")
-    install(FILES README README.md NEWS COPYING ChangeLog AUTHORS DESTINATION ${CMAKE_INSTALL_DOCDIR} COMPONENT doc)
 endif()
 
 #----------------------------------
@@ -223,39 +252,58 @@ endif()
 
 include(CMakePackageConfigHelpers)
 
-install(EXPORT sdbus-c++-targets
-        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/sdbus-c++
-        NAMESPACE SDBusCpp::
-        COMPONENT dev)
-
 configure_package_config_file(cmake/sdbus-c++-config.cmake.in cmake/sdbus-c++-config.cmake
                               INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/sdbus-c++)
 write_basic_package_version_file(cmake/sdbus-c++-config-version.cmake COMPATIBILITY SameMajorVersion)
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/cmake/sdbus-c++-config.cmake
-              ${CMAKE_CURRENT_BINARY_DIR}/cmake/sdbus-c++-config-version.cmake
-        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/sdbus-c++
-        COMPONENT dev)
 
-if(BUILD_SHARED_LIBS AND (BUILD_LIBSYSTEMD OR Systemd_LINK_LIBRARIES MATCHES "/libsystemd\.a(;|$)"))
+if(BUILD_SHARED_LIBS AND (SDBUSCPP_BUILD_LIBSYSTEMD OR Systemd_LINK_LIBRARIES MATCHES "/libsystemd\.a(;|$)"))
     set(PKGCONFIG_REQS ".private")
 else()
     set(PKGCONFIG_REQS "")
 endif()
 set(PKGCONFIG_DEPS ${LIBSYSTEMD_LIB})
 configure_file(pkgconfig/sdbus-c++.pc.in pkgconfig/sdbus-c++.pc @ONLY)
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/pkgconfig/sdbus-c++.pc
-        DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig COMPONENT dev)
 
 #----------------------------------
-# CPack
+# INSTALLATION
 #----------------------------------
+
+if(SDBUSCPP_INSTALL)
+    set(EXPORT_SET sdbus-c++)
+    if(NOT BUILD_SHARED_LIBS)
+        list(APPEND EXPORT_SET "sdbus-c++-objlib")
+    endif()
+    install(TARGETS ${EXPORT_SET}
+            EXPORT sdbus-c++-targets
+            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT runtime
+            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT runtime NAMELINK_COMPONENT dev
+            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT dev
+            PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${SDBUSCPP_INCLUDE_SUBDIR} COMPONENT dev)
+    install(EXPORT sdbus-c++-targets
+            DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/sdbus-c++
+            NAMESPACE SDBusCpp::
+            COMPONENT dev)
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/cmake/sdbus-c++-config.cmake
+            ${CMAKE_CURRENT_BINARY_DIR}/cmake/sdbus-c++-config-version.cmake
+            DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/sdbus-c++
+            COMPONENT dev)
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/pkgconfig/sdbus-c++.pc
+            DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig COMPONENT dev)
+    if(SDBUSCPP_BUILD_DOCS)
+        install(FILES README README.md NEWS COPYING ChangeLog AUTHORS DESTINATION ${CMAKE_INSTALL_DOCDIR} COMPONENT doc)
+    endif()
+endif()
+
+#----------------------------------
+# CPACK
+#----------------------------------
+
 set(CPACK_PACKAGE_VENDOR "Kistler")
-set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "high-level C++ D-Bus library")
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "High-level C++ D-Bus library")
 set(CPACK_PACKAGE_CONTACT "info@kistler.com")
 set(CPACK_RESOURCE_FILE_README "${CMAKE_CURRENT_SOURCE_DIR}/README.md")
 set(CPACK_COMPONENTS_ALL runtime dev doc)
 set(CPACK_COMPONENT_DEV_DEPENDS "runtime")
-
 # specific for DEB generator
 set(CPACK_DEB_COMPONENT_INSTALL ON)
 set(CPACK_DEBIAN_RUNTIME_DEBUGINFO_PACKAGE ON)

--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ $ sudo cmake --build . --target install
 
 ### CMake configuration flags for sdbus-c++
 
-* `BUILD_CODE_GEN` [boolean]
+* `SDBUSCPP_BUILD_CODEGEN` [boolean]
 
-  Option for building the stub code generator `sdbus-c++-xml2cpp` for generating the adaptor and proxy interfaces out of the D-Bus IDL XML description. Default value: `OFF`. Use `-DBUILD_CODE_GEN=ON` flag to turn on building the code gen.
+  Option for building the stub code generator `sdbus-c++-xml2cpp` for generating the adaptor and proxy interfaces out of the D-Bus IDL XML description. Default value: `OFF`. Use `-DSDBUSCPP_BUILD_CODEGEN=ON` flag to turn on building the code gen.
 
-* `BUILD_DOC` [boolean]
+* `SDBUSCPP_BUILD_DOCS` [boolean]
 
   Option for including sdbus-c++ documentation files and tutorials. Default value: `ON`. With this option turned on, you may also enable/disable the following option:
 
@@ -38,35 +38,31 @@ $ sudo cmake --build . --target install
 
       Option for building Doxygen documentation of sdbus-c++ API. If enabled, the documentation must still be built explicitly through `cmake --build . --target doc`. Default value: `OFF`. Use `-DBUILD_DOXYGEN_DOC=OFF` to disable searching for Doxygen and building Doxygen documentation of sdbus-c++ API.
 
-* `BUILD_TESTS` [boolean]
+* `SDBUSCPP_BUILD_TESTS` [boolean]
 
   Option for building sdbus-c++ unit and integration tests, invokable by `cmake --build . --target test` (Note: before invoking `cmake --build . --target test`, make sure you copy `tests/integrationtests/files/org.sdbuscpp.integrationtests.conf` file to `/etc/dbus-1/system.d` directory). That incorporates downloading and building static libraries of Google Test. Default value: `OFF`. Use `-DBUILD_TESTS=ON` to enable building the tests. With this option turned on, you may also enable/disable the following options:
 
-    * `ENABLE_PERF_TESTS` [boolean]
+    * `SDBUSCPP_BUILD_PERF_TESTS` [boolean]
 
       Option for building sdbus-c++ performance tests. Default value: `OFF`.
 
-    * `ENABLE_STRESS_TESTS` [boolean]
+    * `SDBUSCPP_BUILD_STRESS_TESTS` [boolean]
 
       Option for building sdbus-c++ stress tests. Default value: `OFF`.
 
-    * `INSTALL_TESTS` [boolean]
-
-      Option for installing tests that were built. Default value: `OFF`.
-
-    * `TESTS_INSTALL_PATH` [string]
+    * `SDBUSCPP_TESTS_INSTALL_PATH` [string]
 
       Path where the test binaries shall get installed. Default value: `${CMAKE_INSTALL_PREFIX}/tests/sdbus-c++` (previously: `/opt/test/bin`).
 
-* `BUILD_LIBSYSTEMD` [boolean]
+* `SDBUSCPP_BUILD_LIBSYSTEMD` [boolean]
 
   Option for building libsystemd dependency library automatically when sdbus-c++ is built, and making libsystemd an integral part of sdbus-c++ library. Default value: `OFF`. Might be very helpful in non-systemd environments where libsystemd shared library is unavailable (see [Solving libsystemd dependency](docs/using-sdbus-c++.md#solving-libsystemd-dependency) for more information). With this option turned on, you may also provide the following configuration flag:
 
-    * `LIBSYSTEMD_VERSION` [string]
+    * `SDBUSCPP_LIBSYSTEMD_VERSION` [string]
 
       Defines version of systemd to be downloaded, built and integrated into sdbus-c++. Default value: `242`.
 
-    * `LIBSYSTEMD_EXTRA_CONFIG_OPTS` [string]
+    * `SDBUSCPP_LIBSYSTEMD_EXTRA_CONFIG_OPTS` [string]
 
       Additional options to be passed as-is to the libsystemd build system (meson for systemd v242) in its configure step. Can be used for passing e.g. toolchain file path in case of cross builds. Default value: empty.
 
@@ -78,7 +74,7 @@ $ sudo cmake --build . --target install
 
   This is a global CMake flag, promoted in sdbus-c++ project to a CMake option. Use this to control whether sdbus-c++ is built as either a shared or static library. Default value: `ON`.
 
-* `BUILD_EXAMPLES` [boolean]
+* `SDBUSCPP_BUILD_EXAMPLES` [boolean]
 
   Build example programs which are located in the _example_ directory. Examples are not installed. Default value: `OFF`
 
@@ -89,7 +85,7 @@ Dependencies
 * `libsystemd`/`libelogind`/`basu` - libraries containing sd-bus implementation that sdbus-c++ is written around. In case of `libsystemd` and `libelogind`, version >= 236 is needed. (In case you have a non-systemd environment, don't worry, see [Solving libsystemd dependency](docs/using-sdbus-c++.md#solving-libsystemd-dependency) for more information.)
 * `googletest` - google unit testing framework, only necessary when building tests, will be downloaded and built automatically.
 * `pkgconfig` - required for sdbus-c++ to be able to find some dependency packages.
-* `expat` - necessary when building xml2cpp code generator (`BUILD_CODE_GEN` option is ON).
+* `expat` - necessary when building the xml2cpp binding code generator (`SDBUSCPP_BUILD_CODEGEN` option is ON).
 
 Licensing
 ---------

--- a/cmake/LibsystemdExternalProject.cmake
+++ b/cmake/LibsystemdExternalProject.cmake
@@ -18,9 +18,6 @@ if (NOT CAP_FOUND)
     find_library(CAP_LIBRARIES cap) # Compat with Ubuntu 14.04 which ships libcap w/o .pc file
 endif()
 
-set(LIBSYSTEMD_VERSION "242" CACHE STRING "libsystemd version (>=239) to build and incorporate into libsdbus-c++")
-set(LIBSYSTEMD_EXTRA_CONFIG_OPTS "" CACHE STRING "Additional configuration options to be passed as-is to libsystemd build system")
-
 if(NOT CMAKE_BUILD_TYPE)
     set(LIBSYSTEMD_BUILD_TYPE "plain")
 elseif(CMAKE_BUILD_TYPE STREQUAL "Debug")
@@ -29,24 +26,24 @@ else()
     set(LIBSYSTEMD_BUILD_TYPE "release")
 endif()
 
-if(LIBSYSTEMD_VERSION LESS "239")
+if(SDBUSCPP_LIBSYSTEMD_VERSION LESS "239")
     message(FATAL_ERROR "Only libsystemd version >=239 can be built as static part of sdbus-c++")
 endif()
-if(LIBSYSTEMD_VERSION GREATER "240")
+if(SDBUSCPP_LIBSYSTEMD_VERSION GREATER "240")
     set(BUILD_VERSION_H ${NINJA} -C <BINARY_DIR> version.h)
 endif()
 
-message(STATUS "Building with embedded libsystemd v${LIBSYSTEMD_VERSION}")
+message(STATUS "Building with embedded libsystemd v${SDBUSCPP_LIBSYSTEMD_VERSION}")
 
 include(ExternalProject)
 ExternalProject_Add(LibsystemdBuildProject
-                    PREFIX libsystemd-v${LIBSYSTEMD_VERSION}
+                    PREFIX libsystemd-v${SDBUSCPP_LIBSYSTEMD_VERSION}
                     GIT_REPOSITORY    https://github.com/systemd/systemd-stable.git
-                    GIT_TAG           v${LIBSYSTEMD_VERSION}-stable
+                    GIT_TAG           v${SDBUSCPP_LIBSYSTEMD_VERSION}-stable
                     GIT_SHALLOW       1
                     UPDATE_COMMAND    ""
                     CONFIGURE_COMMAND ${CMAKE_COMMAND} -E remove <BINARY_DIR>/*
-                              COMMAND ${MESON} --prefix=<INSTALL_DIR> --buildtype=${LIBSYSTEMD_BUILD_TYPE} -Drootprefix=<INSTALL_DIR> -Dstatic-libsystemd=pic -Dselinux=false <SOURCE_DIR> <BINARY_DIR> ${LIBSYSTEMD_EXTRA_CONFIG_OPTS}
+                              COMMAND ${MESON} --prefix=<INSTALL_DIR> --buildtype=${LIBSYSTEMD_BUILD_TYPE} -Drootprefix=<INSTALL_DIR> -Dstatic-libsystemd=pic -Dselinux=false <SOURCE_DIR> <BINARY_DIR> ${SDBUSCPP_LIBSYSTEMD_EXTRA_CONFIG_OPTS}
                     BUILD_COMMAND     ${BUILD_VERSION_H}
                           COMMAND     ${NINJA} -C <BINARY_DIR> libsystemd.a
                     BUILD_ALWAYS      0

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -15,15 +15,19 @@ if(BUILD_DOXYGEN_DOC)
         # workaround bug https://github.com/doxygen/doxygen/pull/6787
         add_custom_command(TARGET doc POST_BUILD
           COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_LIST_DIR}/sdbus-c++-class-diagram.png ${CMAKE_CURRENT_BINARY_DIR}/html/.)
-
-        install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/html DESTINATION ${CMAKE_INSTALL_DOCDIR} OPTIONAL COMPONENT doc)
     else()
         message(WARNING "Documentation enabled, but Doxygen cannot be found")
     endif()
 endif()
 
-install(FILES sdbus-c++-class-diagram.png
-              sdbus-c++-class-diagram.uml
-              systemd-dbus-config.md
-              using-sdbus-c++.md
-        DESTINATION ${CMAKE_INSTALL_DOCDIR} COMPONENT doc)
+if(SDBUSCPP_INSTALL)
+    install(FILES sdbus-c++-class-diagram.png
+                  sdbus-c++-class-diagram.uml
+                  systemd-dbus-config.md
+                  using-sdbus-c++.md
+            DESTINATION ${CMAKE_INSTALL_DOCDIR} COMPONENT doc)
+
+    if (BUILD_DOXYGEN_DOC AND DOXYGEN_FOUND)
+        install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/html DESTINATION ${CMAKE_INSTALL_DOCDIR} OPTIONAL COMPONENT doc)
+    endif()
+endif()

--- a/docs/using-sdbus-c++.md
+++ b/docs/using-sdbus-c++.md
@@ -108,9 +108,9 @@ $ ninja libsystemd.so.0.26.0  # or another version number depending which system
 
 ### Building and distributing libsystemd as part of sdbus-c++
 
-sdbus-c++ provides `BUILD_LIBSYSTEMD` configuration option. When turned on, sdbus-c++ will automatically download and build libsystemd as a static library and make it an opaque part of sdbus-c++ shared library for you. This is the most convenient and effective approach to build, distribute and use sdbus-c++ as a self-contained, systemd-independent library in non-systemd environments. Just make sure your build machine has all dependencies needed by libsystemd build process. That includes, among others, `meson`, `ninja`, `git`, `gperf`, and -- primarily -- libraries and library headers for `libmount`, `libcap` and `librt` (part of glibc). Also, when distributing, make sure these dependency libraries are installed on the production machine.
+sdbus-c++ provides `SDBUSCPP_BUILD_LIBSYSTEMD` configuration option. When turned on, sdbus-c++ will automatically download and build libsystemd as a static library and make it an opaque part of sdbus-c++ shared library for you. This is the most convenient and effective approach to build, distribute and use sdbus-c++ as a self-contained, systemd-independent library in non-systemd environments. Just make sure your build machine has all dependencies needed by libsystemd build process. That includes, among others, `meson`, `ninja`, `git`, `gperf`, and -- primarily -- libraries and library headers for `libmount`, `libcap` and `librt` (part of glibc). Also, when distributing, make sure these dependency libraries are installed on the production machine.
 
-You may additionally set the `LIBSYSTEMD_VERSION` configuration flag to fine-tune the version of systemd to be taken in. (The default value is 242).
+You may additionally set the `SDBUSCPP_LIBSYSTEMD_VERSION` configuration flag to fine-tune the version of systemd to be taken in. (The default value is 242).
 
 Distributing sdbus-c++
 ----------------------

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,6 +1,12 @@
+# Building examples
 
 add_executable(obj-manager-server org.freedesktop.DBus.ObjectManager/obj-manager-server.cpp)
 target_link_libraries(obj-manager-server sdbus-c++)
 
 add_executable(obj-manager-client org.freedesktop.DBus.ObjectManager/obj-manager-client.cpp)
 target_link_libraries(obj-manager-client sdbus-c++)
+
+if(SDBUSCPP_INSTALL)
+    install(TARGETS obj-manager-server DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT examples)
+    install(TARGETS obj-manager-client DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT examples)
+endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,9 +2,6 @@
 # DOWNLOAD AND BUILD OF GOOGLETEST
 #-------------------------------
 
-set(GOOGLETEST_VERSION 1.10.0 CACHE STRING "Version of gmock to use")
-set(GOOGLETEST_GIT_REPO "https://github.com/google/googletest.git" CACHE STRING "A git repo to clone and build googletest from if gmock is not found in the system")
-
 find_package(GTest ${GOOGLETEST_VERSION} CONFIG)
 if (NOT TARGET GTest::gmock)
     # Try pkg-config if GTest was not found through CMake config
@@ -106,14 +103,14 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(sdbus-c++-unit-tests ${UNITTESTS_SRCS})
 target_compile_definitions(sdbus-c++-unit-tests PRIVATE
-    LIBSYSTEMD_VERSION=${LIBSYSTEMD_VERSION}
+    LIBSYSTEMD_VERSION=${SDBUSCPP_LIBSYSTEMD_VERSION}
     SDBUS_${LIBSYSTEMD_IMPL}
     SDBUS_HEADER=<${LIBSYSTEMD_IMPL}/sd-bus.h>)
 target_link_libraries(sdbus-c++-unit-tests sdbus-c++-objlib GTest::gmock)
 
 add_executable(sdbus-c++-integration-tests ${INTEGRATIONTESTS_SRCS})
 target_compile_definitions(sdbus-c++-integration-tests PRIVATE
-    LIBSYSTEMD_VERSION=${LIBSYSTEMD_VERSION}
+    LIBSYSTEMD_VERSION=${SDBUSCPP_LIBSYSTEMD_VERSION}
     SDBUS_${LIBSYSTEMD})
 if(NOT LIBSYSTEMD STREQUAL "basu")
     # Systemd::Libsystemd is included because integration tests use sd-event. Otherwise sdbus-c++ encapsulates and hides libsystemd.
@@ -123,15 +120,11 @@ else()
     target_link_libraries(sdbus-c++-integration-tests sdbus-c++ GTest::gmock)
 endif()
 
-# Manual performance and stress tests
-option(ENABLE_PERF_TESTS "Build and install manual performance tests (default OFF)" OFF)
-option(ENABLE_STRESS_TESTS "Build and install manual stress tests (default OFF)" OFF)
-
-if(ENABLE_PERF_TESTS OR ENABLE_STRESS_TESTS)
+if(SDBUSCPP_BUILD_PERF_TESTS OR SDBUSCPP_BUILD_STRESS_TESTS)
     set(THREADS_PREFER_PTHREAD_FLAG ON)
     find_package(Threads REQUIRED)
 
-    if(ENABLE_PERF_TESTS)
+    if(SDBUSCPP_BUILD_PERF_TESTS)
         message(STATUS "Building with performance tests")
         add_executable(sdbus-c++-perf-tests-client ${STRESSTESTS_CLIENT_SRCS})
         target_link_libraries(sdbus-c++-perf-tests-client sdbus-c++ Threads::Threads)
@@ -139,7 +132,7 @@ if(ENABLE_PERF_TESTS OR ENABLE_STRESS_TESTS)
         target_link_libraries(sdbus-c++-perf-tests-server sdbus-c++ Threads::Threads)
     endif()
 
-    if(ENABLE_STRESS_TESTS)
+    if(SDBUSCPP_BUILD_STRESS_TESTS)
         message(STATUS "Building with stress tests")
         add_executable(sdbus-c++-stress-tests ${STRESSTESTS_SRCS})
         target_link_libraries(sdbus-c++-stress-tests sdbus-c++ Threads::Threads)
@@ -150,25 +143,25 @@ endif()
 # INSTALLATION
 #----------------------------------
 
-option(INSTALL_TESTS "Install tests (default OFF)" OFF)
-
-if(INSTALL_TESTS)
+if(SDBUSCPP_INSTALL)
     include(GNUInstallDirs)
-    set(TESTS_INSTALL_PATH "tests/${PROJECT_NAME}" CACHE STRING "Specifies where the test binaries will be installed")
-
-    install(TARGETS sdbus-c++-unit-tests DESTINATION ${TESTS_INSTALL_PATH} COMPONENT test)
-    install(TARGETS sdbus-c++-integration-tests DESTINATION ${TESTS_INSTALL_PATH} COMPONENT test)
-    install(FILES ${INTEGRATIONTESTS_SOURCE_DIR}/files/org.sdbuscpp.integrationtests.conf DESTINATION ${CMAKE_INSTALL_FULL_SYSCONFDIR}/dbus-1/system.d COMPONENT test)
-
-    if(ENABLE_PERF_TESTS)
-        install(TARGETS sdbus-c++-perf-tests-client DESTINATION ${TESTS_INSTALL_PATH} COMPONENT test)
-        install(TARGETS sdbus-c++-perf-tests-server DESTINATION ${TESTS_INSTALL_PATH} COMPONENT test)
-        install(FILES ${PERFTESTS_SOURCE_DIR}/files/org.sdbuscpp.perftests.conf DESTINATION ${CMAKE_INSTALL_FULL_SYSCONFDIR}/dbus-1/system.d COMPONENT test)
+    install(TARGETS sdbus-c++-unit-tests DESTINATION ${SDBUSCPP_TESTS_INSTALL_PATH} COMPONENT test)
+    install(TARGETS sdbus-c++-integration-tests DESTINATION ${SDBUSCPP_TESTS_INSTALL_PATH} COMPONENT test)
+    install(FILES ${INTEGRATIONTESTS_SOURCE_DIR}/files/org.sdbuscpp.integrationtests.conf
+            DESTINATION ${CMAKE_INSTALL_FULL_SYSCONFDIR}/dbus-1/system.d
+            COMPONENT test)
+    if(SDBUSCPP_BUILD_PERF_TESTS)
+        install(TARGETS sdbus-c++-perf-tests-client DESTINATION ${SDBUSCPP_TESTS_INSTALL_PATH} COMPONENT test)
+        install(TARGETS sdbus-c++-perf-tests-server DESTINATION ${SDBUSCPP_TESTS_INSTALL_PATH} COMPONENT test)
+        install(FILES ${PERFTESTS_SOURCE_DIR}/files/org.sdbuscpp.perftests.conf
+                DESTINATION ${CMAKE_INSTALL_FULL_SYSCONFDIR}/dbus-1/system.d
+                COMPONENT test)
     endif()
-
-    if(ENABLE_STRESS_TESTS)
-        install(TARGETS sdbus-c++-stress-tests DESTINATION ${TESTS_INSTALL_PATH} COMPONENT test)
-        install(FILES ${STRESSTESTS_SOURCE_DIR}/files/org.sdbuscpp.stresstests.conf DESTINATION ${CMAKE_INSTALL_FULL_SYSCONFDIR}/dbus-1/system.d COMPONENT test)
+    if(SDBUSCPP_BUILD_STRESS_TESTS)
+        install(TARGETS sdbus-c++-stress-tests DESTINATION ${SDBUSCPP_TESTS_INSTALL_PATH} COMPONENT test)
+        install(FILES ${STRESSTESTS_SOURCE_DIR}/files/org.sdbuscpp.stresstests.conf
+                DESTINATION ${CMAKE_INSTALL_FULL_SYSCONFDIR}/dbus-1/system.d
+                COMPONENT test)
     endif()
 endif()
 

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -46,30 +46,37 @@ target_link_libraries (sdbus-c++-xml2cpp ${EXPAT_LIBRARIES})
 target_include_directories(sdbus-c++-xml2cpp PRIVATE ${EXPAT_INCLUDE_DIRS})
 
 #----------------------------------
-# INSTALLATION
-#----------------------------------
-
-install(TARGETS sdbus-c++-xml2cpp EXPORT sdbus-c++-tools-targets DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT dev)
-
-#----------------------------------
 # CMAKE CONFIG & PACKAGE CONFIG
 #----------------------------------
 
 include(CMakePackageConfigHelpers)
 
-install(EXPORT sdbus-c++-tools-targets
-        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/sdbus-c++-tools
-        NAMESPACE SDBusCpp::
-        COMPONENT dev)
-
 configure_package_config_file(cmake/sdbus-c++-tools-config.cmake.in cmake/sdbus-c++-tools-config.cmake
                               INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/sdbus-c++)
 write_basic_package_version_file(cmake/sdbus-c++-tools-config-version.cmake COMPATIBILITY SameMajorVersion)
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/cmake/sdbus-c++-tools-config.cmake
-              ${CMAKE_CURRENT_BINARY_DIR}/cmake/sdbus-c++-tools-config-version.cmake
-        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/sdbus-c++-tools
-        COMPONENT dev)
 
 configure_file(pkgconfig/sdbus-c++-tools.pc.in pkgconfig/sdbus-c++-tools.pc @ONLY)
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/pkgconfig/sdbus-c++-tools.pc
-        DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig COMPONENT dev)
+
+#----------------------------------
+# INSTALLATION
+#----------------------------------
+
+if(NOT DEFINED SDBUSCPP_INSTALL)
+    set(SDBUSCPP_INSTALL ON)
+endif()
+
+if (SDBUSCPP_INSTALL)
+    install(TARGETS sdbus-c++-xml2cpp
+            EXPORT sdbus-c++-tools-targets
+            DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT dev)
+    install(EXPORT sdbus-c++-tools-targets
+            DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/sdbus-c++-tools
+            NAMESPACE SDBusCpp::
+            COMPONENT dev)
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/cmake/sdbus-c++-tools-config.cmake
+            ${CMAKE_CURRENT_BINARY_DIR}/cmake/sdbus-c++-tools-config-version.cmake
+            DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/sdbus-c++-tools
+            COMPONENT dev)
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/pkgconfig/sdbus-c++-tools.pc
+            DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig COMPONENT dev)
+endif()


### PR DESCRIPTION
This improves usability of sdbus-c++ in downstream CMake projects. CMake options now have `SDBUSCPP_` prefix so potential conflicts with downstream options/variables are minimized. Also, all configurable options and variables are placed in a single place in root CMake file.