### PR TITLE
test: add integration tests for std::variant

### DIFF
--- a/include/sdbus-c++/TypeTraits.h
+++ b/include/sdbus-c++/TypeTraits.h
@@ -98,6 +98,9 @@ namespace sdbus {
     struct dont_expect_reply_t { explicit dont_expect_reply_t() = default; };
     inline constexpr dont_expect_reply_t dont_expect_reply{};
 
+    // Helper for static assert
+    template <class... _T> constexpr bool always_false = false;
+
     // Template specializations for getting D-Bus signatures from C++ types
     template <typename _T, typename _Enable = void>
     struct signature_of
@@ -107,9 +110,9 @@ namespace sdbus {
 
         static const std::string str()
         {
-            // sizeof(_T) < 0 is here to make compiler not being able to figure out
-            // the assertion expression before the template instantiation takes place.
-            static_assert(sizeof(_T) < 0, "Unknown DBus type");
+            // See using-sdbus-c++.md, section "Extending sdbus-c++ type system",
+            // on how to teach sdbus-c++ about your custom types
+            static_assert(always_false<_T>, "Unsupported DBus type (template specializations are needed for your custom types)");
             return "";
         }
     };

--- a/tests/integrationtests/DBusMethodsTests.cpp
+++ b/tests/integrationtests/DBusMethodsTests.cpp
@@ -98,6 +98,13 @@ TEST_F(SdbusTestObject, CallsMethodWithVariantSuccesfully)
     ASSERT_THAT(variantRes.get<int32_t>(), Eq(static_cast<int32_t>(DOUBLE_VALUE)));
 }
 
