### PR TITLE
fix: replace variable 's' with 'source' in deleteSdEventSource

### DIFF
--- a/src/Connection.cpp
+++ b/src/Connection.cpp
@@ -466,8 +466,8 @@ void Connection::deleteSdEventSource(sd_event_source *source)
 #if LIBSYSTEMD_VERSION>=243
     sd_event_source_disable_unref(source);
 #else
-    sd_event_source_set_enabled(s, SD_EVENT_OFF);
-    sd_event_source_unref(s);
+    sd_event_source_set_enabled(source, SD_EVENT_OFF);
+    sd_event_source_unref(source);
 #endif
 }
 


### PR DESCRIPTION
This PR fixes a variable name typo in `Connection::deleteSdEventSource` in src/Connection.cpp.

In the `#else` branch (used when `LIBSYSTEMD_VERSION < 243`), the code used the variable `s` instead of the function parameter `source`:

```
sd_event_source_set_enabled(s, SD_EVENT_OFF);
sd_event_source_unref(s);
```

This can lead to a compilation error if `s` is undefined, or unintended behavior.

The fix replaces `s` with `source` to ensure the correct event source is unreferenced.

```diff
- sd_event_source_set_enabled(s, SD_EVENT_OFF);
- sd_event_source_unref(s);
+ sd_event_source_set_enabled(source, SD_EVENT_OFF);
+ sd_event_source_unref(source);
```