### PR TITLE
refactor: enable compile-time D-Bus signature generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,12 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04, ubuntu-22.04]
-        compiler: [g++, clang]
+        compiler: [g++]
         build: [shared-libsystemd]
         include:
+          - os: ubuntu-22.04
+            compiler: clang
+            build: shared-libsystemd
           - os: ubuntu-22.04
             compiler: g++
             build: embedded-static-libsystemd
@@ -94,7 +97,7 @@ jobs:
         cd build
         cpack -G DEB
     - name: 'Upload Artifact'
-      if: matrix.build == 'shared-libsystemd' && matrix.os == 'ubuntu-20.04' && matrix.compiler == 'g++'
+      if: matrix.build == 'shared-libsystemd' && matrix.os == 'ubuntu-22.04' && matrix.compiler == 'g++'
       uses: actions/upload-artifact@v3
       with:
         name: "debian-packages-${{ matrix.os }}-${{ matrix.compiler }}"

--- a/docs/using-sdbus-c++.md
+++ b/docs/using-sdbus-c++.md
@@ -56,7 +56,7 @@ PKG_CHECK_MODULES(SDBUSCPP, [sdbus-c++ >= 0.6],,
 )
 ```
 
-> **_Note_:** sdbus-c++ library uses a number of modern C++17 features. Please make certain you have a recent compiler (gcc >= 7, clang >= 6).
+> **_Note_:** sdbus-c++ library uses a number of modern C++17 (and, conditionally, C++20) features. Please make sure you have a recent compiler (best gcc >= 10, clang >= 11).
 
 If you intend to use xml-to-c++ generator tool (explained later) in your project to generate interface headers from XML, you can integrate that too with CMake or `pkg-config`:
 
@@ -1568,7 +1568,7 @@ We need two things to do that:
 * implement `sdbus::Message` insertion (serialization) and extraction (deserialization) operators, so sdbus-c++ knows how to serialize/deserialize our custom type,
 * specialize `sdbus::signature_of` template for our custom type, so sdbus-c++ knows the mapping to D-Bus type and other necessary information about our type.
 
-Say, we would like to represent D-Bus arrays as `std::list`s in our application. Since sdbus-c++ comes with pre-defined support for `std::vector`s, `std::array`s and `std::span`s as D-Bus array representations, we have to provide an extension. To implement message serialization and deserialization functions for `std::list`, we can simply copy the sdbus-c++ implementation of these functions for `std::vector`, and simply adjust for `std::list`. Then we provide `signature_of` specialization, again written on terms of one specialized for `std::vector`:
+Say, we would like to represent D-Bus arrays as `std::list`s in our application. Since sdbus-c++ comes with pre-defined support for `std::vector`s, `std::array`s and `std::span`s as D-Bus array representations, we have to provide an extension. To implement message serialization and deserialization functions for `std::list`, we can simply copy the sdbus-c++ implementation of these functions for `std::vector`, and simply adjust for `std::list`. Then we provide `signature_of` specialization, again written in terms of one specialized for `std::vector`:
 
 ```c++
 #include <list>
