### PR TITLE
chore(cmake): implement more flexible searching for sd-bus libs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,19 +12,22 @@ include(GNUInstallDirs) # Installation directories for `install` command and pkg
 # CONFIGURATION OPTIONS
 # -------------------------------
 
-option(SDBUSCPP_BUILD_LIBSYSTEMD "Fetch & build libsystemd static library and make it part of libsdbus-c++, instead of searching for libsystemd in the system" OFF)
-if(SDBUSCPP_BUILD_LIBSYSTEMD)
+option(SDBUSCPP_BUILD_LIBSYSTEMD "Fetch & build libsystemd static library and make it part of libsdbus-c++, instead of searching for it in the system" OFF)
+if(NOT SDBUSCPP_BUILD_LIBSYSTEMD)
+    set(SDBUSCPP_SDBUS_LIB "default" CACHE STRING "sd-bus implementation library to search for and use (default, systemd, elogind, or basu)")
+    set_property(CACHE SDBUSCPP_SDBUS_LIB PROPERTY STRINGS default systemd elogind basu)
+else()
     set(SDBUSCPP_LIBSYSTEMD_VERSION "242" CACHE STRING "libsystemd version (>=239) to build and incorporate into libsdbus-c++")
     set(SDBUSCPP_LIBSYSTEMD_EXTRA_CONFIG_OPTS "" CACHE STRING "Additional configuration options to be passed as-is to libsystemd build system")
 endif()
 option(SDBUSCPP_INSTALL "Enable installation of sdbus-c++ (downstream projects embedding sdbus-c++ may want to turn this OFF)" ON)
 option(SDBUSCPP_BUILD_TESTS "Build tests" OFF)
 if (SDBUSCPP_BUILD_TESTS)
-    option(SDBUSCPP_BUILD_PERF_TESTS "Build also sdbus-c++ performance tests" OFF) # tranferred from tests/cmake
-    option(SDBUSCPP_BUILD_STRESS_TESTS "Build also sdbus-c++ stress tests" OFF) # tranferred from tests/cmake
-    set(SDBUSCPP_TESTS_INSTALL_PATH "tests/${PROJECT_NAME}" CACHE STRING "Specifies where the test binaries will be installed")  # tranferred from tests/cmake
-    set(SDBUSCPP_GOOGLETEST_VERSION 1.10.0 CACHE STRING "Version of gmock library to use") # tranferred from tests/cmake
-    set(SDBUSCPP_GOOGLETEST_GIT_REPO "https://github.com/google/googletest.git" CACHE STRING "A git repo to clone and build googletest from if gmock is not found in the system") # tranferred from tests/cmake
+    option(SDBUSCPP_BUILD_PERF_TESTS "Build also sdbus-c++ performance tests" OFF)
+    option(SDBUSCPP_BUILD_STRESS_TESTS "Build also sdbus-c++ stress tests" OFF)
+    set(SDBUSCPP_TESTS_INSTALL_PATH "tests/${PROJECT_NAME}" CACHE STRING "Specifies where the test binaries will be installed")
+    set(SDBUSCPP_GOOGLETEST_VERSION 1.10.0 CACHE STRING "Version of gmock library to use")
+    set(SDBUSCPP_GOOGLETEST_GIT_REPO "https://github.com/google/googletest.git" CACHE STRING "A git repo to clone and build googletest from if gmock is not found in the system")
 endif()
 option(SDBUSCPP_BUILD_CODEGEN "Build generator tool for C++ native bindings" OFF)
 option(SDBUSCPP_BUILD_EXAMPLES "Build example programs" OFF)
@@ -71,43 +74,56 @@ message(STATUS "")
 # PERFORMING CHECKS & PREPARING THE DEPENDENCIES
 #-------------------------------
 
