### PR TITLE
refactor: remove floating_slot_t tag and use return_slot_t instead

### DIFF
--- a/docs/using-sdbus-c++.md
+++ b/docs/using-sdbus-c++.md
@@ -1798,6 +1798,8 @@ sdbus-c++ v2 is a major release that comes with a number of breaking API/ABI/beh
 * `createDefaultBusConnection()` has been renamed to `createBusConnection()`.
 * `IObject::removeObjectManager()` and `IObject::hasObjectManager()` were removed. Clients should now use the slot-returning `IObject::addObjectManager()` to control the `ObjectManager` interface lifetime.
 * `floating_slot_t` tag was removed from `IConnection::addObjectManager()`, the function is now by default floating-slot-based.
+* Slot-returning `IConnection::addMatch()` has gotten the `return_slot_t` tag parameter, while `floating_slot_t` was removed from the floating slot-based overload of the method.
+* Slot-returning `IConnection::addMatchAsync()` has gotten the `return_slot_t` tag parameter, while `floating_slot_t` was removed from the floating slot-based overload of the method.
 * Change in behavior: `Proxy`s now by default call `createBusConnection()` to get a connection when the connection is not provided explicitly by the caller, so they connect to either the session bus or the system bus depending on the context (as opposed to always to the system bus like before).
 * Callbacks taking `const sdbus::Error* error` were changed to take `std::optional<sdbus::Error>`, which better expresses the intent and meaning.
 * `getInterfaceName()`, `getMemberName()`, `getSender()`, `getPath()` and `getDestination()` methods of `Message` class now return `const char*` instead of `std::string`, for efficiency reasons.
@@ -1808,7 +1810,7 @@ sdbus-c++ v2 is a major release that comes with a number of breaking API/ABI/beh
 * CMake options got `SDBUSCPP_` prefix for better usability and minimal risk of conflicts in downstream CMake projects. `SDBUSCPP_INSTALL` CMake option was added.
 * CMake components got `sdbus-c++-` prefix.
 
-Some of these changes required correspoding adaptations in the sdbus-c++ codegen. Hence, your **C++ bindings (if any) must be re-generated** with the new sdbus-c++-xml2cpp v2 in order to use them with sdbus-c++ v2 API.
+An important note: **C++ bindings generated from XML files must be re-generated** with the new `sdbus-c++-xml2cpp` when migrating to sdbus-c++ v2.0.
 
 Conclusion
 ----------

