### PR TITLE
refactor: invert dependency between Message and Connection

### DIFF
--- a/include/sdbus-c++/IObject.h
+++ b/include/sdbus-c++/IObject.h
@@ -403,7 +403,7 @@ namespace sdbus {
          *
          * @throws sdbus::Error in case of failure
          */
-        [[nodiscard]] virtual Signal createSignal(const InterfaceName& interfaceName, const SignalName& signalName) = 0;
+        [[nodiscard]] virtual Signal createSignal(const InterfaceName& interfaceName, const SignalName& signalName) const = 0;
 
         /*!
          * @brief Emits signal for this object path
@@ -419,7 +419,7 @@ namespace sdbus {
     protected: // Internal API for efficiency reasons used by high-level API helper classes
         friend SignalEmitter;
 
-        [[nodiscard]] virtual Signal createSignal(const char* interfaceName, const char* signalName) = 0;
+        [[nodiscard]] virtual Signal createSignal(const char* interfaceName, const char* signalName) const = 0;
     };
 
     // Out-of-line member definitions

--- a/include/sdbus-c++/IProxy.h
+++ b/include/sdbus-c++/IProxy.h
@@ -364,7 +364,7 @@ namespace sdbus {
          *
          * @throws sdbus::Error in case of failure
          */
-        [[nodiscard]] virtual MethodCall createMethodCall(const InterfaceName& interfaceName, const MethodName& methodName) = 0;
+        [[nodiscard]] virtual MethodCall createMethodCall(const InterfaceName& interfaceName, const MethodName& methodName) const = 0;
 
         /*!
          * @brief Calls method on the remote D-Bus object
@@ -652,7 +652,7 @@ namespace sdbus {
         friend AsyncMethodInvoker;
         friend SignalSubscriber;
 
-        [[nodiscard]] virtual MethodCall createMethodCall(const char* interfaceName, const char* methodName) = 0;
+        [[nodiscard]] virtual MethodCall createMethodCall(const char* interfaceName, const char* methodName) const = 0;
         virtual void registerSignalHandler( const char* interfaceName
                                           , const char* signalName
                                           , signal_handler signalHandler ) = 0;

--- a/include/sdbus-c++/Message.h
+++ b/include/sdbus-c++/Message.h
@@ -58,7 +58,7 @@ namespace sdbus {
     class UnixFd;
     class MethodReply;
     namespace internal {
-        class ISdBus;
+        class IConnection;
     }
 }
 
@@ -245,15 +245,15 @@ namespace sdbus {
 
     protected:
         Message() = default;
-        explicit Message(internal::ISdBus* sdbus) noexcept;
-        Message(void *msg, internal::ISdBus* sdbus) noexcept;
-        Message(void *msg, internal::ISdBus* sdbus, adopt_message_t) noexcept;
+        explicit Message(internal::IConnection* connection) noexcept;
+        Message(void *msg, internal::IConnection* connection) noexcept;
+        Message(void *msg, internal::IConnection* connection, adopt_message_t) noexcept;
 
         friend Factory;
 
     protected:
         void* msg_{};
-        internal::ISdBus* sdbus_{};
+        internal::IConnection* connection_{};
         mutable bool ok_{true};
     };
 
@@ -275,7 +275,7 @@ namespace sdbus {
         bool doesntExpectReply() const;
 
     protected:
-        MethodCall(void *msg, internal::ISdBus* sdbus, adopt_message_t) noexcept;
+        MethodCall(void *msg, internal::IConnection* connection, adopt_message_t) noexcept;
 
     private:
         MethodReply sendWithReply(uint64_t timeout = 0) const;

--- a/src/Connection.h
+++ b/src/Connection.h
@@ -120,9 +120,6 @@ namespace sdbus::internal {
         void detachSdEventLoop() override;
         sd_event *getSdEventLoop() override;
 
-        [[nodiscard]] const ISdBus& getSdBusInterface() const override;
-        [[nodiscard]] ISdBus& getSdBusInterface() override;
-
         Slot addObjectVTable( const ObjectPath& objectPath
                             , const InterfaceName& interfaceName
                             , const sd_bus_vtable* vtable
@@ -145,9 +142,6 @@ namespace sdbus::internal {
                                          , const char* interfaceName
                                          , const char* signalName ) const override;
 
-        MethodReply callMethod(const MethodCall& message, uint64_t timeout) override;
-        Slot callMethod(const MethodCall& message, void* callback, void* userData, uint64_t timeout, return_slot_t) override;
-
         void emitPropertiesChangedSignal( const ObjectPath& objectPath
                                         , const InterfaceName& interfaceName
                                         , const std::vector<PropertyName>& propNames ) override;
@@ -168,6 +162,20 @@ namespace sdbus::internal {
                                   , sd_bus_message_handler_t callback
                                   , void* userData
                                   , return_slot_t ) override;
+
+        sd_bus_message* incrementMessageRefCount(sd_bus_message* sdbusMsg) override;
+        sd_bus_message* decrementMessageRefCount(sd_bus_message* sdbusMsg) override;
+
+        int querySenderCredentials(sd_bus_message* sdbusMsg, uint64_t mask, sd_bus_creds **creds) override;
+        sd_bus_creds* incrementCredsRefCount(sd_bus_creds* creds) override;
+        sd_bus_creds* decrementCredsRefCount(sd_bus_creds* creds) override;
+
+        sd_bus_message* callMethod(sd_bus_message* sdbusMsg, uint64_t timeout) override;
+        Slot callMethodAsync(sd_bus_message* sdbusMsg, sd_bus_message_handler_t callback, void* userData, uint64_t timeout, return_slot_t) override;
+        void sendMessage(sd_bus_message* sdbusMsg) override;
+
+        sd_bus_message* createMethodReply(sd_bus_message* sdbusMsg) override;
+        sd_bus_message* createErrorReplyMessage(sd_bus_message* sdbusMsg, const Error& error) override;
 
     private:
         using BusFactory = std::function<int(sd_bus**)>;

--- a/src/ISdBus.h
+++ b/src/ISdBus.h
@@ -98,6 +98,7 @@ namespace sdbus::internal {
         virtual int sd_bus_message_set_destination(sd_bus_message *m, const char *destination) = 0;
 
         virtual int sd_bus_query_sender_creds(sd_bus_message *m, uint64_t mask, sd_bus_creds **c) = 0;
+        virtual sd_bus_creds* sd_bus_creds_ref(sd_bus_creds *c) = 0;
         virtual sd_bus_creds* sd_bus_creds_unref(sd_bus_creds *c) = 0;
 
         virtual int sd_bus_creds_get_pid(sd_bus_creds *c, pid_t *pid) = 0;

--- a/src/MessageUtils.h
+++ b/src/MessageUtils.h
@@ -47,15 +47,15 @@ namespace sdbus
         }
 
         template<typename _Msg>
-        static _Msg create(void *msg, internal::ISdBus* sdbus)
+        static _Msg create(void *msg, internal::IConnection* connection)
         {
-            return _Msg{msg, sdbus};
+            return _Msg{msg, connection};
         }
 
         template<typename _Msg>
-        static _Msg create(void *msg, internal::ISdBus* sdbus, adopt_message_t)
+        static _Msg create(void *msg, internal::IConnection* connection, adopt_message_t)
         {
-            return _Msg{msg, sdbus, adopt_message};
+            return _Msg{msg, connection, adopt_message};
         }
     };
 }

--- a/src/Object.cpp
+++ b/src/Object.cpp
@@ -83,12 +83,12 @@ void Object::unregister()
     objectManagerSlot_.reset();
 }
 
-sdbus::Signal Object::createSignal(const InterfaceName& interfaceName, const SignalName& signalName)
+Signal Object::createSignal(const InterfaceName& interfaceName, const SignalName& signalName) const
 {
     return connection_.createSignal(objectPath_, interfaceName, signalName);
 }
 
-sdbus::Signal Object::createSignal(const char* interfaceName, const char* signalName)
+Signal Object::createSignal(const char* interfaceName, const char* signalName) const
 {
     return connection_.createSignal(objectPath_.c_str(), interfaceName, signalName);
 }
@@ -326,7 +326,7 @@ int Object::sdbus_method_callback(sd_bus_message *sdbusMessage, void *userData, 
     assert(vtable != nullptr);
     assert(vtable->object != nullptr);
 
-    auto message = Message::Factory::create<MethodCall>(sdbusMessage, &vtable->object->connection_.getSdBusInterface());
+    auto message = Message::Factory::create<MethodCall>(sdbusMessage, &vtable->object->connection_);
 
     const auto* methodItem = findMethod(*vtable, message.getMemberName());
     assert(methodItem != nullptr);
@@ -359,7 +359,7 @@ int Object::sdbus_property_get_callback( sd_bus */*bus*/
         return 1;
     }
 
