### PR TITLE
feat: support enums in D-Bus serialization and signatures

### DIFF
--- a/include/sdbus-c++/Message.h
+++ b/include/sdbus-c++/Message.h
@@ -100,12 +100,9 @@ namespace sdbus {
 #if __cplusplus >= 202002L
         template <typename _Element, std::size_t _Extent>
         Message& operator<<(const std::span<_Element, _Extent>& items);
-        template <typename _Enum> requires std::is_enum_v<_Enum>
-        Message& operator<<(const _Enum& item);
-#else
+#endif
         template <typename _Enum, typename = std::enable_if_t<std::is_enum_v<_Enum>>>
         Message& operator<<(const _Enum& item);
-#endif
         template <typename _Key, typename _Value, typename _Compare, typename _Allocator>
         Message& operator<<(const std::map<_Key, _Value, _Compare, _Allocator>& items);
         template <typename _Key, typename _Value, typename _Hash, typename _KeyEqual, typename _Allocator>
@@ -137,12 +134,9 @@ namespace sdbus {
 #if __cplusplus >= 202002L
         template <typename _Element, std::size_t _Extent>
         Message& operator>>(std::span<_Element, _Extent>& items);
-        template <typename _Enum> requires std::is_enum_v<_Enum>
-        Message& operator>>(_Enum& item);
-#else
+#endif
         template <typename _Enum, typename = std::enable_if_t<std::is_enum_v<_Enum>>>
         Message& operator>>(_Enum& item);
-#endif
         template <typename _Key, typename _Value, typename _Compare, typename _Allocator>
         Message& operator>>(std::map<_Key, _Value, _Compare, _Allocator>& items);
         template <typename _Key, typename _Value, typename _Hash, typename _KeyEqual, typename _Allocator>
@@ -341,19 +335,13 @@ namespace sdbus {
 
         return *this;
     }
+#endif
 
-    template <typename _Enum> requires std::is_enum_v<_Enum>
-    inline Message& Message::operator<<(const _Enum &item)
-    {
-        return operator<<(static_cast<std::underlying_type_t<_Enum>>(item));
-    }
-#else
     template <typename _Enum, typename>
     inline Message& Message::operator<<(const _Enum &item)
     {
         return operator<<(static_cast<std::underlying_type_t<_Enum>>(item));
     }
-#endif
 
     template <typename _Array>
     inline void Message::serializeArray(const _Array& items)
@@ -478,16 +466,8 @@ namespace sdbus {
 
         return *this;
     }
+#endif
 
-    template <typename _Enum> requires std::is_enum_v<_Enum>
-    inline Message& Message::operator>>(_Enum& item)
-    {
-        std::underlying_type_t<_Enum> val;
-        *this >> val;
-        item = static_cast<_Enum>(val);
-        return *this;
-    }
-#else
     template <typename _Enum, typename>
     inline Message& Message::operator>>(_Enum& item)
     {
@@ -496,7 +476,6 @@ namespace sdbus {
         item = static_cast<_Enum>(val);
         return *this;
     }
-#endif
 
     template <typename _Array>
     inline void Message::deserializeArray(_Array& items)

--- a/include/sdbus-c++/Message.h
+++ b/include/sdbus-c++/Message.h
@@ -100,11 +100,11 @@ namespace sdbus {
 #if __cplusplus >= 202002L
         template <typename _Element, std::size_t _Extent>
         Message& operator<<(const std::span<_Element, _Extent>& items);
-
-        template <typename Enum> requires std::is_enum_v<Enum>
-        Message& operator<<(const Enum &item) {
-            return operator<<(static_cast<std::underlying_type_t<Enum>>(item));
-        }
+        template <typename _Enum> requires std::is_enum_v<_Enum>
+        Message& operator<<(const _Enum& item);
+#else
+        template <typename _Enum, typename = std::enable_if_t<std::is_enum_v<_Enum>>>
+        Message& operator<<(const _Enum& item);
 #endif
         template <typename _Key, typename _Value, typename _Compare, typename _Allocator>
         Message& operator<<(const std::map<_Key, _Value, _Compare, _Allocator>& items);
@@ -137,14 +137,11 @@ namespace sdbus {
 #if __cplusplus >= 202002L
         template <typename _Element, std::size_t _Extent>
         Message& operator>>(std::span<_Element, _Extent>& items);
-
-        template <typename Enum> requires std::is_enum_v<Enum>
-        Message& operator>>(Enum &item) {
-            std::underlying_type_t<Enum> val;
-            *this >> val;
-            item = static_cast<Enum>(val);
-            return *this;
-        }
+        template <typename _Enum> requires std::is_enum_v<_Enum>
+        Message& operator>>(_Enum& item);
+#else
+        template <typename _Enum, typename = std::enable_if_t<std::is_enum_v<_Enum>>>
+        Message& operator>>(_Enum& item);
 #endif
         template <typename _Key, typename _Value, typename _Compare, typename _Allocator>
         Message& operator>>(std::map<_Key, _Value, _Compare, _Allocator>& items);
@@ -344,6 +341,18 @@ namespace sdbus {
 
         return *this;
     }
+
+    template <typename _Enum> requires std::is_enum_v<_Enum>
+    inline Message& Message::operator<<(const _Enum &item)
+    {
+        return operator<<(static_cast<std::underlying_type_t<_Enum>>(item));
+    }
+#else
+    template <typename _Enum, typename>
+    inline Message& Message::operator<<(const _Enum &item)
+    {
+        return operator<<(static_cast<std::underlying_type_t<_Enum>>(item));
+    }
 #endif
 
     template <typename _Array>
@@ -467,6 +476,24 @@ namespace sdbus {
     {
         deserializeArray(items);
 
+        return *this;
+    }
+
+    template <typename _Enum> requires std::is_enum_v<_Enum>
+    inline Message& Message::operator>>(_Enum& item)
+    {
+        std::underlying_type_t<_Enum> val;
+        *this >> val;
+        item = static_cast<_Enum>(val);
+        return *this;
+    }
+#else
+    template <typename _Enum, typename>
+    inline Message& Message::operator>>(_Enum& item)
+    {
+        std::underlying_type_t<_Enum> val;
+        *this >> val;
+        item = static_cast<_Enum>(val);
         return *this;
     }
 #endif

--- a/include/sdbus-c++/Message.h
+++ b/include/sdbus-c++/Message.h
@@ -29,9 +29,10 @@
 
 #include <sdbus-c++/TypeTraits.h>
 #include <sdbus-c++/Error.h>
-#include <string>
-#include <vector>
 #include <array>
+#include <string>
+#include <utility>
+#include <vector>
 #if __cplusplus >= 202002L
 #include <span>
 #endif
@@ -99,6 +100,11 @@ namespace sdbus {
 #if __cplusplus >= 202002L
         template <typename _Element, std::size_t _Extent>
         Message& operator<<(const std::span<_Element, _Extent>& items);
+
+        template <typename Enum> requires std::is_enum_v<Enum>
+        Message& operator<<(const Enum &item) {
+            return operator<<(static_cast<std::underlying_type_t<Enum>>(item));
+        }
 #endif
         template <typename _Key, typename _Value, typename _Compare, typename _Allocator>
         Message& operator<<(const std::map<_Key, _Value, _Compare, _Allocator>& items);
@@ -131,6 +137,14 @@ namespace sdbus {
 #if __cplusplus >= 202002L
         template <typename _Element, std::size_t _Extent>
         Message& operator>>(std::span<_Element, _Extent>& items);
+
+        template <typename Enum> requires std::is_enum_v<Enum>
+        Message& operator>>(Enum &item) {
+            std::underlying_type_t<Enum> val;
+            *this >> val;
+            item = static_cast<Enum>(val);
+            return *this;
+        }
 #endif
         template <typename _Key, typename _Value, typename _Compare, typename _Allocator>
         Message& operator>>(std::map<_Key, _Value, _Compare, _Allocator>& items);

--- a/include/sdbus-c++/TypeTraits.h
+++ b/include/sdbus-c++/TypeTraits.h
@@ -403,17 +403,13 @@ namespace sdbus {
             return "a" + signature_of<_Element>::str();
         }
     };
+#endif
 
-    template <typename _Enum> requires std::is_enum_v<_Enum>
-    struct signature_of<_Enum>
-        : public signature_of<std::underlying_type_t<_Enum>>
-    {};
-#else
     template <typename _Enum>
     struct signature_of<_Enum, typename std::enable_if_t<std::is_enum_v<_Enum>>>
         : public signature_of<std::underlying_type_t<_Enum>>
     {};
-#endif
+
 
     template <typename _Key, typename _Value, typename _Compare, typename _Allocator>
     struct signature_of<std::map<_Key, _Value, _Compare, _Allocator>>

--- a/include/sdbus-c++/TypeTraits.h
+++ b/include/sdbus-c++/TypeTraits.h
@@ -98,7 +98,7 @@ namespace sdbus {
     inline constexpr dont_expect_reply_t dont_expect_reply{};
 
     // Template specializations for getting D-Bus signatures from C++ types
-    template <typename _T>
+    template <typename _T, typename _Enable = void>
     struct signature_of
     {
         static constexpr bool is_valid = false;
@@ -120,7 +120,7 @@ namespace sdbus {
 
     template <typename _T>
     struct signature_of<_T&>
-            : public signature_of<_T>
+        : public signature_of<_T>
     {};
 
     template <>
@@ -404,9 +404,14 @@ namespace sdbus {
         }
     };
 
-    template <typename Enum> requires std::is_enum_v<Enum>
-    struct signature_of<Enum>
-        : public signature_of<std::underlying_type_t<Enum>>
+    template <typename _Enum> requires std::is_enum_v<_Enum>
+    struct signature_of<_Enum>
+        : public signature_of<std::underlying_type_t<_Enum>>
+    {};
+#else
+    template <typename _Enum>
+    struct signature_of<_Enum, typename std::enable_if_t<std::is_enum_v<_Enum>>>
+        : public signature_of<std::underlying_type_t<_Enum>>
     {};
 #endif
 

--- a/include/sdbus-c++/TypeTraits.h
+++ b/include/sdbus-c++/TypeTraits.h
@@ -403,6 +403,11 @@ namespace sdbus {
             return "a" + signature_of<_Element>::str();
         }
     };
+
+    template <typename Enum> requires std::is_enum_v<Enum>
+    struct signature_of<Enum>
+        : public signature_of<std::underlying_type_t<Enum>>
+    {};
 #endif
 
     template <typename _Key, typename _Value, typename _Compare, typename _Allocator>

--- a/include/sdbus-c++/TypeTraits.h
+++ b/include/sdbus-c++/TypeTraits.h
@@ -429,7 +429,6 @@ namespace sdbus {
         }
     };
 
-
     // Function traits implementation inspired by (c) kennytm,
     // https://github.com/kennytm/utils/blob/master/traits.hpp
     template <typename _Type>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -107,10 +107,12 @@ add_executable(sdbus-c++-unit-tests ${UNITTESTS_SRCS})
 target_compile_definitions(sdbus-c++-unit-tests PRIVATE
     LIBSYSTEMD_VERSION=${LIBSYSTEMD_VERSION}
     SDBUS_HEADER=<${LIBSYSTEMD_IMPL}/sd-bus.h>)
+target_compile_features(sdbus-c++-unit-tests PUBLIC cxx_std_20)
 target_link_libraries(sdbus-c++-unit-tests sdbus-c++-objlib GTest::gmock)
 
 add_executable(sdbus-c++-integration-tests ${INTEGRATIONTESTS_SRCS})
 target_compile_definitions(sdbus-c++-integration-tests PRIVATE LIBSYSTEMD_VERSION=${LIBSYSTEMD_VERSION})
+target_compile_features(sdbus-c++-integration-tests PUBLIC cxx_std_20)
 target_link_libraries(sdbus-c++-integration-tests sdbus-c++ GTest::gmock)
 
 # Manual performance and stress tests

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -107,12 +107,10 @@ add_executable(sdbus-c++-unit-tests ${UNITTESTS_SRCS})
 target_compile_definitions(sdbus-c++-unit-tests PRIVATE
     LIBSYSTEMD_VERSION=${LIBSYSTEMD_VERSION}
     SDBUS_HEADER=<${LIBSYSTEMD_IMPL}/sd-bus.h>)
-target_compile_features(sdbus-c++-unit-tests PUBLIC cxx_std_20)
 target_link_libraries(sdbus-c++-unit-tests sdbus-c++-objlib GTest::gmock)
 
 add_executable(sdbus-c++-integration-tests ${INTEGRATIONTESTS_SRCS})
 target_compile_definitions(sdbus-c++-integration-tests PRIVATE LIBSYSTEMD_VERSION=${LIBSYSTEMD_VERSION})
-target_compile_features(sdbus-c++-integration-tests PUBLIC cxx_std_20)
 target_link_libraries(sdbus-c++-integration-tests sdbus-c++ GTest::gmock)
 
 # Manual performance and stress tests

--- a/tests/unittests/Message_test.cpp
+++ b/tests/unittests/Message_test.cpp
@@ -345,6 +345,28 @@ TEST(AMessage, CanCarryDBusArrayOfNontrivialTypesGivenAsStdSpan)
 
     ASSERT_THAT(std::vector(dataRead.begin(), dataRead.end()), Eq(std::vector(dataWritten.begin(), dataWritten.end())));
 }
+
+TEST(ECmessage, CanCarryDBusArrayOfEnumClass)
+{
+    auto msg = sdbus::createPlainMessage();
+
+    enum class A : int16_t {X = 0};
+    enum class B : int32_t {Y = 1};
+    enum struct C : uint64_t { Z = 787};
+
+    A a = A::X;
+    B b = B::Y;
+    C c = C::Z;
+
+    msg << a << b << c;
+    msg.seal();
+
+    msg >> a >> b >> c;
+
+    ASSERT_EQ(a, A::X);
+    ASSERT_EQ(b, B::Y);
+    ASSERT_EQ(c, C::Z);
+}
 #endif
 
 TEST(AMessage, ThrowsWhenDestinationStdArrayIsTooSmallDuringDeserialization)

--- a/tests/unittests/Message_test.cpp
+++ b/tests/unittests/Message_test.cpp
@@ -345,29 +345,25 @@ TEST(AMessage, CanCarryDBusArrayOfNontrivialTypesGivenAsStdSpan)
 
     ASSERT_THAT(std::vector(dataRead.begin(), dataRead.end()), Eq(std::vector(dataWritten.begin(), dataWritten.end())));
 }
+#endif
 
-TEST(ECmessage, CanCarryDBusArrayOfEnumClass)
+TEST(AMessage, CanCarryAnEnumValue)
 {
     auto msg = sdbus::createPlainMessage();
 
-    enum class A : int16_t {X = 0};
-    enum class B : int32_t {Y = 1};
-    enum struct C : uint64_t { Z = 787};
+    enum class EnumA : int16_t {X = 5} aWritten{EnumA::X};
+    enum EnumB {Y = 11} bWritten{EnumB::Y};
 
-    A a = A::X;
-    B b = B::Y;
-    C c = C::Z;
-
-    msg << a << b << c;
+    msg << aWritten << bWritten;
     msg.seal();
 
-    msg >> a >> b >> c;
+    EnumA aRead{};
+    EnumB bRead{};
+    msg >> aRead >> bRead;
 
-    ASSERT_EQ(a, A::X);
-    ASSERT_EQ(b, B::Y);
-    ASSERT_EQ(c, C::Z);
+    ASSERT_THAT(aRead, Eq(aWritten));
+    ASSERT_THAT(bRead, Eq(bWritten));
 }
-#endif
 
 TEST(AMessage, ThrowsWhenDestinationStdArrayIsTooSmallDuringDeserialization)
 {

--- a/tests/unittests/TypeTraits_test.cpp
+++ b/tests/unittests/TypeTraits_test.cpp
@@ -79,7 +79,7 @@ namespace
     TYPE(std::vector<int16_t>)HAS_DBUS_TYPE_SIGNATURE("an")
     TYPE(std::array<int16_t, 3>)HAS_DBUS_TYPE_SIGNATURE("an")
 #if __cplusplus >= 202002L
-    TYPE(std::span<int16_t>)HAS_DBUS_TYPE_SIGNATURE("ao")
+    TYPE(std::span<int16_t>)HAS_DBUS_TYPE_SIGNATURE("an")
 #endif
     TYPE(std::map<int32_t, int64_t>)HAS_DBUS_TYPE_SIGNATURE("a{ix}")
     TYPE(std::unordered_map<int32_t, int64_t>)HAS_DBUS_TYPE_SIGNATURE("a{ix}")

--- a/tests/unittests/TypeTraits_test.cpp
+++ b/tests/unittests/TypeTraits_test.cpp
@@ -79,7 +79,23 @@ namespace
     TYPE(std::vector<int16_t>)HAS_DBUS_TYPE_SIGNATURE("an")
     TYPE(std::array<int16_t, 3>)HAS_DBUS_TYPE_SIGNATURE("an")
 #if __cplusplus >= 202002L
+
+    enum class SomeEnumClass : uint8_t {
+        A, B, C
+    };
+
+    enum struct SomeEnumStruct : int64_t {
+        A, B, C
+    };
+
+    enum struct StandardEnumClass {
+        A, B, C
+    };
+
     TYPE(std::span<int16_t>)HAS_DBUS_TYPE_SIGNATURE("an")
+    TYPE(SomeEnumClass)HAS_DBUS_TYPE_SIGNATURE("y")
+    TYPE(SomeEnumStruct)HAS_DBUS_TYPE_SIGNATURE("x")
+    TYPE(StandardEnumClass)HAS_DBUS_TYPE_SIGNATURE("i")
 #endif
     TYPE(std::map<int32_t, int64_t>)HAS_DBUS_TYPE_SIGNATURE("a{ix}")
     TYPE(std::unordered_map<int32_t, int64_t>)HAS_DBUS_TYPE_SIGNATURE("a{ix}")
@@ -126,6 +142,9 @@ namespace
                             , std::array<int16_t, 3>
 #if __cplusplus >= 202002L
                             , std::span<int16_t>
+                            , SomeEnumClass
+                            , SomeEnumStruct
+                            , StandardEnumClass
 #endif
                             , std::map<int32_t, int64_t>
                             , std::unordered_map<int32_t, int64_t>

--- a/tests/unittests/TypeTraits_test.cpp
+++ b/tests/unittests/TypeTraits_test.cpp
@@ -49,6 +49,21 @@ namespace
         static std::string getDBusTypeSignature();
     };
 
+    enum class SomeEnumClass : uint8_t
+    {
+        A, B, C
+    };
+
+    enum struct SomeEnumStruct : int64_t
+    {
+        A, B, C
+    };
+
+    enum SomeClassicEnum
+    {
+        A, B, C
+    };
+
 #define TYPE(...)                                                                       \
     template <>                                                                         \
     std::string Type2DBusTypeSignatureConversion<__VA_ARGS__>::getDBusTypeSignature()   \
@@ -79,24 +94,11 @@ namespace
     TYPE(std::vector<int16_t>)HAS_DBUS_TYPE_SIGNATURE("an")
     TYPE(std::array<int16_t, 3>)HAS_DBUS_TYPE_SIGNATURE("an")
 #if __cplusplus >= 202002L
-
-    enum class SomeEnumClass : uint8_t {
-        A, B, C
-    };
-
-    enum struct SomeEnumStruct : int64_t {
-        A, B, C
-    };
-
-    enum struct StandardEnumClass {
-        A, B, C
-    };
-
     TYPE(std::span<int16_t>)HAS_DBUS_TYPE_SIGNATURE("an")
+#endif
     TYPE(SomeEnumClass)HAS_DBUS_TYPE_SIGNATURE("y")
     TYPE(SomeEnumStruct)HAS_DBUS_TYPE_SIGNATURE("x")
-    TYPE(StandardEnumClass)HAS_DBUS_TYPE_SIGNATURE("i")
-#endif
+    TYPE(SomeClassicEnum)HAS_DBUS_TYPE_SIGNATURE("u")
     TYPE(std::map<int32_t, int64_t>)HAS_DBUS_TYPE_SIGNATURE("a{ix}")
     TYPE(std::unordered_map<int32_t, int64_t>)HAS_DBUS_TYPE_SIGNATURE("a{ix}")
     using ComplexType = std::map<
@@ -142,10 +144,10 @@ namespace
                             , std::array<int16_t, 3>
 #if __cplusplus >= 202002L
                             , std::span<int16_t>
+#endif
                             , SomeEnumClass
                             , SomeEnumStruct
-                            , StandardEnumClass
-#endif
+                            , SomeClassicEnum
                             , std::map<int32_t, int64_t>
                             , std::unordered_map<int32_t, int64_t>
                             , ComplexType


### PR DESCRIPTION
This PR adds the possiblity for C++20 compilers to use enums, enum classes and enum structs.

C++20 is required because of `requires`. I coulndn't find a way without it. If you're more successful than me, please open a PR or edit this PR, feel free :)

If anything bugs you, please comment