### PR TITLE
Support serialization and deserialization of std::variant

### DIFF
--- a/docs/using-sdbus-c++.md
+++ b/docs/using-sdbus-c++.md
@@ -1516,7 +1516,7 @@ sdbus-c++ provides many default, pre-defined C++ type representations for D-Bus 
 | string-like, basic  | 103         | g          | SIGNATURE          | `sdbus::Signature`                |
 | container           | 97          | a          | ARRAY              | `std::vector<T>`, `std::array<T>`, `std::span<T>` - if used as an array followed by a single complete type `T` <br /> `std::map<T1, T2>`, `std::unordered_map<T1, T2>` - if used as an array of dict entries |
 | container           | 114,40,41   | r()        | STRUCT             | `sdbus::Struct<T1, T2, ...>` variadic class template                               |
-| container           | 118         | v          | VARIANT            | `sdbus::Variant`                  |
+| container           | 118         | v          | VARIANT            | `sdbus::Variant`, `std::variant<T1, ...>` |
 | container           | 101,123,125 | e{}        | DICT_ENTRY         | -                               |
 | fixed, basic        | 104         | h          | UNIX_FD            | `sdbus::UnixFd`                   |
 | reserved            | 109         | m          | (reserved)         | -                               |

--- a/include/sdbus-c++/TypeTraits.h
+++ b/include/sdbus-c++/TypeTraits.h
@@ -332,8 +332,8 @@ namespace sdbus {
         }
     };
 
-    template<typename ...Elements>
-    struct signature_of<std::variant<Elements...>>: public signature_of<Variant>
+    template <typename... Elements>
+    struct signature_of<std::variant<Elements...>> : signature_of<Variant>
     {};
 
     template <>

--- a/include/sdbus-c++/TypeTraits.h
+++ b/include/sdbus-c++/TypeTraits.h
@@ -31,6 +31,7 @@
 #include <string>
 #include <vector>
 #include <array>
+#include <variant>
 #if __cplusplus >= 202002L
 #include <span>
 #endif
@@ -330,6 +331,10 @@ namespace sdbus {
             return "v";
         }
     };
+
+    template<typename ...Elements>
+    struct signature_of<std::variant<Elements...>>: public signature_of<Variant>
+    {};
 
     template <>
     struct signature_of<ObjectPath>

--- a/tests/unittests/Message_test.cpp
+++ b/tests/unittests/Message_test.cpp
@@ -484,11 +484,11 @@ TEST(AMessage, CanCarryDBusStructGivenAsCustomType)
     ASSERT_THAT(dataRead, Eq(dataWritten));
 }
 
-class AMessageVariant: public ::testing::TestWithParam<std::variant<int32_t, std::string, my::Struct>>
+class AMessage : public ::testing::TestWithParam<std::variant<int32_t, std::string, my::Struct>>
 {
 };
 
-TEST_P(AMessageVariant, CanCarryDBusVariantGivenAsStdVariant)
+TEST_P(AMessage, CanCarryDBusVariantGivenAsStdVariant)
 {
     auto msg = sdbus::createPlainMessage();
 
@@ -503,7 +503,7 @@ TEST_P(AMessageVariant, CanCarryDBusVariantGivenAsStdVariant)
     ASSERT_THAT(dataRead, Eq(dataWritten));
 }
 
-TEST_P(AMessageVariant, ThrowsWhenDestinationStdVariantHasWrongTypeDuringDeserialization)
+TEST_P(AMessage, ThrowsWhenDestinationStdVariantHasWrongTypeDuringDeserialization)
 {
     auto msg = sdbus::createPlainMessage();
 
@@ -516,6 +516,6 @@ TEST_P(AMessageVariant, ThrowsWhenDestinationStdVariantHasWrongTypeDuringDeseria
     ASSERT_THROW(msg >> dataRead, sdbus::Error);
 }
 
-INSTANTIATE_TEST_SUITE_P(StringIntStruct,
-                         AMessageVariant,
-                         ::testing::Values("hello"s, 1, my::Struct {}));
+INSTANTIATE_TEST_SUITE_P( StringIntStruct
+                        , AMessage
+                        , ::testing::Values("hello"s, 1, my::Struct{}));

--- a/tests/unittests/TypeTraits_test.cpp
+++ b/tests/unittests/TypeTraits_test.cpp
@@ -78,6 +78,7 @@ namespace
     TYPE(sdbus::Struct<uint16_t, double, std::string, sdbus::Variant>)HAS_DBUS_TYPE_SIGNATURE("(qdsv)")
     TYPE(std::vector<int16_t>)HAS_DBUS_TYPE_SIGNATURE("an")
     TYPE(std::array<int16_t, 3>)HAS_DBUS_TYPE_SIGNATURE("an")
+    TYPE(std::variant<int16_t, std::string>)HAS_DBUS_TYPE_SIGNATURE("v")
 #if __cplusplus >= 202002L
     TYPE(std::span<int16_t>)HAS_DBUS_TYPE_SIGNATURE("ao")
 #endif
@@ -124,6 +125,7 @@ namespace
                             , sdbus::Struct<uint16_t, double, std::string, sdbus::Variant>
                             , std::vector<int16_t>
                             , std::array<int16_t, 3>
+                            , std::variant<int16_t, std::string>
 #if __cplusplus >= 202002L
                             , std::span<int16_t>
 #endif


### PR DESCRIPTION
It can be useful to directly serialize from and deserialize to `std::variant<>` instead of `sdbus::Variant`.