### PR TITLE
fix: const enum signature_of ambiguity error

### DIFF
--- a/include/sdbus-c++/TypeTraits.h
+++ b/include/sdbus-c++/TypeTraits.h
@@ -141,6 +141,10 @@ namespace sdbus {
     {};
 
     template <typename _T>
+    struct signature_of<const volatile _T> : signature_of<_T>
+    {};
+
+    template <typename _T>
     struct signature_of<_T&> : signature_of<_T>
     {};
 
@@ -337,9 +341,9 @@ namespace sdbus {
     };
 #endif
 
-    template <typename _Enum>
-    struct signature_of<_Enum, typename std::enable_if_t<std::is_enum_v<_Enum>>>
-        : public signature_of<std::underlying_type_t<_Enum>>
+    template <typename _Enum> // is_const_v and is_volatile_v to avoid ambiguity conflicts with const and volatile specializations of signature_of
+    struct signature_of<_Enum, typename std::enable_if_t<std::is_enum_v<_Enum> && !std::is_const_v<_Enum> && !std::is_volatile_v<_Enum>>>
+        : signature_of<std::underlying_type_t<_Enum>>
     {};
 
     template <typename _Key, typename _Value, typename _Compare, typename _Allocator>

--- a/tests/unittests/Message_test.cpp
+++ b/tests/unittests/Message_test.cpp
@@ -93,17 +93,24 @@ struct sdbus::signature_of<std::list<_Element, _Allocator>>
 {};
 
 namespace my {
+    enum class Enum
+    {
+        Value1,
+        Value2
+    };
+
     struct Struct
     {
         int i;
         std::string s;
         std::list<double> l;
+        Enum e;
 
         friend bool operator==(const Struct& lhs, const Struct& rhs) = default;
     };
 }
 
-SDBUSCPP_REGISTER_STRUCT(my::Struct, i, s, l);
+SDBUSCPP_REGISTER_STRUCT(my::Struct, i, s, l, e);
 
 /*-------------------------------------*/
 /* --          TEST CASES           -- */
@@ -487,7 +494,7 @@ TEST(AMessage, CanCarryDBusStructGivenAsCustomType)
 {
     auto msg = sdbus::createPlainMessage();
 
-    const my::Struct dataWritten{3545342, "hello"s, {3.14, 2.4568546}};
+    const my::Struct dataWritten{3545342, "hello"s, {3.14, 2.4568546}, my::Enum::Value2};
 
     msg << dataWritten;
     msg.seal();

--- a/tests/unittests/TypeTraits_test.cpp
+++ b/tests/unittests/TypeTraits_test.cpp
@@ -102,6 +102,9 @@ namespace
     TYPE(std::span<int16_t>)HAS_DBUS_TYPE_SIGNATURE("an")
 #endif
     TYPE(SomeEnumClass)HAS_DBUS_TYPE_SIGNATURE("y")
+    TYPE(const SomeEnumClass)HAS_DBUS_TYPE_SIGNATURE("y")
+    TYPE(volatile SomeEnumClass)HAS_DBUS_TYPE_SIGNATURE("y")
+    TYPE(const volatile SomeEnumClass)HAS_DBUS_TYPE_SIGNATURE("y")
     TYPE(SomeEnumStruct)HAS_DBUS_TYPE_SIGNATURE("x")
     TYPE(SomeClassicEnum)HAS_DBUS_TYPE_SIGNATURE("u")
     TYPE(std::map<int32_t, int64_t>)HAS_DBUS_TYPE_SIGNATURE("a{ix}")
@@ -157,6 +160,9 @@ namespace
                             , std::span<int16_t>
 #endif
                             , SomeEnumClass
+                            , const SomeEnumClass
+                            , volatile SomeEnumClass
+                            , const volatile SomeEnumClass
                             , SomeEnumStruct
                             , SomeClassicEnum
                             , std::map<int32_t, int64_t>


### PR DESCRIPTION
This fixes the template specialization ambiguity error when a `signature_of` applied upon a `const` (and/or `volatile`) enum type would render the `const` specialization and the enum specialization as two equally-ranked candidates.

Fixes #443 