@@ -1580,7 +1580,7 @@ namespace sdbus {
 template <typename _ElementType>
 sdbus::Message& operator<<(sdbus::Message& msg, const std::list<_ElementType>& items)
 {
-    msg.openContainer(sdbus::signature_of<_ElementType>::str());
+    msg.openContainer<_ElementType>();
 
     for (const auto& item : items)
         msg << item;
@@ -1594,7 +1594,7 @@ sdbus::Message& operator<<(sdbus::Message& msg, const std::list<_ElementType>& i
 template <typename _ElementType>
 sdbus::Message& operator>>(sdbus::Message& msg, std::list<_ElementType>& items)
 {
-    if(!msg.enterContainer(sdbus::signature_of<_ElementType>::str()))
+    if(!msg.enterContainer<_ElementType>())
         return msg;
 
     while (true)
@@ -1615,15 +1615,17 @@ sdbus::Message& operator>>(sdbus::Message& msg, std::list<_ElementType>& items)
 
 } // namespace sdbus
 
-// Implementing type traits for std::list, and since we map it to D-Bus array,
-// we can re-use std::vector type traits because it's the same stuff.
+// Implementing type traits for std::list -- we re-use by inheriting
+// from type traits already provided by sdbus-c++ for D-Bus arrays
 template <typename _Element, typename _Allocator>
 struct sdbus::signature_of<std::list<_Element, _Allocator>>
-        : sdbus::signature_of<std::vector<_Element, _Allocator>>
+    : sdbus::signature_of<std::vector<_Element>>
 {};
 ```
 
 Then we can simply use `std::list`s, serialize/deserialize them in a D-Bus message, in D-Bus method calls or return values... and they will be simply transmitted as D-Bus arrays.
+
+Similarly, say we have our own `lockfree_map` which we would like to use natively with sdbus-c++ as a C++ type for D-Bus dictionary -- we can copy or build on top of `std::map` specializations.
 
 As another example, say we have our custom type `my::Struct` which we'd like to use as a D-Bus structure representation (sdbus-c++ provides `sdbus::Struct` type for that, but we don't want to use it because using our custom type directly is more convenient). Again, we have to provide type traits and message serialization/deserialization functions for our custom type. We build our functions and specializations on top of `sdbus::Struct`, so we don't have to copy and write a lot of boiler-plate. Serialization/deserialization functions can be placed in the same namespace as our custom type, and will be found thanks to the ADR lookup. The `signature_of` specialization must always be in either `sdbus` namespace or in a global namespace:
 

--- a/include/sdbus-c++/VTableItems.inl
+++ b/include/sdbus-c++/VTableItems.inl
@@ -42,8 +42,8 @@ namespace sdbus {
     template <typename _Function>
     MethodVTableItem& MethodVTableItem::implementedAs(_Function&& callback)
     {
-        inputSignature = signature_of_function_input_arguments<_Function>::str();
-        outputSignature = signature_of_function_output_arguments<_Function>::str();
+        inputSignature = signature_of_function_input_arguments_v<_Function>;
+        outputSignature = signature_of_function_output_arguments_v<_Function>;
         callbackHandler = [callback = std::forward<_Function>(callback)](MethodCall call)
         {
             // Create a tuple of callback input arguments' types, which will be used
@@ -142,7 +142,7 @@ namespace sdbus {
     template <typename... _Args>
     inline SignalVTableItem& SignalVTableItem::withParameters()
     {
-        signature = signature_of_function_input_arguments<void(_Args...)>::str();
+        signature = signature_of_function_input_arguments_v<void(_Args...)>;
 
         return *this;
     }
@@ -192,7 +192,7 @@ namespace sdbus {
         static_assert(!std::is_void<function_result_t<_Function>>::value, "Property getter function must return property value");
 
         if (signature.empty())
-            signature = signature_of_function_output_arguments<_Function>::str();
+            signature = signature_of_function_output_arguments_v<_Function>;
 
         getter = [callback = std::forward<_Function>(callback)](PropertyGetReply& reply)
         {
@@ -210,7 +210,7 @@ namespace sdbus {
         static_assert(std::is_void<function_result_t<_Function>>::value, "Property setter function must not return any value");
 
         if (signature.empty())
-            signature = signature_of_function_input_arguments<_Function>::str();
+            signature = signature_of_function_input_arguments_v<_Function>;
 
         setter = [callback = std::forward<_Function>(callback)](PropertySetCall call)
         {

--- a/src/Message.cpp
+++ b/src/Message.cpp
@@ -429,10 +429,9 @@ Message& Message::operator>>(UnixFd &item)
     return *this;
 }
 
-
-Message& Message::openContainer(const std::string& signature)
+Message& Message::openContainer(const char* signature)
 {
-    auto r = sd_bus_message_open_container((sd_bus_message*)msg_, SD_BUS_TYPE_ARRAY, signature.c_str());
+    auto r = sd_bus_message_open_container((sd_bus_message*)msg_, SD_BUS_TYPE_ARRAY, signature);
     SDBUS_THROW_ERROR_IF(r < 0, "Failed to open a container", -r);
 
     return *this;
@@ -446,9 +445,9 @@ Message& Message::closeContainer()
     return *this;
 }
 
-Message& Message::openDictEntry(const std::string& signature)
+Message& Message::openDictEntry(const char* signature)
 {
-    auto r = sd_bus_message_open_container((sd_bus_message*)msg_, SD_BUS_TYPE_DICT_ENTRY, signature.c_str());
+    auto r = sd_bus_message_open_container((sd_bus_message*)msg_, SD_BUS_TYPE_DICT_ENTRY, signature);
     SDBUS_THROW_ERROR_IF(r < 0, "Failed to open a dictionary entry", -r);
 
     return *this;
@@ -462,9 +461,9 @@ Message& Message::closeDictEntry()
     return *this;
 }
 
-Message& Message::openVariant(const std::string& signature)
+Message& Message::openVariant(const char* signature)
 {
-    auto r = sd_bus_message_open_container((sd_bus_message*)msg_, SD_BUS_TYPE_VARIANT, signature.c_str());
+    auto r = sd_bus_message_open_container((sd_bus_message*)msg_, SD_BUS_TYPE_VARIANT, signature);
     SDBUS_THROW_ERROR_IF(r < 0, "Failed to open a variant", -r);
 
     return *this;
@@ -478,9 +477,9 @@ Message& Message::closeVariant()
     return *this;
 }
 
-Message& Message::openStruct(const std::string& signature)
+Message& Message::openStruct(const char* signature)
 {
-    auto r = sd_bus_message_open_container((sd_bus_message*)msg_, SD_BUS_TYPE_STRUCT, signature.c_str());
+    auto r = sd_bus_message_open_container((sd_bus_message*)msg_, SD_BUS_TYPE_STRUCT, signature);
     SDBUS_THROW_ERROR_IF(r < 0, "Failed to open a struct", -r);
 
     return *this;
@@ -494,10 +493,9 @@ Message& Message::closeStruct()
     return *this;
 }
 
-
-Message& Message::enterContainer(const std::string& signature)
+Message& Message::enterContainer(const char* signature)
 {
-    auto r = sd_bus_message_enter_container((sd_bus_message*)msg_, SD_BUS_TYPE_ARRAY, signature.c_str());
+    auto r = sd_bus_message_enter_container((sd_bus_message*)msg_, SD_BUS_TYPE_ARRAY, signature);
     if (r == 0)
         ok_ = false;
 
@@ -514,9 +512,9 @@ Message& Message::exitContainer()
     return *this;
 }
 
-Message& Message::enterDictEntry(const std::string& signature)
+Message& Message::enterDictEntry(const char* signature)
 {
-    auto r = sd_bus_message_enter_container((sd_bus_message*)msg_, SD_BUS_TYPE_DICT_ENTRY, signature.c_str());
+    auto r = sd_bus_message_enter_container((sd_bus_message*)msg_, SD_BUS_TYPE_DICT_ENTRY, signature);
     if (r == 0)
         ok_ = false;
 
@@ -533,9 +531,9 @@ Message& Message::exitDictEntry()
     return *this;
 }
 
-Message& Message::enterVariant(const std::string& signature)
+Message& Message::enterVariant(const char* signature)
 {
-    auto r = sd_bus_message_enter_container((sd_bus_message*)msg_, SD_BUS_TYPE_VARIANT, signature.c_str());
+    auto r = sd_bus_message_enter_container((sd_bus_message*)msg_, SD_BUS_TYPE_VARIANT, signature);
     if (r == 0)
         ok_ = false;
 
@@ -552,9 +550,9 @@ Message& Message::exitVariant()
     return *this;
 }
 
-Message& Message::enterStruct(const std::string& signature)
+Message& Message::enterStruct(const char* signature)
 {
-    auto r = sd_bus_message_enter_container((sd_bus_message*)msg_, SD_BUS_TYPE_STRUCT, signature.c_str());
+    auto r = sd_bus_message_enter_container((sd_bus_message*)msg_, SD_BUS_TYPE_STRUCT, signature);
     if (r == 0)
         ok_ = false;
 

--- a/tests/unittests/Message_test.cpp
+++ b/tests/unittests/Message_test.cpp
@@ -51,7 +51,7 @@ namespace sdbus {
     template <typename _ElementType>
     sdbus::Message& operator<<(sdbus::Message& msg, const std::list<_ElementType>& items)
     {
-        msg.openContainer(sdbus::signature_of<_ElementType>::str());
+        msg.openContainer<_ElementType>();
 
         for (const auto& item : items)
             msg << item;
@@ -64,7 +64,7 @@ namespace sdbus {
     template <typename _ElementType>
     sdbus::Message& operator>>(sdbus::Message& msg, std::list<_ElementType>& items)
     {
-        if(!msg.enterContainer(sdbus::signature_of<_ElementType>::str()))
+        if(!msg.enterContainer<_ElementType>())
             return msg;
 
         while (true)

--- a/tests/unittests/TypeTraits_test.cpp
+++ b/tests/unittests/TypeTraits_test.cpp
@@ -170,7 +170,8 @@ namespace
 
 TYPED_TEST(Type2DBusTypeSignatureConversion, ConvertsTypeToProperDBusSignature)
 {
-    ASSERT_THAT(sdbus::signature_of<TypeParam>::str(), Eq(this->dbusTypeSignature_));
+    constexpr auto signature = sdbus::as_null_terminated(sdbus::signature_of_v<TypeParam>);
+    ASSERT_THAT(signature.data(), Eq(this->dbusTypeSignature_));
 }
 
 TEST(FreeFunctionTypeTraits, DetectsTraitsOfTrivialSignatureFunction)


### PR DESCRIPTION
Since sdbus-c++ knows types of D-Bus call/signal/property input/output parameters at compile time, why not assemble the D-Bus signature strings at compile time, too, instead of assembling them at run time as `std::string` with likely cost of (unnecessary) heap allocations...

`std::array` is well supported `constexpr` type in C++20, so we harness it to build the D-Bus signature string and store it into the binary at compile time.