### PR TITLE
refactor: make createPlainMessage public

### DIFF
--- a/include/sdbus-c++/Message.h
+++ b/include/sdbus-c++/Message.h
@@ -332,6 +332,8 @@ namespace sdbus {
         PlainMessage() = default;
     };
 
+    PlainMessage createPlainMessage();
+
     template <typename ...Elements>
     inline Message& Message::operator<<(const std::variant<Elements...>& value)
     {

--- a/src/MessageUtils.h
+++ b/src/MessageUtils.h
@@ -58,8 +58,6 @@ namespace sdbus
             return _Msg{msg, sdbus, adopt_message};
         }
     };
-
-    PlainMessage createPlainMessage();
 }
 
 #endif /* SDBUS_CXX_INTERNAL_MESSAGEUTILS_H_ */


### PR DESCRIPTION
Library clients may need to manually create plain sdbus-c++ message to be able to unit test their code.

Fixes #277 