### PR TITLE
Added -v, --version command line tool options to xml2cpp 

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -6,8 +6,6 @@ cmake_minimum_required(VERSION 3.5)
 
 project(sdbus-c++-tools VERSION 2.0.0)
 
-set(sdbus-c++-tools_VERSION ${CMAKE_PROJECT_VERSION})
-
 include(GNUInstallDirs)
 
 #-------------------------------
@@ -46,7 +44,7 @@ set(CMAKE_CXX_STANDARD 14)
 add_executable(sdbus-c++-xml2cpp ${SDBUSCPP_XML2CPP_SRCS})
 target_link_libraries (sdbus-c++-xml2cpp ${EXPAT_LIBRARIES})
 target_include_directories(sdbus-c++-xml2cpp PRIVATE ${EXPAT_INCLUDE_DIRS})
-target_compile_definitions(sdbus-c++-xml2cpp PRIVATE SDBUS_XML2CPP_VERSION="${sdbus-c++-tools_VERSION}")
+target_compile_definitions(sdbus-c++-xml2cpp PRIVATE SDBUS_XML2CPP_VERSION="${CMAKE_PROJECT_VERSION}")
 
 #----------------------------------
 # CMAKE CONFIG & PACKAGE CONFIG

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -6,6 +6,8 @@ cmake_minimum_required(VERSION 3.5)
 
 project(sdbus-c++-tools VERSION 2.0.0)
 
+set(sdbus-c++-tools_VERSION ${CMAKE_PROJECT_VERSION})
+
 include(GNUInstallDirs)
 
 #-------------------------------
@@ -44,6 +46,7 @@ set(CMAKE_CXX_STANDARD 14)
 add_executable(sdbus-c++-xml2cpp ${SDBUSCPP_XML2CPP_SRCS})
 target_link_libraries (sdbus-c++-xml2cpp ${EXPAT_LIBRARIES})
 target_include_directories(sdbus-c++-xml2cpp PRIVATE ${EXPAT_INCLUDE_DIRS})
+target_compile_definitions(sdbus-c++-xml2cpp PRIVATE SDBUS_XML2CPP_VERSION="${sdbus-c++-tools_VERSION}")
 
 #----------------------------------
 # CMAKE CONFIG & PACKAGE CONFIG

--- a/tools/xml2cpp-codegen/xml2cpp.cpp
+++ b/tools/xml2cpp-codegen/xml2cpp.cpp
@@ -51,7 +51,7 @@ void usage(std::ostream& output, const char* programName)
             "      --adaptor=FILE   Generate header file FILE with stub class (server)" << endl <<
             "  -h, --help           " << endl <<
             "      --verbose        Explain what is being done" << endl <<
-            "  -v, --version        Prints out the current SDBus version used by the tool" << endl <<
+            "  -v, --version        Prints out sdbus-c++ version used by the tool" << endl <<
             endl <<
             "The stub generator takes an XML file describing DBus interface and creates" << endl <<
             "C++ header files to be used by C++ code wanting to cumminicate through that" << endl <<

--- a/tools/xml2cpp-codegen/xml2cpp.cpp
+++ b/tools/xml2cpp-codegen/xml2cpp.cpp
@@ -51,6 +51,7 @@ void usage(std::ostream& output, const char* programName)
             "      --adaptor=FILE   Generate header file FILE with stub class (server)" << endl <<
             "  -h, --help           " << endl <<
             "      --verbose        Explain what is being done" << endl <<
+            "  -v, --version        Prints out the current SDBus version used by the tool" << endl <<
             endl <<
             "The stub generator takes an XML file describing DBus interface and creates" << endl <<
             "C++ header files to be used by C++ code wanting to cumminicate through that" << endl <<
@@ -102,6 +103,11 @@ int main(int argc, char **argv)
         else if (!strcmp(*argv, "--help") || !strcmp(*argv, "-h"))
         {
             usage(std::cout, programName);
+            return 0;
+        }
+        else if (!strcmp(*argv, "--version") || !strcmp(*argv, "-v"))
+        {
+            std::cout << "Version: " << SDBUS_XML2CPP_VERSION << std::endl;
             return 0;
         }
         else if (!strcmp(*argv, "--verbose"))


### PR DESCRIPTION
Adds the `-v, --version` command line tool options to the `xml2cpp` tool.

Closes https://github.com/Kistler-Group/sdbus-cpp/issues/460 

Usage:
```bash
$ ./sdbus-c++-xml2cpp --version
Version: 2.0.0
```

```bash
$ ./sdbus-c++-xml2cpp -v
Version: 2.0.0
```