--- a/include/sdbus-c++/Message.h
+++ b/include/sdbus-c++/Message.h
@@ -266,8 +266,7 @@ namespace sdbus {
         MethodCall() = default;
 
         MethodReply send(uint64_t timeout) const;
-        void send(void* callback, void* userData, uint64_t timeout, floating_slot_t) const;
-        [[nodiscard]] Slot send(void* callback, void* userData, uint64_t timeout) const;
+        [[nodiscard]] Slot send(void* callback, void* userData, uint64_t timeout, return_slot_t) const;
 
         MethodReply createReply() const;
         MethodReply createErrorReply(const sdbus::Error& error) const;

--- a/src/Connection.h
+++ b/src/Connection.h
@@ -108,10 +108,13 @@ namespace sdbus::internal {
         void setMethodCallTimeout(uint64_t timeout) override;
         [[nodiscard]] uint64_t getMethodCallTimeout() const override;
 
-        [[nodiscard]] Slot addMatch(const std::string& match, message_handler callback) override;
-        void addMatch(const std::string& match, message_handler callback, floating_slot_t) override;
-        [[nodiscard]] Slot addMatchAsync(const std::string& match, message_handler callback, message_handler installCallback) override;
-        void addMatchAsync(const std::string& match, message_handler callback, message_handler installCallback, floating_slot_t) override;
+        void addMatch(const std::string& match, message_handler callback) override;
+        [[nodiscard]] Slot addMatch(const std::string& match, message_handler callback, return_slot_t) override;
+        void addMatchAsync(const std::string& match, message_handler callback, message_handler installCallback) override;
+        [[nodiscard]] Slot addMatchAsync( const std::string& match
+                                        , message_handler callback
+                                        , message_handler installCallback
+                                        , return_slot_t ) override;
 
         void attachSdEventLoop(sd_event *event, int priority) override;
         void detachSdEventLoop() override;
@@ -123,7 +126,8 @@ namespace sdbus::internal {
         Slot addObjectVTable( const ObjectPath& objectPath
                             , const InterfaceName& interfaceName
                             , const sd_bus_vtable* vtable
-                            , void* userData ) override;
+                            , void* userData
+                            , return_slot_t ) override;
 
         [[nodiscard]] PlainMessage createPlainMessage() const override;
         [[nodiscard]] MethodCall createMethodCall( const ServiceName& destination
@@ -142,8 +146,7 @@ namespace sdbus::internal {
                                          , const char* signalName ) const override;
 
         MethodReply callMethod(const MethodCall& message, uint64_t timeout) override;
-        void callMethod(const MethodCall& message, void* callback, void* userData, uint64_t timeout, floating_slot_t) override;
-        Slot callMethod(const MethodCall& message, void* callback, void* userData, uint64_t timeout) override;
+        Slot callMethod(const MethodCall& message, void* callback, void* userData, uint64_t timeout, return_slot_t) override;
 
         void emitPropertiesChangedSignal( const ObjectPath& objectPath
                                         , const InterfaceName& interfaceName
@@ -163,7 +166,8 @@ namespace sdbus::internal {
                                   , const char* interfaceName
                                   , const char* signalName
                                   , sd_bus_message_handler_t callback
-                                  , void* userData ) override;
+                                  , void* userData
+                                  , return_slot_t ) override;
 
     private:
         using BusFactory = std::function<int(sd_bus**)>;

--- a/src/IConnection.h
+++ b/src/IConnection.h
@@ -70,7 +70,8 @@ namespace sdbus::internal {
         [[nodiscard]] virtual Slot addObjectVTable( const ObjectPath& objectPath
                                                   , const InterfaceName& interfaceName
                                                   , const sd_bus_vtable* vtable
-                                                  , void* userData ) = 0;
+                                                  , void* userData
+                                                  , return_slot_t ) = 0;
 
         [[nodiscard]] virtual PlainMessage createPlainMessage() const = 0;
         [[nodiscard]] virtual MethodCall createMethodCall( const ServiceName& destination
@@ -89,8 +90,11 @@ namespace sdbus::internal {
                                                  , const char* signalName ) const = 0;
 
         virtual MethodReply callMethod(const MethodCall& message, uint64_t timeout) = 0;
-        virtual void callMethod(const MethodCall& message, void* callback, void* userData, uint64_t timeout, floating_slot_t) = 0;
-        [[nodiscard]] virtual Slot callMethod(const MethodCall& message, void* callback, void* userData, uint64_t timeout) = 0;
+        [[nodiscard]] virtual Slot callMethod( const MethodCall& message
+                                             , void* callback
+                                             , void* userData
+                                             , uint64_t timeout
+                                             , return_slot_t ) = 0;
 
         virtual void emitPropertiesChangedSignal( const ObjectPath& objectPath
                                                 , const InterfaceName& interfaceName
@@ -110,7 +114,8 @@ namespace sdbus::internal {
                                                         , const char* interfaceName
                                                         , const char* signalName
                                                         , sd_bus_message_handler_t callback
-                                                        , void* userData ) = 0;
+                                                        , void* userData
+                                                        , return_slot_t ) = 0;
     };
 
     [[nodiscard]] std::unique_ptr<sdbus::internal::IConnection> createPseudoConnection();

--- a/src/Message.cpp
+++ b/src/Message.cpp
@@ -821,13 +821,7 @@ MethodReply MethodCall::sendWithNoReply() const
     return Factory::create<MethodReply>(); // No reply
 }
 
-void MethodCall::send(void* callback, void* userData, uint64_t timeout, floating_slot_t) const
-{
-    auto r = sdbus_->sd_bus_call_async(nullptr, nullptr, (sd_bus_message*)msg_, (sd_bus_message_handler_t)callback, userData, timeout);
-    SDBUS_THROW_ERROR_IF(r < 0, "Failed to call method", -r);
-}
-
-Slot MethodCall::send(void* callback, void* userData, uint64_t timeout) const
+Slot MethodCall::send(void* callback, void* userData, uint64_t timeout, return_slot_t) const
 {
     sd_bus_slot* slot;
 

--- a/src/Object.cpp
+++ b/src/Object.cpp
@@ -67,7 +67,11 @@ Slot Object::addVTable(InterfaceName interfaceName, std::vector<VTableItem> vtab
     internalVTable->sdbusVTable = createInternalSdBusVTable(*internalVTable);
 
     // 3rd step -- register the vtable with sd-bus
-    internalVTable->slot = connection_.addObjectVTable(objectPath_, internalVTable->interfaceName, &internalVTable->sdbusVTable[0], internalVTable.get());
+    internalVTable->slot = connection_.addObjectVTable( objectPath_
+                                                      , internalVTable->interfaceName
+                                                      , &internalVTable->sdbusVTable[0]
+                                                      , internalVTable.get()
+                                                      , return_slot );
 
     // Return vtable wrapped in a Slot object
     return {internalVTable.release(), [](void *ptr){ delete static_cast<VTable*>(ptr); }};

--- a/src/Proxy.cpp
+++ b/src/Proxy.cpp
@@ -124,7 +124,11 @@ PendingAsyncCall Proxy::callMethodAsync(const MethodCall& message, async_reply_h
                                                                       , .proxy = *this
                                                                       , .floating = false });
 
-    asyncCallInfo->slot = connection_->callMethod(message, (void*)&Proxy::sdbus_async_reply_handler, asyncCallInfo.get(), timeout);
+    asyncCallInfo->slot = connection_->callMethod( message
+                                                 , (void*)&Proxy::sdbus_async_reply_handler
+                                                 , asyncCallInfo.get()
+                                                 , timeout
+                                                 , return_slot );
 
     auto asyncCallInfoWeakPtr = std::weak_ptr{asyncCallInfo};
 
@@ -141,7 +145,11 @@ Slot Proxy::callMethodAsync(const MethodCall& message, async_reply_handler async
                                                                       , .proxy = *this
                                                                       , .floating = true });
 
-    asyncCallInfo->slot = connection_->callMethod(message, (void*)&Proxy::sdbus_async_reply_handler, asyncCallInfo.get(), timeout);
+    asyncCallInfo->slot = connection_->callMethod( message
+                                                 , (void*)&Proxy::sdbus_async_reply_handler
+                                                 , asyncCallInfo.get()
+                                                 , timeout
+                                                 , return_slot );
 
     return {asyncCallInfo.release(), [](void *ptr){ delete static_cast<AsyncCallInfo*>(ptr); }};
 }
@@ -209,7 +217,8 @@ Slot Proxy::registerSignalHandler( const char* interfaceName
                                                          , interfaceName
                                                          , signalName
                                                          , &Proxy::sdbus_signal_handler
-                                                         , signalInfo.get() );
+                                                         , signalInfo.get()
+                                                         , return_slot );
 
     return {signalInfo.release(), [](void *ptr){ delete static_cast<SignalInfo*>(ptr); }};
 }

