### PR TITLE
refactor: rename connection creation methods

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -242,26 +242,22 @@ v1.4.0
 
 v2.x
 - Breaking changes in API/ABI/behavior:
-  - In *synchronous* D-Bus calls, the proxy now **always** blocks the connection for concurrent use until the call finishes (with either a received reply,
-    an error, or time out). If this creates a connection contention issue in your multi-threaded design, use short-lived, light-weight proxies, or call
-    the method in an asynchronous way.
-  - Signatures of callbacks `async_reply_handler`, `signal_handler`, `message_handler` and `property_set_callback` were modified to take input message objects
-    by value, as opposed to non-const ref. Callee assumes ownership of the message. This API is more idiomatic, cleaner and safer.
+  - In *synchronous* D-Bus calls, the proxy now **always** blocks the connection for concurrent use until the call finishes (with either a received reply, an error, or time out). If this creates a connection contention issue in your multi-threaded design, use short-lived, light-weight proxies, or call the method in an asynchronous way.
+  - Signatures of callbacks `async_reply_handler`, `signal_handler`, `message_handler` and `property_set_callback` were modified to take input message objects by value, as opposed to non-const ref. Callee assumes ownership of the message. This API is more idiomatic, cleaner and safer.
   - The `PollData` struct has been extended with a new data member: `eventFd`. All hooks with external event loops shall be modified to poll on this fd as well.
-  - `PollData::timeout_usec` was renamed to `PollData::timeout` and its type has been changed to `std::chrono::microseconds`. This member now holds directly
-    what before had to be obtained through `PollData::getAbsoluteTimeout()` call.
+  - `PollData::timeout_usec` was renamed to `PollData::timeout` and its type has been changed to `std::chrono::microseconds`. This member now holds directly what before had to be obtained through `PollData::getAbsoluteTimeout()` call.
   - `PollData::getRelativeTimeout()` return type was changed to `std::chrono::microseconds`.
   - `IConnection::processPendingRequest()` was renamed to `IConnection::processPendingEvent()`.
   - `Variant` constructor is now explicit.
   - `IProxy::getCurrentlyProcessedMessage()` now returns `Message` by value instead of a raw pointer to it. The caller assumes ownership of the message.
   - Object D-Bus API registration is now done through `IObject::addVTable()` method. The registration holds immediately; no `finishRegistration()` call is needed anymore.
-  - Subscription to signals has been simplified. The subscription is active right after the `registerSignalHandler`/`uponSignal()` call. No need for the final
-    call to `finishRegistration()`. `IProxy::muteSignal()` has been removed in favor of the RAII-based slot object returned by the slot-returning variant of the
-    registration method. Destroying the slot object means unsubscribing from the signal.
+  - Subscription to signals has been simplified. The subscription is active right after the `registerSignalHandler`/`uponSignal()` call. No need for the final call to `finishRegistration()`. `IProxy::muteSignal()` has been removed in favor of the RAII-based slot object returned by the slot-returning variant of the registration method. Destroying the slot object means unsubscribing from the signal.
   - `request_slot` tag was renamed to `return_slot`.
-  - `[[nodiscard]]` attribute has been added to relevant API methods.
   - `ProxyInterfaces::getObjectPath()` was removed, it can be replaced with `ProxyInterfaces::getProxy().getObjectPath()`.
   - `AdaptorInterfaces::getObjectPath()` was removed, it can be replaced with `AdaptorInterfaces::getObject().getObjectPath()`.
+  - `createConnection()` has been removed, to create a connection to the system bus use `createSystemConnection()` instead.
+  - `createDefaultBusConnection()` has been renamed to `createBusConnection()`.
+  - `Proxy`s now by default call `createBusConnection()` to get a connection when the connection is not provided explicitly by the caller, so they connect to either the session bus or the system bus depending on the context (as opposed to always to the system bus like before).
   - Callbacks taking `const sdbus::Error* error` were changed to take `std::optional<sdbus::Error>`, which better expresses the intent and meaning.
   - Types and methods marked deprecated in sdbus-c++ v1 were removed completely.
   - CMake options got `SDBUSCPP_` prefix for better usability and minimal risk of conflicts in downstream CMake projects.
@@ -271,4 +267,5 @@ v2.x
 - Fix for external event loops in which the event loop thread ID was not correctly initialized (now fixed and simplified by not needing the thread ID anymore)
 - Introduce native integration for sd-event
 - Add method to get currently processed message also to `IConnection`
+- `[[nodiscard]]` attribute has been added to relevant API methods.
 - Other simplifications, improvements and fixes springing out from the above refactoring