-set(LIBSYSTEMD_IMPL "systemd")
-set(LIBSYSTEMD_LIB "libsystemd")
-
-if(NOT SDBUSCPP_BUILD_LIBSYSTEMD)
-    find_package(PkgConfig REQUIRED)
-    pkg_check_modules(Systemd IMPORTED_TARGET GLOBAL libsystemd>=238)
-    if(NOT TARGET PkgConfig::Systemd)
-        message(WARNING "libsystemd not found, checking for libelogind instead")
-        pkg_check_modules(Systemd IMPORTED_TARGET GLOBAL libelogind>=238)
-        if(TARGET PkgConfig::Systemd)
-            set(LIBSYSTEMD_IMPL "elogind")
-            set(LIBSYSTEMD_LIB "libelogind")
-            string(REPLACE "." ";" VERSION_LIST ${Systemd_VERSION})
-            list(GET VERSION_LIST 0 Systemd_VERSION)
-        else()
-            message(WARNING "libelogind not found, checking for basu instead")
-            pkg_check_modules(Systemd IMPORTED_TARGET GLOBAL basu)
-            set(LIBSYSTEMD_IMPL "basu")
-            set(LIBSYSTEMD_LIB "basu")
-            # https://git.sr.ht/~emersion/basu/commit/d4d185d29a26
-            set(Systemd_VERSION "240")
-        endif()
+if(SDBUSCPP_BUILD_LIBSYSTEMD)
+    # Build static libsystemd library as an external project
+    include(cmake/LibsystemdExternalProject.cmake)
+    set(SDBUS_IMPL "systemd")
+    set(SDBUS_LIB "libsystemd")
+else()
+    # Search for sd-bus implementations in the system as per user's configuration
+    set(SDBUS_LIBS ${SDBUSCPP_SDBUS_LIB})
+    if(SDBUSCPP_SDBUS_LIB STREQUAL "default")
+        set(SDBUS_LIBS systemd elogind basu) # This is the default search order
     endif()
+
+    find_package(PkgConfig REQUIRED)
+    foreach(LIB ${SDBUS_LIBS})
+        if(LIB STREQUAL "systemd")
+            pkg_check_modules(Systemd IMPORTED_TARGET GLOBAL libsystemd>=238)
+            if(TARGET PkgConfig::Systemd)
+                set(SDBUS_IMPL "systemd")
+                set(SDBUS_LIB "libsystemd")
+                break()
+            endif()
+        elseif(LIB STREQUAL "elogind")
+            pkg_check_modules(Systemd IMPORTED_TARGET GLOBAL libelogind>=238)
+            if(TARGET PkgConfig::Systemd)
+                set(SDBUS_IMPL "elogind")
+                set(SDBUS_LIB "libelogind")
+                string(REPLACE "." ";" VERSION_LIST ${Systemd_VERSION})
+                list(GET VERSION_LIST 0 Systemd_VERSION)
+                break()
+            endif()
+        elseif(LIB STREQUAL "basu")
+            pkg_check_modules(Systemd IMPORTED_TARGET GLOBAL basu)
+            if(TARGET PkgConfig::Systemd)
+                set(SDBUS_IMPL "basu")
+                set(SDBUS_LIB "basu")
+                set(Systemd_VERSION "240") # https://git.sr.ht/~emersion/basu/commit/d4d185d29a26
+                break()
+            endif()
+        else()
+            message(FATAL_ERROR "Unrecognized sd-bus implementation library ${LIB}")
+        endif()
+    endforeach()
+
     if(NOT TARGET PkgConfig::Systemd)
-        message(FATAL_ERROR "libsystemd of version at least 238 is required, but was not found "
-                            "(if you have systemd in your OS, you may want to install package containing pkgconfig "
-                            " files for libsystemd library. On Ubuntu, that is libsystemd-dev. "
-                            " Alternatively, you may turn SDBUSCPP_BUILD_LIBSYSTEMD on for sdbus-c++ to download, "
-                            " build and incorporate libsystemd as embedded library within sdbus-c++)")
+        message(FATAL_ERROR "None of ${SDBUS_LIBS} libraries implementing sd-bus was found (Are their dev packages installed?)")
     endif()
     add_library(Systemd::Libsystemd ALIAS PkgConfig::Systemd)
     string(REGEX MATCHALL "([0-9]+)" SYSTEMD_VERSION_LIST "${Systemd_VERSION}")
     list(GET SYSTEMD_VERSION_LIST 0 SDBUSCPP_LIBSYSTEMD_VERSION)
     message(STATUS "Building with libsystemd v${SDBUSCPP_LIBSYSTEMD_VERSION}")
-else()
-    # Build static libsystemd library as an external project
-    include(cmake/LibsystemdExternalProject.cmake)
 endif()
 
 find_package(Threads REQUIRED)
@@ -182,8 +198,8 @@ add_library(sdbus-c++-objlib OBJECT ${SDBUSCPP_SRCS})
 target_compile_definitions(sdbus-c++-objlib PRIVATE
     BUILD_LIB=1
     LIBSYSTEMD_VERSION=${SDBUSCPP_LIBSYSTEMD_VERSION}
-    SDBUS_${LIBSYSTEMD_IMPL}
-    SDBUS_HEADER=<${LIBSYSTEMD_IMPL}/sd-bus.h>)
+    SDBUS_${SDBUS_IMPL}
+    SDBUS_HEADER=<${SDBUS_IMPL}/sd-bus.h>)
 target_include_directories(sdbus-c++-objlib PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
                                                    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>)
 if(BUILD_SHARED_LIBS)