--- a/tests/integrationtests/DBusGeneralTests.cpp
+++ b/tests/integrationtests/DBusGeneralTests.cpp
@@ -83,7 +83,7 @@ TYPED_TEST(AConnection, WillCallCallbackHandlerForIncomingMessageMatchingMatchRu
     {
         if(msg.getPath() == OBJECT_PATH)
             matchingMessageReceived = true;
-    });
+    }, sdbus::return_slot);
 
     this->m_adaptor->emitSimpleSignal();
 
@@ -104,7 +104,8 @@ TYPED_TEST(AConnection, CanInstallMatchRuleAsynchronously)
                                                       , [&](sdbus::Message /*msg*/)
                                                         {
                                                             matchRuleInstalled = true;
-                                                        } );
+                                                        }
+                                                      , sdbus::return_slot );
 
     EXPECT_TRUE(waitUntil(matchRuleInstalled));
 
@@ -121,7 +122,7 @@ TYPED_TEST(AConnection, WillUnsubscribeMatchRuleWhenClientDestroysTheAssociatedS
     {
         if(msg.getPath() == OBJECT_PATH)
             matchingMessageReceived = true;
-    });
+    }, sdbus::return_slot);
     slot.reset();
 
     this->m_adaptor->emitSimpleSignal();
@@ -140,7 +141,7 @@ TYPED_TEST(AConnection, CanAddFloatingMatchRule)
         if(msg.getPath() == OBJECT_PATH)
             matchingMessageReceived = true;
     };
-    con->addMatch(matchRule, std::move(callback), sdbus::floating_slot);
+    con->addMatch(matchRule, std::move(callback));
     this->m_adaptor->emitSimpleSignal();
     [[maybe_unused]] auto gotMessage = waitUntil(matchingMessageReceived, 2s);
     assert(gotMessage);
@@ -160,7 +161,7 @@ TYPED_TEST(AConnection, WillNotPassToMatchCallbackMessagesThatDoNotMatchTheRule)
     {
         if(msg.getMemberName() == "simpleSignal"sv)
             numberOfMatchingMessages++;
-    });
+    }, sdbus::return_slot);
     auto adaptor2 = std::make_unique<TestAdaptor>(*this->s_adaptorConnection, OBJECT_PATH_2);
 
     this->m_adaptor->emitSignalWithMap({});


### PR DESCRIPTION
Make all the API consistent by using `return_slot_t`-based overloads for returning the slots to clients, and overloads without that tag for "floating" slots. `floating_slot_t` tag was previously added for API backwards compatibility reasons, but now is a (counter-)duplicate to the `return_slot_t`.