--- a/include/sdbus-c++/IConnection.h
+++ b/include/sdbus-c++/IConnection.h
@@ -396,32 +396,13 @@ namespace sdbus {
     }
 
     /*!
-     * @brief Creates/opens D-Bus system bus connection
-     *
-     * @return Connection instance
-     *
-     * @throws sdbus::Error in case of failure
-     */
-    [[nodiscard]] std::unique_ptr<sdbus::IConnection> createConnection();
-
-    /*!
-     * @brief Creates/opens D-Bus system bus connection with a name
-     *
-     * @param[in] name Name to request on the connection after its opening
-     * @return Connection instance
-     *
-     * @throws sdbus::Error in case of failure
-     */
-    [[nodiscard]] std::unique_ptr<sdbus::IConnection> createConnection(const std::string& name);
-
-    /*!
      * @brief Creates/opens D-Bus session bus connection when in a user context, and a system bus connection, otherwise.
      *
      * @return Connection instance
      *
      * @throws sdbus::Error in case of failure
      */
-    [[nodiscard]] std::unique_ptr<sdbus::IConnection> createDefaultBusConnection();
+    [[nodiscard]] std::unique_ptr<sdbus::IConnection> createBusConnection();
 
     /*!
      * @brief Creates/opens D-Bus session bus connection with a name when in a user context, and a system bus connection with a name, otherwise.
@@ -431,7 +412,7 @@ namespace sdbus {
      *
      * @throws sdbus::Error in case of failure
      */
