### PR TITLE
feat: introduce support for struct<->dict (de)serialization

### DIFF
--- a/tests/integrationtests/TestAdaptor.cpp
+++ b/tests/integrationtests/TestAdaptor.cpp
@@ -246,6 +246,11 @@ void TestAdaptor::sendLargeMessage(const std::map<int, std::string>& /*collectio
     //printf("Adaptor: got collection with %zu items", collection.size());
 }
 
+std::map<std::string, sdbus::Variant> TestAdaptor::returnDictionary(const std::map<std::string, sdbus::Variant>& dict)
+{
+    return dict;
+}
+
 std::string TestAdaptor::state()
 {
     return m_state;

--- a/tests/integrationtests/TestAdaptor.h
+++ b/tests/integrationtests/TestAdaptor.h
@@ -85,6 +85,7 @@ protected:
     void doPrivilegedStuff() override;
     void emitTwoSimpleSignals() override;
     void sendLargeMessage(const std::map<int, std::string>& collection) override;
+    std::map<std::string, sdbus::Variant> returnDictionary(const std::map<std::string, sdbus::Variant>& dict) override;
 
     uint32_t action() override;
     void action(const uint32_t& value) override;
@@ -147,6 +148,7 @@ protected:
     void doPrivilegedStuff() override {}
     void emitTwoSimpleSignals() override {}
     void sendLargeMessage(const std::map<int, std::string>&) override {}
+    std::map<std::string, sdbus::Variant> returnDictionary(const std::map<std::string, sdbus::Variant>&) override { return {}; }
 
     uint32_t action() override { return {}; }
     void action(const uint32_t&) override {}

--- a/tests/integrationtests/integrationtests-adaptor.h
+++ b/tests/integrationtests/integrationtests-adaptor.h
@@ -58,6 +58,7 @@ protected:
                           , sdbus::registerMethod("doPrivilegedStuff").implementedAs([this](){ return this->doPrivilegedStuff(); }).markAsPrivileged()
                           , sdbus::registerMethod("emitTwoSimpleSignals").implementedAs([this](){ return this->emitTwoSimpleSignals(); })
                           , sdbus::registerMethod("sendLargeMessage").implementedAs([this](const std::map<int, std::string>& collection){ this->sendLargeMessage(collection); })
+                          , sdbus::registerMethod("returnDictionary").implementedAs([this](const std::map<std::string, sdbus::Variant>& dictionary){ return this->returnDictionary(dictionary); })
                           , sdbus::registerSignal("simpleSignal").markAsDeprecated()
                           , sdbus::registerSignal("signalWithMap").withParameters<std::map<int32_t, std::string>>("aMap")
                           , sdbus::registerSignal("signalWithVariant").withParameters<sdbus::Variant>("aVariant")
@@ -108,6 +109,7 @@ private:
     virtual void doPrivilegedStuff() = 0;
     virtual void emitTwoSimpleSignals() = 0;
     virtual void sendLargeMessage(const std::map<int, std::string>& collection) = 0;
+    virtual std::map<std::string, sdbus::Variant> returnDictionary(const std::map<std::string, sdbus::Variant>& dict) = 0;
 
 private:
     virtual uint32_t action() = 0;


### PR DESCRIPTION
This extends the functionality of `SDBUSCPP_REGISTER_STRUCT` macro.

It now provides functionality for serializing a user-defined struct as an `a{sv}` dictionary, and for deserializing an `a{sv}` dictionary into a user-defined struct. The former one is achieved by decorating the struct with `sdbus::as_dictionary(struct)`, the latter one is an automatic behavior -- when sdbus-c++ is asked to deserialize into a struct but the data in the message is of type `a{sv}`, then the dict-to-struct deserialization is performed automatically.

There are some aspects of behavior in the serialization/deserialization functionality that can be customized by the client. Newly introduced `SDBUSCPP_ENABLE_NESTED_STRUCT2DICT_SERIALIZATION` and `SDBUSCPP_ENABLE_RELAXED_DICT2STRUCT_DESERIALIZATION` macros serve the purpose.

Closes https://github.com/Kistler-Group/sdbus-cpp/issues/397