### PR TITLE
chore: rename COMPONENTs in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -275,22 +275,22 @@ if(SDBUSCPP_INSTALL)
     endif()
     install(TARGETS ${EXPORT_SET}
             EXPORT sdbus-c++-targets
-            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT runtime
-            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT runtime NAMELINK_COMPONENT dev
-            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT dev
-            PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${SDBUSCPP_INCLUDE_SUBDIR} COMPONENT dev)
+            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT sdbus-c++-runtime
+            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT sdbus-c++-runtime NAMELINK_COMPONENT sdbus-c++-dev
+            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT sdbus-c++-dev
+            PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${SDBUSCPP_INCLUDE_SUBDIR} COMPONENT sdbus-c++-dev)
     install(EXPORT sdbus-c++-targets
             DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/sdbus-c++
             NAMESPACE SDBusCpp::
-            COMPONENT dev)
+            COMPONENT sdbus-c++-dev)
     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/cmake/sdbus-c++-config.cmake
             ${CMAKE_CURRENT_BINARY_DIR}/cmake/sdbus-c++-config-version.cmake
             DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/sdbus-c++
-            COMPONENT dev)
+            COMPONENT sdbus-c++-dev)
     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/pkgconfig/sdbus-c++.pc
-            DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig COMPONENT dev)
+            DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig COMPONENT sdbus-c++-dev)
     if(SDBUSCPP_BUILD_DOCS)
-        install(FILES README README.md NEWS COPYING ChangeLog AUTHORS DESTINATION ${CMAKE_INSTALL_DOCDIR} COMPONENT doc)
+        install(FILES README README.md NEWS COPYING ChangeLog AUTHORS DESTINATION ${CMAKE_INSTALL_DOCDIR} COMPONENT sdbus-c++-doc)
     endif()
 endif()
 

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -25,9 +25,9 @@ if(SDBUSCPP_INSTALL)
                   sdbus-c++-class-diagram.uml
                   systemd-dbus-config.md
                   using-sdbus-c++.md
-            DESTINATION ${CMAKE_INSTALL_DOCDIR} COMPONENT doc)
+            DESTINATION ${CMAKE_INSTALL_DOCDIR} COMPONENT sdbus-c++-doc)
 
     if (BUILD_DOXYGEN_DOC AND DOXYGEN_FOUND)
-        install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/html DESTINATION ${CMAKE_INSTALL_DOCDIR} OPTIONAL COMPONENT doc)
+        install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/html DESTINATION ${CMAKE_INSTALL_DOCDIR} OPTIONAL COMPONENT sdbus-c++-doc)
     endif()
 endif()

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -7,6 +7,6 @@ add_executable(obj-manager-client org.freedesktop.DBus.ObjectManager/obj-manager
 target_link_libraries(obj-manager-client sdbus-c++)
 
 if(SDBUSCPP_INSTALL)
-    install(TARGETS obj-manager-server DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT examples)
-    install(TARGETS obj-manager-client DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT examples)
+    install(TARGETS obj-manager-server DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT sdbus-c++-examples)
+    install(TARGETS obj-manager-client DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT sdbus-c++-examples)
 endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -145,23 +145,23 @@ endif()
 
 if(SDBUSCPP_INSTALL)
     include(GNUInstallDirs)
-    install(TARGETS sdbus-c++-unit-tests DESTINATION ${SDBUSCPP_TESTS_INSTALL_PATH} COMPONENT test)
-    install(TARGETS sdbus-c++-integration-tests DESTINATION ${SDBUSCPP_TESTS_INSTALL_PATH} COMPONENT test)
+    install(TARGETS sdbus-c++-unit-tests DESTINATION ${SDBUSCPP_TESTS_INSTALL_PATH} COMPONENT sdbus-c++-test)
+    install(TARGETS sdbus-c++-integration-tests DESTINATION ${SDBUSCPP_TESTS_INSTALL_PATH} COMPONENT sdbus-c++-test)
     install(FILES ${INTEGRATIONTESTS_SOURCE_DIR}/files/org.sdbuscpp.integrationtests.conf
             DESTINATION ${CMAKE_INSTALL_FULL_SYSCONFDIR}/dbus-1/system.d
-            COMPONENT test)
+            COMPONENT sdbus-c++-test)
     if(SDBUSCPP_BUILD_PERF_TESTS)
-        install(TARGETS sdbus-c++-perf-tests-client DESTINATION ${SDBUSCPP_TESTS_INSTALL_PATH} COMPONENT test)
-        install(TARGETS sdbus-c++-perf-tests-server DESTINATION ${SDBUSCPP_TESTS_INSTALL_PATH} COMPONENT test)
+        install(TARGETS sdbus-c++-perf-tests-client DESTINATION ${SDBUSCPP_TESTS_INSTALL_PATH} COMPONENT sdbus-c++-test)
+        install(TARGETS sdbus-c++-perf-tests-server DESTINATION ${SDBUSCPP_TESTS_INSTALL_PATH} COMPONENT sdbus-c++-test)
         install(FILES ${PERFTESTS_SOURCE_DIR}/files/org.sdbuscpp.perftests.conf
                 DESTINATION ${CMAKE_INSTALL_FULL_SYSCONFDIR}/dbus-1/system.d
-                COMPONENT test)
+                COMPONENT sdbus-c++-test)
     endif()
     if(SDBUSCPP_BUILD_STRESS_TESTS)
-        install(TARGETS sdbus-c++-stress-tests DESTINATION ${SDBUSCPP_TESTS_INSTALL_PATH} COMPONENT test)
+        install(TARGETS sdbus-c++-stress-tests DESTINATION ${SDBUSCPP_TESTS_INSTALL_PATH} COMPONENT sdbus-c++-test)
         install(FILES ${STRESSTESTS_SOURCE_DIR}/files/org.sdbuscpp.stresstests.conf
                 DESTINATION ${CMAKE_INSTALL_FULL_SYSCONFDIR}/dbus-1/system.d
-                COMPONENT test)
+                COMPONENT sdbus-c++-test)
     endif()
 endif()
 

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -68,15 +68,15 @@ endif()
 if (SDBUSCPP_INSTALL)
     install(TARGETS sdbus-c++-xml2cpp
             EXPORT sdbus-c++-tools-targets
-            DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT dev)
+            DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT sdbus-c++-dev)
     install(EXPORT sdbus-c++-tools-targets
             DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/sdbus-c++-tools
             NAMESPACE SDBusCpp::
-            COMPONENT dev)
+            COMPONENT sdbus-c++-dev)
     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/cmake/sdbus-c++-tools-config.cmake
             ${CMAKE_CURRENT_BINARY_DIR}/cmake/sdbus-c++-tools-config-version.cmake
             DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/sdbus-c++-tools
-            COMPONENT dev)
+            COMPONENT sdbus-c++-dev)
     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/pkgconfig/sdbus-c++-tools.pc
-            DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig COMPONENT dev)
+            DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig COMPONENT sdbus-c++-dev)
 endif()


### PR DESCRIPTION
This, too, is a change for better scoping and usability in downstream CMake projects