-    [[nodiscard]] std::unique_ptr<sdbus::IConnection> createDefaultBusConnection(const std::string& name);
+    [[nodiscard]] std::unique_ptr<sdbus::IConnection> createBusConnection(const std::string& name);
 
     /*!
      * @brief Creates/opens D-Bus system bus connection

--- a/src/Connection.cpp
+++ b/src/Connection.cpp
@@ -872,14 +872,6 @@ int IConnection::PollData::getPollTimeout() const
 
 namespace sdbus::internal {
 
-std::unique_ptr<sdbus::internal::IConnection> createConnection()
-{
-    auto connection = sdbus::createConnection();
-    SCOPE_EXIT{ connection.release(); };
-    auto connectionInternal = dynamic_cast<sdbus::internal::IConnection*>(connection.get());
-    return std::unique_ptr<sdbus::internal::IConnection>(connectionInternal);
-}
-
 std::unique_ptr<sdbus::internal::IConnection> createPseudoConnection()
 {
     auto interface = std::make_unique<sdbus::internal::SdBus>();
@@ -892,25 +884,15 @@ namespace sdbus {
 
 using internal::Connection;
 
-std::unique_ptr<sdbus::IConnection> createConnection()
-{
-    return createSystemBusConnection();
-}
-
-std::unique_ptr<sdbus::IConnection> createConnection(const std::string& name)
-{
-    return createSystemBusConnection(name);
-}
-
-std::unique_ptr<sdbus::IConnection> createDefaultBusConnection()
+std::unique_ptr<sdbus::IConnection> createBusConnection()
 {
     auto interface = std::make_unique<sdbus::internal::SdBus>();
     return std::make_unique<sdbus::internal::Connection>(std::move(interface), Connection::default_bus);
 }
 
-std::unique_ptr<sdbus::IConnection> createDefaultBusConnection(const std::string& name)
+std::unique_ptr<sdbus::IConnection> createBusConnection(const std::string& name)
 {
-    auto conn = createDefaultBusConnection();
+    auto conn = createBusConnection();
     conn->requestName(name);
     return conn;
 }

--- a/src/IConnection.h
+++ b/src/IConnection.h
@@ -98,7 +98,6 @@ namespace sdbus::internal {
                                                         , void* userData ) = 0;
     };
 
-    [[nodiscard]] std::unique_ptr<sdbus::internal::IConnection> createConnection();
     [[nodiscard]] std::unique_ptr<sdbus::internal::IConnection> createPseudoConnection();
 
 }

--- a/src/Proxy.cpp
+++ b/src/Proxy.cpp
@@ -310,7 +310,7 @@ std::unique_ptr<sdbus::IProxy> createProxy( std::unique_ptr<IConnection>&& conne
 std::unique_ptr<sdbus::IProxy> createProxy( std::string destination
                                           , std::string objectPath )
 {
-    auto connection = sdbus::createConnection();
+    auto connection = sdbus::createBusConnection();
 
     auto sdbusConnection = std::unique_ptr<sdbus::internal::IConnection>(dynamic_cast<sdbus::internal::IConnection*>(connection.release()));
     assert(sdbusConnection != nullptr);
@@ -324,7 +324,7 @@ std::unique_ptr<sdbus::IProxy> createProxy( std::string destination
                                           , std::string objectPath
                                           , dont_run_event_loop_thread_t )
 {
-    auto connection = sdbus::createConnection();
+    auto connection = sdbus::createBusConnection();
 
     auto sdbusConnection = std::unique_ptr<sdbus::internal::IConnection>(dynamic_cast<sdbus::internal::IConnection*>(connection.release()));
     assert(sdbusConnection != nullptr);

--- a/tests/integrationtests/DBusConnectionTests.cpp
+++ b/tests/integrationtests/DBusConnectionTests.cpp
@@ -48,12 +48,12 @@ using namespace sdbus::test;
 
 TEST(Connection, CanBeDefaultConstructed)
 {
-    ASSERT_NO_THROW(auto con = sdbus::createConnection());
+    ASSERT_NO_THROW(auto con = sdbus::createBusConnection());
 }
 
 TEST(Connection, CanRequestRegisteredDbusName)
 {
-    auto connection = sdbus::createConnection();
+    auto connection = sdbus::createBusConnection();
 
     ASSERT_NO_THROW(connection->requestName(BUS_NAME))
         << "Perhaps you've forgotten to copy `org.sdbuscpp.integrationtests.conf` file to `/etc/dbus-1/system.d` directory before running the tests?";
@@ -61,13 +61,13 @@ TEST(Connection, CanRequestRegisteredDbusName)
 
 TEST(Connection, CannotRequestNonregisteredDbusName)
 {
-    auto connection = sdbus::createConnection();
+    auto connection = sdbus::createBusConnection();
     ASSERT_THROW(connection->requestName("some.random.not.supported.dbus.name"), sdbus::Error);
 }
 
 TEST(Connection, CanReleasedRequestedName)
 {
-    auto connection = sdbus::createConnection();
+    auto connection = sdbus::createBusConnection();
 
     connection->requestName(BUS_NAME);
     ASSERT_NO_THROW(connection->releaseName(BUS_NAME));
@@ -75,13 +75,13 @@ TEST(Connection, CanReleasedRequestedName)
 
 TEST(Connection, CannotReleaseNonrequestedName)
 {
-    auto connection = sdbus::createConnection();
+    auto connection = sdbus::createBusConnection();
     ASSERT_THROW(connection->releaseName("some.random.nonrequested.name"), sdbus::Error);
 }
 
 TEST(Connection, CanEnterAndLeaveInternalEventLoop)
 {
-    auto connection = sdbus::createConnection();
+    auto connection = sdbus::createBusConnection();
     connection->requestName(BUS_NAME);
 
     std::thread t([&](){ connection->enterEventLoop(); });

--- a/tests/integrationtests/DBusGeneralTests.cpp
+++ b/tests/integrationtests/DBusGeneralTests.cpp
@@ -53,7 +53,7 @@ using ADirectConnection = TestFixtureWithDirectConnection;
 
 TEST(AdaptorAndProxy, CanBeConstructedSuccesfully)
 {
-    auto connection = sdbus::createConnection();
+    auto connection = sdbus::createBusConnection();
     connection->requestName(BUS_NAME);
 
     ASSERT_NO_THROW(TestAdaptor adaptor(*connection, OBJECT_PATH));

--- a/tests/integrationtests/DBusSignalsTests.cpp
+++ b/tests/integrationtests/DBusSignalsTests.cpp
@@ -70,7 +70,7 @@ TYPED_TEST(SdbusTestObject, EmitsSimpleSignalToMultipleProxiesSuccesfully)
 TYPED_TEST(SdbusTestObject, ProxyDoesNotReceiveSignalFromOtherBusName)
 {
     auto otherBusName = BUS_NAME + "2";
-    auto connection2 = sdbus::createConnection(otherBusName);
+    auto connection2 = sdbus::createBusConnection(otherBusName);
     auto adaptor2 = std::make_unique<TestAdaptor>(*connection2, OBJECT_PATH);
 
     adaptor2->emitSimpleSignal();


### PR DESCRIPTION
This PR makes things around connection factories a little more consistent and more intuitive:

* `createConnection()` has been removed. One shall call more expressive `createSystemConnection()` instead to get a connection to the system bus.
* `createDefaultBusConnection()` has been renamed to `createBusConnection()`, so as not to be confused with libsystemd's `default_bus`, which is a different thing (a reusable thread-local bus).
 
`Proxy`ies still by default call `createBusConnection()` to get a connection when the connection is not provided explicitly by the caller, but now `createBusConnection()` does a different thing, so now the `Proxy`ies connect to either session bus or system bus depending on the context (as opposed to always to system bus like before).