+TEST_F(SdbusTestObject, CallsMethodWithStdVariantSuccesfully)
+{
+    std::variant<int32_t, double, std::string> v{DOUBLE_VALUE};
+    auto variantRes = m_proxy->processVariant(v);
+    ASSERT_THAT(std::get<int32_t>(variantRes), Eq(static_cast<int32_t>(DOUBLE_VALUE)));
+}
+
 TEST_F(SdbusTestObject, CallsMethodWithStructVariantsAndGetMapSuccesfully)
 {
     std::vector<int32_t> x{-2, 0, 2};

--- a/tests/integrationtests/TestAdaptor.cpp
+++ b/tests/integrationtests/TestAdaptor.cpp
@@ -75,9 +75,9 @@ std::vector<int16_t> TestAdaptor::getInts16FromStruct(const sdbus::Struct<uint8_
     return res;
 }
 
-sdbus::Variant TestAdaptor::processVariant(const sdbus::Variant& v)
+sdbus::Variant TestAdaptor::processVariant(const std::variant<int32_t, double, std::string>& v)
 {
-    sdbus::Variant res{static_cast<int32_t>(v.get<double>())};
+    sdbus::Variant res{static_cast<int32_t>(std::get<double>(v))};
     return res;
 }
 

--- a/tests/integrationtests/TestAdaptor.h
+++ b/tests/integrationtests/TestAdaptor.h
@@ -66,7 +66,7 @@ protected:
     double multiply(const int64_t& a, const double& b) override;
     void multiplyWithNoReply(const int64_t& a, const double& b) override;
     std::vector<int16_t> getInts16FromStruct(const sdbus::Struct<uint8_t, int16_t, double, std::string, std::vector<int16_t>>& arg0) override;
-    sdbus::Variant processVariant(const sdbus::Variant& variant) override;
+    sdbus::Variant processVariant(const std::variant<int32_t, double, std::string>& variant) override;
     std::map<int32_t, sdbus::Variant> getMapOfVariants(const std::vector<int32_t>& x, const sdbus::Struct<sdbus::Variant, sdbus::Variant>& y) override;
     sdbus::Struct<std::string, sdbus::Struct<std::map<int32_t, int32_t>>> getStructInStruct() override;
     int32_t sumStructItems(const sdbus::Struct<uint8_t, uint16_t>& arg0, const sdbus::Struct<int32_t, int64_t>& arg1) override;
@@ -123,7 +123,7 @@ protected:
     double multiply(const int64_t&, const double&) override { return {}; }
     void multiplyWithNoReply(const int64_t&, const double&) override {}
     std::vector<int16_t> getInts16FromStruct(const sdbus::Struct<uint8_t, int16_t, double, std::string, std::vector<int16_t>>&) override { return {}; }
-    sdbus::Variant processVariant(const sdbus::Variant&) override { return {}; }
+    sdbus::Variant processVariant(const std::variant<int32_t, double, std::string>&) override { return {}; }
     std::map<int32_t, sdbus::Variant> getMapOfVariants(const std::vector<int32_t>&, const sdbus::Struct<sdbus::Variant, sdbus::Variant>&) override { return {}; }
     sdbus::Struct<std::string, sdbus::Struct<std::map<int32_t, int32_t>>> getStructInStruct() override { return {}; }
     int32_t sumStructItems(const sdbus::Struct<uint8_t, uint16_t>&, const sdbus::Struct<int32_t, int64_t>&) override { return {}; }

--- a/tests/integrationtests/integrationtests-adaptor.h
+++ b/tests/integrationtests/integrationtests-adaptor.h
@@ -29,7 +29,7 @@ protected:
         object_->registerMethod("multiply").onInterface(INTERFACE_NAME).withInputParamNames("a", "b").withOutputParamNames("result").implementedAs([this](const int64_t& a, const double& b){ return this->multiply(a, b); });
         object_->registerMethod("multiplyWithNoReply").onInterface(INTERFACE_NAME).withInputParamNames("a", "b").implementedAs([this](const int64_t& a, const double& b){ return this->multiplyWithNoReply(a, b); }).markAsDeprecated().withNoReply();
         object_->registerMethod("getInts16FromStruct").onInterface(INTERFACE_NAME).withInputParamNames("arg0").withOutputParamNames("arg0").implementedAs([this](const sdbus::Struct<uint8_t, int16_t, double, std::string, std::vector<int16_t>>& arg0){ return this->getInts16FromStruct(arg0); });
-        object_->registerMethod("processVariant").onInterface(INTERFACE_NAME).withInputParamNames("variant").withOutputParamNames("result").implementedAs([this](const sdbus::Variant& variant){ return this->processVariant(variant); });
+        object_->registerMethod("processVariant").onInterface(INTERFACE_NAME).withInputParamNames("variant").withOutputParamNames("result").implementedAs([this](const std::variant<int32_t, double, std::string>& variant){ return this->processVariant(variant); });
         object_->registerMethod("getMapOfVariants").onInterface(INTERFACE_NAME).withInputParamNames("x", "y").withOutputParamNames("aMapOfVariants").implementedAs([this](const std::vector<int32_t>& x, const sdbus::Struct<sdbus::Variant, sdbus::Variant>& y){ return this->getMapOfVariants(x, y); });
         object_->registerMethod("getStructInStruct").onInterface(INTERFACE_NAME).withOutputParamNames("aMapOfVariants").implementedAs([this](){ return this->getStructInStruct(); });
         object_->registerMethod("sumStructItems").onInterface(INTERFACE_NAME).withInputParamNames("arg0", "arg1").withOutputParamNames("arg0").implementedAs([this](const sdbus::Struct<uint8_t, uint16_t>& arg0, const sdbus::Struct<int32_t, int64_t>& arg1){ return this->sumStructItems(arg0, arg1); });
@@ -82,7 +82,7 @@ private:
     virtual double multiply(const int64_t& a, const double& b) = 0;
     virtual void multiplyWithNoReply(const int64_t& a, const double& b) = 0;
     virtual std::vector<int16_t> getInts16FromStruct(const sdbus::Struct<uint8_t, int16_t, double, std::string, std::vector<int16_t>>& arg0) = 0;
-    virtual sdbus::Variant processVariant(const sdbus::Variant& variant) = 0;
+    virtual sdbus::Variant processVariant(const std::variant<int32_t, double, std::string>& variant) = 0;
     virtual std::map<int32_t, sdbus::Variant> getMapOfVariants(const std::vector<int32_t>& x, const sdbus::Struct<sdbus::Variant, sdbus::Variant>& y) = 0;
     virtual sdbus::Struct<std::string, sdbus::Struct<std::map<int32_t, int32_t>>> getStructInStruct() = 0;
     virtual int32_t sumStructItems(const sdbus::Struct<uint8_t, uint16_t>& arg0, const sdbus::Struct<int32_t, int64_t>& arg1) = 0;

--- a/tests/integrationtests/integrationtests-proxy.h
+++ b/tests/integrationtests/integrationtests-proxy.h
@@ -84,6 +84,13 @@ public:
         return result;
     }
 
+    std::variant<int32_t, double, std::string> processVariant(const std::variant<int32_t, double, std::string>& variant)
+    {
+        std::variant<int32_t, double, std::string> result;
+        proxy_->callMethod("processVariant").onInterface(INTERFACE_NAME).withArguments(variant).storeResultsTo(result);
+        return result;
+    }
+
     std::map<int32_t, sdbus::Variant> getMapOfVariants(const std::vector<int32_t>& x, const sdbus::Struct<sdbus::Variant, sdbus::Variant>& y)
     {
         std::map<int32_t, sdbus::Variant> result;


### PR DESCRIPTION
Also use `always_false` technique instead of `sizeof` trick for unsupported D-Bus type representation static assert. This one is more expressive and leads to more specific, more revealing compiler error messages.