-    auto reply = Message::Factory::create<PropertyGetReply>(sdbusReply, &vtable->object->connection_.getSdBusInterface());
+    auto reply = Message::Factory::create<PropertyGetReply>(sdbusReply, &vtable->object->connection_);
 
     auto ok = invokeHandlerAndCatchErrors([&](){ propertyItem->getCallback(reply); }, retError);
 
@@ -382,7 +382,7 @@ int Object::sdbus_property_set_callback( sd_bus */*bus*/
     assert(propertyItem != nullptr);
     assert(propertyItem->setCallback);
 
-    auto value = Message::Factory::create<PropertySetCall>(sdbusValue, &vtable->object->connection_.getSdBusInterface());
+    auto value = Message::Factory::create<PropertySetCall>(sdbusValue, &vtable->object->connection_);
 
     auto ok = invokeHandlerAndCatchErrors([&](){ propertyItem->setCallback(std::move(value)); }, retError);
 

--- a/src/Object.h
+++ b/src/Object.h
@@ -53,8 +53,8 @@ namespace sdbus::internal {
         Slot addVTable(InterfaceName interfaceName, std::vector<VTableItem> vtable, return_slot_t) override;
         void unregister() override;
 
-        sdbus::Signal createSignal(const InterfaceName& interfaceName, const SignalName& signalName) override;
-        sdbus::Signal createSignal(const char* interfaceName, const char* signalName) override;
+        Signal createSignal(const InterfaceName& interfaceName, const SignalName& signalName) const override;
+        Signal createSignal(const char* interfaceName, const char* signalName) const override;
         void emitSignal(const sdbus::Signal& message) override;
         void emitPropertiesChangedSignal(const InterfaceName& interfaceName, const std::vector<PropertyName>& propNames) override;
         void emitPropertiesChangedSignal(const char* interfaceName, const std::vector<PropertyName>& propNames) override;

--- a/src/Proxy.h
+++ b/src/Proxy.h
@@ -56,8 +56,8 @@ namespace sdbus::internal {
              , ObjectPath objectPath
              , dont_run_event_loop_thread_t );
 
-        MethodCall createMethodCall(const InterfaceName& interfaceName, const MethodName& methodName) override;
-        MethodCall createMethodCall(const char* interfaceName, const char* methodName) override;
+        MethodCall createMethodCall(const InterfaceName& interfaceName, const MethodName& methodName) const override;
+        MethodCall createMethodCall(const char* interfaceName, const char* methodName) const override;
         MethodReply callMethod(const MethodCall& message) override;
         MethodReply callMethod(const MethodCall& message, uint64_t timeout) override;
         PendingAsyncCall callMethodAsync(const MethodCall& message, async_reply_handler asyncReplyCallback) override;

--- a/src/SdBus.cpp
+++ b/src/SdBus.cpp
@@ -454,6 +454,13 @@ int SdBus::sd_bus_query_sender_creds(sd_bus_message *m, uint64_t mask, sd_bus_cr
     return ::sd_bus_query_sender_creds(m, mask, c);
 }
 
+sd_bus_creds* SdBus::sd_bus_creds_ref(sd_bus_creds *c)
+{
+    std::lock_guard lock(sdbusMutex_);
+
+    return ::sd_bus_creds_ref(c);
+}
+
 sd_bus_creds* SdBus::sd_bus_creds_unref(sd_bus_creds *c)
 {
     std::lock_guard lock(sdbusMutex_);

--- a/src/SdBus.h
+++ b/src/SdBus.h
@@ -90,6 +90,7 @@ public:
     virtual int sd_bus_message_set_destination(sd_bus_message *m, const char *destination) override;
 
     virtual int sd_bus_query_sender_creds(sd_bus_message *m, uint64_t mask, sd_bus_creds **c) override;
+    virtual sd_bus_creds* sd_bus_creds_ref(sd_bus_creds *c) override;
     virtual sd_bus_creds* sd_bus_creds_unref(sd_bus_creds *c) override;
 
     virtual int sd_bus_creds_get_pid(sd_bus_creds *c, pid_t *pid) override;

--- a/tests/unittests/mocks/SdBusMock.h
+++ b/tests/unittests/mocks/SdBusMock.h
@@ -89,6 +89,7 @@ public:
     MOCK_METHOD2(sd_bus_message_set_destination, int(sd_bus_message *m, const char *destination));
 
     MOCK_METHOD3(sd_bus_query_sender_creds, int(sd_bus_message *, uint64_t, sd_bus_creds **));
+    MOCK_METHOD1(sd_bus_creds_ref, sd_bus_creds*(sd_bus_creds *));
     MOCK_METHOD1(sd_bus_creds_unref, sd_bus_creds*(sd_bus_creds *));
 
     MOCK_METHOD2(sd_bus_creds_get_pid, int(sd_bus_creds *, pid_t *));


### PR DESCRIPTION
This reorganizes the layers of abstraction in the sense how `Message` depends on `Connection` and vice versa. Now, `Message` has a link to the `Connection`. This replaces the shortcut link to the low-level `SdBus` interface that the `Message` kept. The interactions from `Message` now go through `Connection` which forwards them to `SdBus`. `Connection` is now a sole owner of the low-level `SdBus` interface. This allows for future changes around `SdBus` (e.g. a change from virtual functions back to non-virtual functions) without affecting the rest of the library. `Proxy`s and `Object`s can now send messages directly without having to go through `Connection`. The `Connection` no more depends on `Message` business-logic methods; it serves only as a factory for messages.

The flow for creating messages: `Proxy`/`Object` -> `Connection` -> `SdBus`
The flow for sending messages: (`Proxy`/`Object` ->) `Message` -> `Connection` -> `SdBus`

This also better reflects how dependencies are managed in the underlying sd-bus library.

Additionally, `getSdBusInterface()` methods are removed which was anyway planned, and improves the design by "Tell, don't ask" principle.

This refactoring is the necessary enabler for other upcoming improvements (regarding sending long messages, or creds refactoring, for example).