@@ -259,7 +275,7 @@ if(BUILD_SHARED_LIBS AND (SDBUSCPP_BUILD_LIBSYSTEMD OR Systemd_LINK_LIBRARIES MA
 else()
     set(PKGCONFIG_REQS "")
 endif()
-set(PKGCONFIG_DEPS ${LIBSYSTEMD_LIB})
+set(PKGCONFIG_DEPS ${SDBUS_LIB})
 configure_file(pkgconfig/sdbus-c++.pc.in pkgconfig/sdbus-c++.pc @ONLY)
 
 #----------------------------------

--- a/ChangeLog
+++ b/ChangeLog
@@ -248,4 +248,5 @@ v2.0.0
 - Introduce native integration for sd-event
 - Add method to get currently processed message also to `IConnection`
 - `[[nodiscard]]` attribute has been added to relevant API methods.
+- Add new `SDBUSCPP_SDBUS_LIB` CMake configuration variable determining which sd-bus library shall be picked
 - Other simplifications, improvements and fixes springing out from the above refactoring

--- a/README.md
+++ b/README.md
@@ -56,7 +56,17 @@ $ sudo cmake --build . --target install
 
 * `SDBUSCPP_BUILD_LIBSYSTEMD` [boolean]
 
-  Option for building libsystemd dependency library automatically when sdbus-c++ is built, and making libsystemd an integral part of sdbus-c++ library. Default value: `OFF`. Might be very helpful in non-systemd environments where libsystemd shared library is unavailable (see [Solving libsystemd dependency](docs/using-sdbus-c++.md#solving-libsystemd-dependency) for more information). With this option turned on, you may also provide the following configuration flag:
+  Option for building libsystemd as a sd-bus implementation when sdbus-c++ is built, and making libsystemd an integral part of sdbus-c++ library. Default value: `OFF`, which means that the sd-bus implementation library (`libsystemd`, `libelogind`, or `basu`) will be searched via `pkg-config` in the system.
+
+  This option may be very helpful in environments where sd-bus implementation library is unavailable (see [Solving sd-bus dependency](docs/using-sdbus-c++.md#solving-sd-bus-dependency) for more information).
+  
+  With this option turned off, you may provide the following additional configuration flag:
+
+    * `SDBUSCPP_SDBUS_LIB` [string]
+
+      Defines which sd-bus implementation library to search for and use. Allowed values: `default`, `systemd`, `elogind`, `basu`. Default value: `default`, which means that sdbus-c++ will try to find any of `systemd`, `elogind`, `basu` in the order as listed here.
+
+  With this option turned on, you may provide the following additional configuration flag:
 
     * `SDBUSCPP_LIBSYSTEMD_VERSION` [string]
 
@@ -82,10 +92,10 @@ Dependencies
 ------------
 
 * `C++17` - the library uses C++17 features.
-* `libsystemd`/`libelogind`/`basu` - libraries containing sd-bus implementation that sdbus-c++ is written around. In case of `libsystemd` and `libelogind`, version >= 236 is needed. (In case you have a non-systemd environment, don't worry, see [Solving libsystemd dependency](docs/using-sdbus-c++.md#solving-libsystemd-dependency) for more information.)
+* `libsystemd`/`libelogind`/`basu` - libraries containing sd-bus implementation that sdbus-c++ is written around. In case of `libsystemd` and `libelogind`, version >= 236 is needed. (In case you have you're missing any of those sd-bus implementations, don't worry, see [Solving sd-bus dependency](docs/using-sdbus-c++.md#solving-sd-bus-dependency) for more information.)
 * `googletest` - google unit testing framework, only necessary when building tests, will be downloaded and built automatically.
 * `pkgconfig` - required for sdbus-c++ to be able to find some dependency packages.
-* `expat` - necessary when building the xml2cpp binding code generator (`SDBUSCPP_BUILD_CODEGEN` option is ON).
+* `expat` - necessary when building the xml2cpp binding code generator (`SDBUSCPP_BUILD_CODEGEN` option is `ON`).
 
 Licensing
 ---------

--- a/docs/using-sdbus-c++.md
+++ b/docs/using-sdbus-c++.md
@@ -5,7 +5,7 @@ Using sdbus-c++ library
 
 1. [Introduction](#introduction)
 2. [Integrating sdbus-c++ into your project](#integrating-sdbus-c-into-your-project)
-3. [Solving libsystemd dependency](#solving-libsystemd-dependency)
+3. [Solving sd-bus dependency](#solving-sd-bus-dependency)
 4. [Distributing sdbus-c++](#distributing-sdbus-c)
 5. [Header files and namespaces](#header-files-and-namespaces)
 6. [Error signalling and propagation](#error-signalling-and-propagation)
@@ -74,14 +74,14 @@ add_custom_command(
 )
 ```
 
-Solving libsystemd dependency
------------------------------
+Solving sd-bus dependency
+-------------------------
 
-sdbus-c++ depends on sd-bus API, which is implemented in libsystemd, a C library that is part of [systemd](https://github.com/systemd/systemd).
+sdbus-c++ is a wrapper around sd-bus, a C library that has been written as part of [systemd](https://github.com/systemd/systemd) project.
 
-Minimum required libsystemd shared library version is 0.20.0 (which corresponds to minimum systemd version 236).
+Within systemd, sd-bus is implemented as part of `libsystemd` shared library. At least version 0.22.0 (which corresponds to the minimum systemd version 238) of `libsystemd` is needed.
 
-If your target Linux distribution is already based on systemd ecosystem of version 236 and higher, then there is no additional effort, just make sure you have corresponding systemd header files available (provided by `libsystemd-dev` package on Debian/Ubuntu, for example), and you may go on building sdbus-c++ seamlessly.
+If your target Linux distribution is already based on systemd ecosystem of version 238 and higher, then there is no additional effort, just make sure you have corresponding systemd header files available (provided by `libsystemd-dev` package on Debian/Ubuntu, for example), and you may go on building sdbus-c++ seamlessly.
 
 However, sdbus-c++ can perfectly be used in non-systemd environments as well. If `libsystemd` is not found in the system when configuring sdbus-c++, then
 
@@ -89,7 +89,9 @@ However, sdbus-c++ can perfectly be used in non-systemd environments as well. If
 
 2. sdbus-c++ will try to find `basu`, which is just sd-bus implementation extracted from systemd.
 
-On systems where neither of these is available, we can build sd-bus as a shared lib manually or we can (conveniently) instruct sdbus-c++ to build and integrate sd-bus into itself for us.
+Alternatively to this fallback search sequence, you may explicitly instruct sdbus-c++ to use a specified sd-bus implementation through the `SDBUSCPP_SDBUS_LIB` CMake configuration option.
+
+On systems where neither of those libraries is available, we can build sd-bus manually, or we can (conveniently) instruct sdbus-c++ to build and integrate sd-bus into itself for us.
 
 ### Building and distributing libsystemd as a shared library yourself
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -104,15 +104,15 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 add_executable(sdbus-c++-unit-tests ${UNITTESTS_SRCS})
 target_compile_definitions(sdbus-c++-unit-tests PRIVATE
     LIBSYSTEMD_VERSION=${SDBUSCPP_LIBSYSTEMD_VERSION}
-    SDBUS_${LIBSYSTEMD_IMPL}
-    SDBUS_HEADER=<${LIBSYSTEMD_IMPL}/sd-bus.h>)
+    SDBUS_${SDBUS_IMPL}
+    SDBUS_HEADER=<${SDBUS_IMPL}/sd-bus.h>)
 target_link_libraries(sdbus-c++-unit-tests sdbus-c++-objlib GTest::gmock)
 
 add_executable(sdbus-c++-integration-tests ${INTEGRATIONTESTS_SRCS})
 target_compile_definitions(sdbus-c++-integration-tests PRIVATE
     LIBSYSTEMD_VERSION=${SDBUSCPP_LIBSYSTEMD_VERSION}
-    SDBUS_${LIBSYSTEMD_IMPL})
-if(NOT LIBSYSTEMD_IMPL STREQUAL "basu")
+    SDBUS_${SDBUS_IMPL})
+if(NOT SDBUS_IMPL STREQUAL "basu")
     # Systemd::Libsystemd is included because integration tests use sd-event. Otherwise sdbus-c++ encapsulates and hides libsystemd.
     target_link_libraries(sdbus-c++-integration-tests sdbus-c++ Systemd::Libsystemd GTest::gmock)
 else()


### PR DESCRIPTION
A new CMake configuration variable `SDBUSCPP_SDBUS_LIB` has been introduced that enables clients to specify which sd-bus implementation library shall be used by sdbus-c++.

Fixes #399 