### PR TITLE
This patch fixes the annotation registration generated code.

### DIFF
--- a/tools/xml2cpp-codegen/AdaptorGenerator.cpp
+++ b/tools/xml2cpp-codegen/AdaptorGenerator.cpp
@@ -121,7 +121,7 @@ std::string AdaptorGenerator::processInterface(Node& interface) const
     if(!annotationRegistration.empty())
     {
         std::stringstream str;
-        str << "sdbus::setInterfaceFlags()" << annotationRegistration << ";";
+        str << "sdbus::setInterfaceFlags()" << annotationRegistration;
         annotationRegistration = str.str();
     }
 


### PR DESCRIPTION
Before the patch, generating an adaptor from https://gitlab.freedesktop.org/hadess/mpris-spec/-/blob/master/spec/org.mpris.MediaPlayer2.xml would produce incorrect code like this:
```
        m_object.addVTable( sdbus::setInterfaceFlags().withPropertyUpdateBehavior(sdbus::Flags::EMITS_CHANGE_SIGNAL);
                          , sdbus::registerMethod("Raise").implementedAs([this](){ return this->Raise(); })
                          , sdbus::registerMethod("Quit").implementedAs([this](){ return this->Quit(); })
...

```

With this patch, the code produced is:
```
        m_object.addVTable( sdbus::setInterfaceFlags().withPropertyUpdateBehavior(sdbus::Flags::EMITS_CHANGE_SIGNAL)
                          , sdbus::registerMethod("Raise").implementedAs([this](){ return this->Raise(); })
                          , sdbus::registerMethod("Quit").implementedAs([this](){ return this->Quit(); })
...

```