### PR TITLE
feat: add macro to teach sdbus-c++ about user-defined structs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,19 +14,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04]
-        compiler: [g++]
-        build: [shared-libsystemd]
+        os: [ubuntu-22.04]
+        compiler: [g++, clang]
+        build: [shared-libsystemd, embedded-static-libsystemd]
         include:
-          - os: ubuntu-22.04
-            compiler: clang
+          - os: ubuntu-20.04
+            compiler: gcc
             build: shared-libsystemd
-          - os: ubuntu-22.04
-            compiler: g++
-            build: embedded-static-libsystemd
-          - os: ubuntu-22.04
-            compiler: clang
-            build: embedded-static-libsystemd
     steps:
     - uses: actions/checkout@v3
     - name: install-libsystemd-toolchain
@@ -65,18 +59,18 @@ jobs:
 #        cmake --build . -j4
 #        sudo cmake --build . --target install
     - name: configure-debug
-      if: matrix.build == 'shared-libsystemd' && matrix.os == 'ubuntu-20.04'
-      run: |
-        mkdir build
-        cd build
-        cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX:PATH=/usr -DCMAKE_CXX_FLAGS="-O0 -g -W -Wextra -Wall -Wnon-virtual-dtor -Werror $SDBUSCPP_EXTRA_CXX_FLAGS" -DCMAKE_VERBOSE_MAKEFILE=ON -DSDBUSCPP_INSTALL=ON -DSDBUSCPP_BUILD_TESTS=ON -DSDBUSCPP_BUILD_PERF_TESTS=ON -DSDBUSCPP_BUILD_STRESS_TESTS=ON -DSDBUSCPP_BUILD_CODEGEN=ON ..
-    - name: configure-release
       if: matrix.build == 'shared-libsystemd' && matrix.os == 'ubuntu-22.04'
       run: |
         mkdir build
         cd build
-        cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX:PATH=/usr -DCMAKE_CXX_FLAGS="-O3 -DNDEBUG -W -Wextra -Wall -Wnon-virtual-dtor -Werror $SDBUSCPP_EXTRA_CXX_FLAGS" -DCMAKE_VERBOSE_MAKEFILE=ON -DSDBUSCPP_INSTALL=ON -DSDBUSCPP_BUILD_TESTS=ON -DSDBUSCPP_BUILD_PERF_TESTS=ON -DSDBUSCPP_BUILD_STRESS_TESTS=ON -DSDBUSCPP_BUILD_CODEGEN=ON -DSDBUSCPP_GOOGLETEST_VERSION=1.14.0 ..
-    - name: configure-with-embedded-libsystemd
+        cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX:PATH=/usr -DCMAKE_CXX_FLAGS="-O0 -g -W -Wextra -Wall -Wnon-virtual-dtor -Werror $SDBUSCPP_EXTRA_CXX_FLAGS" -DCMAKE_VERBOSE_MAKEFILE=ON -DSDBUSCPP_INSTALL=ON -DSDBUSCPP_BUILD_TESTS=ON -DSDBUSCPP_BUILD_PERF_TESTS=ON -DSDBUSCPP_BUILD_STRESS_TESTS=ON -DSDBUSCPP_BUILD_CODEGEN=ON -DSDBUSCPP_GOOGLETEST_VERSION=1.14.0 ..
+    - name: configure-debug-no-tests
+      if: matrix.os == 'ubuntu-20.04'
+      run: |
+        mkdir build
+        cd build
+        cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX:PATH=/usr -DCMAKE_CXX_FLAGS="-O0 -g -W -Wextra -Wall -Wnon-virtual-dtor -Werror $SDBUSCPP_EXTRA_CXX_FLAGS" -DCMAKE_VERBOSE_MAKEFILE=ON -DSDBUSCPP_INSTALL=ON -DSDBUSCPP_BUILD_TESTS=OFF -DSDBUSCPP_BUILD_PERF_TESTS=ON -DSDBUSCPP_BUILD_STRESS_TESTS=ON -DSDBUSCPP_BUILD_CODEGEN=ON ..
+    - name: configure-release-with-embedded-libsystemd
       if: matrix.build == 'embedded-static-libsystemd'
       run: |
         mkdir build

--- a/ChangeLog
+++ b/ChangeLog
@@ -291,3 +291,7 @@ v2.0.0
 - Add `SDBUSCPP_` prefix to CMake configuration variables to avoid conflicts with downstream projects
 - Require systemd of at least v238
 - Many other fixes and updates in code, tests, build system, CI, and documentation
+
+v2.x.y
+- Add SDBUSCPP_REGISTER_STRUCT macro to conveniently teach sdbus-c++ about user-defined structs
+- Fix partially renamed BUILD_DOXYGEN_DOC CMake option

--- a/tests/unittests/Message_test.cpp
+++ b/tests/unittests/Message_test.cpp
@@ -89,40 +89,21 @@ namespace sdbus {
 
 template <typename _Element, typename _Allocator>
 struct sdbus::signature_of<std::list<_Element, _Allocator>>
-        : sdbus::signature_of<std::vector<_Element, _Allocator>>
+    : sdbus::signature_of<std::vector<_Element, _Allocator>>
 {};
 
 namespace my {
-
     struct Struct
     {
         int i;
         std::string s;
         std::list<double> l;
+
+        friend bool operator==(const Struct& lhs, const Struct& rhs) = default;
     };
-
-    bool operator==(const Struct& lhs, const Struct& rhs)
-    {
-        return lhs.i == rhs.i && lhs.s == rhs.s && lhs.l == rhs.l;
-    }
-
-    sdbus::Message& operator<<(sdbus::Message& msg, const Struct& items)
-    {
-        return msg << sdbus::Struct{std::forward_as_tuple(items.i, items.s, items.l)};
-    }
-
-    sdbus::Message& operator>>(sdbus::Message& msg, Struct& items)
-    {
-        sdbus::Struct s{std::forward_as_tuple(items.i, items.s, items.l)};
-        return msg >> s;
-    }
-
 }
 
-template <>
-struct sdbus::signature_of<my::Struct>
-    : sdbus::signature_of<sdbus::Struct<int, std::string, std::list<double>>>
-{};
+SDBUSCPP_REGISTER_STRUCT(my::Struct, i, s, l);
 
 /*-------------------------------------*/
 /* --          TEST CASES           -- */


### PR DESCRIPTION
This introduces `SDBUSCPP_REGISTER_STRUCT()` macro that helps clients conveniently, in one line, teach sdbus-c++ to recognize and accept their custom C++ struct types wherever D-Bus structs are expected in a D-Bus API.

The macro saves some boilerplate that would otherwise be needed on client side for every registered struct.