### PR TITLE
Move only callables

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,3 @@
+# TODO: Introduce common clang-format rule set
+DisableFormat: true
+SortIncludes: false

--- a/include/sdbus-c++/ConvenienceApiClasses.inl
+++ b/include/sdbus-c++/ConvenienceApiClasses.inl
@@ -304,7 +304,7 @@ namespace sdbus {
     template <typename Function>
     inline async_reply_handler AsyncMethodInvoker::makeAsyncReplyHandler(Function&& callback)
     {
-        return [callback = std::forward<Function>(callback)](MethodReply reply, std::optional<Error> error)
+        return [callback = std::forward<Function>(callback)](MethodReply reply, std::optional<Error> error) mutable
         {
             // Create a tuple of callback input arguments' types, which will be used
             // as a storage for the argument values deserialized from the message.

--- a/include/sdbus-c++/ConvenienceApiClasses.inl
+++ b/include/sdbus-c++/ConvenienceApiClasses.inl
@@ -334,18 +334,18 @@ namespace sdbus {
     template <typename... Args>
     std::future<future_return_t<Args...>> AsyncMethodInvoker::getResultAsFuture()
     {
-        auto promise = std::make_shared<std::promise<future_return_t<Args...>>>();
-        auto future = promise->get_future();
+        std::promise<future_return_t<Args...>> promise{};
+        auto future = promise.get_future();
 
-        uponReplyInvoke([promise = std::move(promise)](std::optional<Error> error, Args... args)
+        uponReplyInvoke([promise = std::move(promise)](std::optional<Error> error, Args... args) mutable
         {
             if (!error)
                 if constexpr (!std::is_void_v<future_return_t<Args...>>)
-                    promise->set_value({std::move(args)...});
+                    promise.set_value({std::move(args)...});
                 else
-                    promise->set_value();
+                    promise.set_value();
             else
-                promise->set_exception(std::make_exception_ptr(*std::move(error)));
+                promise.set_exception(std::make_exception_ptr(*std::move(error)));
         });
 
         // Will be std::future<void> for no D-Bus method return value

--- a/include/sdbus-c++/ConvenienceApiClasses.inl
+++ b/include/sdbus-c++/ConvenienceApiClasses.inl
@@ -436,7 +436,7 @@ namespace sdbus {
     template <typename Function>
     inline signal_handler SignalSubscriber::makeSignalHandler(Function&& callback)
     {
-        return [callback = std::forward<Function>(callback)](Signal signal)
+        return [callback = std::forward<Function>(callback)](Signal signal) mutable
         {
             // Create a tuple of callback input arguments' types, which will be used
             // as a storage for the argument values deserialized from the signal message.

--- a/include/sdbus-c++/IConnection.h
+++ b/include/sdbus-c++/IConnection.h
@@ -277,7 +277,7 @@ namespace sdbus {
          *
          * @throws sdbus::Error in case of failure
          */
-        virtual void addMatch(const std::string& match, message_handler callback) = 0;
+        virtual void addMatch(const std::string& match, message_handler&& callback) = 0;
 
         /*!
          * @brief Installs a match rule for messages received on this bus connection
@@ -300,14 +300,14 @@ namespace sdbus {
          *
          * @throws sdbus::Error in case of failure
          */
-        [[nodiscard]] virtual Slot addMatch(const std::string& match, message_handler callback, return_slot_t) = 0;
+        [[nodiscard]] virtual Slot addMatch(const std::string& match, message_handler&& callback, return_slot_t) = 0;
 
         /*!
          * @brief Asynchronously installs a floating match rule for messages received on this bus connection
          *
          * @param[in] match Match expression to filter incoming D-Bus message
          * @param[in] callback Callback handler to be called upon processing an inbound D-Bus message matching the rule
-         * @param[in] installCallback Callback handler to be called upon processing an inbound D-Bus message matching the rule
+         * @param[in] installCallback One-shot handler invoked once with the broker's response to the install request
          *
          * This method operates the same as `addMatch()` above, just that it installs the match rule asynchronously,
          * in a non-blocking fashion. A request is sent to the broker, but the call does not wait for a response.
@@ -323,14 +323,14 @@ namespace sdbus {
          *
          * @throws sdbus::Error in case of failure
          */
-        virtual void addMatchAsync(const std::string& match, message_handler callback, message_handler installCallback) = 0;
+        virtual void addMatchAsync(const std::string& match, message_handler&& callback, match_install_handler&& installCallback) = 0;
 
         /*!
          * @brief Asynchronously installs a match rule for messages received on this bus connection
          *
          * @param[in] match Match expression to filter incoming D-Bus message
          * @param[in] callback Callback handler to be called upon processing an inbound D-Bus message matching the rule
-         * @param[in] installCallback Callback handler to be called upon processing an inbound D-Bus message matching the rule
+         * @param[in] installCallback One-shot handler invoked once with the broker's response to the install request
          * @return RAII-style slot handle representing the ownership of the subscription
          *
          * This method operates the same as `addMatch()` above, just that it installs the match rule asynchronously,
@@ -347,8 +347,8 @@ namespace sdbus {
          * @throws sdbus::Error in case of failure
          */
         [[nodiscard]] virtual Slot addMatchAsync( const std::string& match
-                                                , message_handler callback
-                                                , message_handler installCallback
+                                                , message_handler&& callback
+                                                , match_install_handler&& installCallback
                                                 , return_slot_t ) = 0;
 
         /*!

--- a/include/sdbus-c++/IObject.h
+++ b/include/sdbus-c++/IObject.h
@@ -442,13 +442,23 @@ namespace sdbus {
     template <typename... VTableItems, typename>
     void IObject::addVTable(InterfaceName interfaceName, VTableItems&&... items)
     {
-        addVTable(std::move(interfaceName), {std::forward<VTableItems>(items)...});
+        // Built via emplace_back rather than a braced initializer_list: items hold move-only
+        // callbacks, and initializer_list elements are const (copy-only).
+        std::vector<VTableItem> vtable;
+        vtable.reserve(sizeof...(items));
+        (vtable.emplace_back(std::forward<VTableItems>(items)), ...);
+        addVTable(std::move(interfaceName), std::move(vtable));
     }
 
     template <typename... VTableItems, typename>
     VTableAdder IObject::addVTable(VTableItems&&... items)
     {
-        return addVTable(std::vector<VTableItem>{std::forward<VTableItems>(items)...});
+        // Built via emplace_back rather than a braced initializer_list: items hold move-only
+        // callbacks, and initializer_list elements are const (copy-only).
+        std::vector<VTableItem> vtable;
+        vtable.reserve(sizeof...(items));
+        (vtable.emplace_back(std::forward<VTableItems>(items)), ...);
+        return addVTable(std::move(vtable));
     }
 
     inline VTableAdder IObject::addVTable(std::vector<VTableItem> vtable)

--- a/include/sdbus-c++/IProxy.h
+++ b/include/sdbus-c++/IProxy.h
@@ -455,7 +455,7 @@ namespace sdbus {
          *
          * @throws sdbus::Error in case of failure
          */
-        virtual PendingAsyncCall callMethodAsync(const MethodCall& message, async_reply_handler asyncReplyCallback) = 0;
+        virtual PendingAsyncCall callMethodAsync(const MethodCall& message, async_reply_handler&& asyncReplyCallback) = 0;
 
         /*!
          * @brief Calls method on the D-Bus object asynchronously
@@ -480,7 +480,7 @@ namespace sdbus {
          * @throws sdbus::Error in case of failure
          */
         [[nodiscard]] virtual Slot callMethodAsync( const MethodCall& message
-                                                  , async_reply_handler asyncReplyCallback
+                                                  , async_reply_handler&& asyncReplyCallback
                                                   , return_slot_t ) = 0;
 
         /*!
@@ -506,7 +506,7 @@ namespace sdbus {
          * @throws sdbus::Error in case of failure
          */
         virtual PendingAsyncCall callMethodAsync( const MethodCall& message
-                                                , async_reply_handler asyncReplyCallback
+                                                , async_reply_handler&& asyncReplyCallback
                                                 , uint64_t timeout ) = 0;
 
         /*!
@@ -533,7 +533,7 @@ namespace sdbus {
          * @throws sdbus::Error in case of failure
          */
         [[nodiscard]] virtual Slot callMethodAsync( const MethodCall& message
-                                                  , async_reply_handler asyncReplyCallback
+                                                  , async_reply_handler&& asyncReplyCallback
                                                   , uint64_t timeout
                                                   , return_slot_t ) = 0;
 
@@ -542,7 +542,7 @@ namespace sdbus {
          */
         template <typename Rep, typename Period>
         PendingAsyncCall callMethodAsync( const MethodCall& message
-                                        , async_reply_handler asyncReplyCallback
+                                        , async_reply_handler&& asyncReplyCallback
                                         , const std::chrono::duration<Rep, Period>& timeout );
 
         /*!
@@ -550,7 +550,7 @@ namespace sdbus {
          */
         template <typename Rep, typename Period>
         [[nodiscard]] Slot callMethodAsync( const MethodCall& message
-                                          , async_reply_handler asyncReplyCallback
+                                          , async_reply_handler&& asyncReplyCallback
                                           , const std::chrono::duration<Rep, Period>& timeout
                                           , return_slot_t );
 
@@ -669,7 +669,7 @@ namespace sdbus {
          */
         virtual void registerSignalHandler( const InterfaceName& interfaceName
                                           , const SignalName& signalName
-                                          , signal_handler signalHandler ) = 0;
+                                          , signal_handler&& signalHandler ) = 0;
 
         /*!
          * @brief Registers a handler for the desired signal emitted by the D-Bus object
@@ -689,7 +689,7 @@ namespace sdbus {
          */
         [[nodiscard]] virtual Slot registerSignalHandler( const InterfaceName& interfaceName
                                                         , const SignalName& signalName
-                                                        , signal_handler signalHandler
+                                                        , signal_handler&& signalHandler
                                                         , return_slot_t ) = 0;
 
     protected: // Internal API for efficiency reasons used by high-level API helper classes
@@ -700,10 +700,10 @@ namespace sdbus {
         [[nodiscard]] virtual MethodCall createMethodCall(const char* interfaceName, const char* methodName) const = 0;
         virtual void registerSignalHandler( const char* interfaceName
                                           , const char* signalName
-                                          , signal_handler signalHandler ) = 0;
+                                          , signal_handler&& signalHandler ) = 0;
         [[nodiscard]] virtual Slot registerSignalHandler( const char* interfaceName
                                                         , const char* signalName
-                                                        , signal_handler signalHandler
+                                                        , signal_handler&& signalHandler
                                                         , return_slot_t ) = 0;
     };
 
@@ -759,7 +759,7 @@ namespace sdbus {
 
     template <typename Rep, typename Period>
     inline PendingAsyncCall IProxy::callMethodAsync( const MethodCall& message
-                                                   , async_reply_handler asyncReplyCallback
+                                                   , async_reply_handler&& asyncReplyCallback
                                                    , const std::chrono::duration<Rep, Period>& timeout )
     {
         auto microsecs = std::chrono::duration_cast<std::chrono::microseconds>(timeout);
@@ -768,7 +768,7 @@ namespace sdbus {
 
     template <typename Rep, typename Period>
     inline Slot IProxy::callMethodAsync( const MethodCall& message
-                                       , async_reply_handler asyncReplyCallback
+                                       , async_reply_handler&& asyncReplyCallback
                                        , const std::chrono::duration<Rep, Period>& timeout
                                        , return_slot_t )
     {

--- a/include/sdbus-c++/TypeTraits.h
+++ b/include/sdbus-c++/TypeTraits.h
@@ -82,7 +82,7 @@ namespace sdbus {
     using property_get_callback = std::function<void(PropertyGetReply& reply)>;
 
     // Type-erased RAII-style handle to callbacks/subscriptions registered to sdbus-c++
-    using Slot = std::unique_ptr<void, std::function<void(void*)>>;
+    using Slot = std::unique_ptr<void, std::move_only_function<void(void*)>>;
 
     // Tag specifying that an owning handle (so-called slot) of the logical resource shall be provided to the client
     struct return_slot_t { explicit return_slot_t() = default; };

--- a/include/sdbus-c++/TypeTraits.h
+++ b/include/sdbus-c++/TypeTraits.h
@@ -75,7 +75,7 @@ namespace sdbus {
 
     // Callbacks from sdbus-c++
     using method_callback = std::function<void(MethodCall msg)>;
-    using async_reply_handler = std::function<void(MethodReply reply, std::optional<Error> error)>;
+    using async_reply_handler = std::move_only_function<void(MethodReply reply, std::optional<Error> error)>;
     using signal_handler = std::function<void(Signal signal)>;
     using message_handler = std::function<void(Message msg)>;
     using property_set_callback = std::function<void(PropertySetCall msg)>;
@@ -380,6 +380,9 @@ namespace sdbus {
         static constexpr bool is_trivial_dbus_type = false;
     };
 
+    template <typename... Types>
+    concept valid_signature = signature_of<Types...>::is_valid;
+
     // To simplify conversions of arrays to C strings
     template <typename T, std::size_t N>
     constexpr auto as_null_terminated(std::array<T, N> arr)
@@ -506,6 +509,10 @@ namespace sdbus {
 
     template <typename FunctionType>
     struct function_traits<std::function<FunctionType>> : function_traits<FunctionType>
+    {};
+
+    template <typename FunctionType>
+    struct function_traits<std::move_only_function<FunctionType>> : function_traits<FunctionType>
     {};
 
     template <class Function>

--- a/include/sdbus-c++/TypeTraits.h
+++ b/include/sdbus-c++/TypeTraits.h
@@ -74,12 +74,22 @@ namespace sdbus {
 namespace sdbus {
 
     // Callbacks from sdbus-c++
-    using method_callback = std::function<void(MethodCall msg)>;
-    using async_reply_handler = std::move_only_function<void(MethodReply reply, std::optional<Error> error)>;
-    using signal_handler = std::function<void(Signal signal)>;
-    using message_handler = std::function<void(Message msg)>;
-    using property_set_callback = std::function<void(PropertySetCall msg)>;
-    using property_get_callback = std::function<void(PropertyGetReply& reply)>;
+    // Server-side vtable entries: looked up through a const vtable, so invocation is const.
+    // Handlers should be pure w.r.t. their own state (capture shared state by ref/shared_ptr).
+    using method_callback = std::move_only_function<void(MethodCall msg) const>;
+    using property_set_callback = std::move_only_function<void(PropertySetCall msg) const>;
+    using property_get_callback = std::move_only_function<void(PropertyGetReply& reply) const>;
+
+    // Client-side reactive handlers: stored non-const, stateful captures are permitted
+    // (counters, rolling averages, debouncers).
+    using signal_handler = std::move_only_function<void(Signal signal)>;
+    using message_handler = std::move_only_function<void(Message msg)>;
+
+    // One-shot callbacks: invoked exactly once (async reply arrives / match rule installed).
+    // Rvalue-qualified so the library must std::move to invoke, making the call-once contract
+    // visible at the call site and letting handlers move-consume captured resources.
+    using async_reply_handler = std::move_only_function<void(MethodReply reply, std::optional<Error> error) &&>;
+    using match_install_handler = std::move_only_function<void(Message msg) &&>;
 
     // Type-erased RAII-style handle to callbacks/subscriptions registered to sdbus-c++
     using Slot = std::unique_ptr<void, std::move_only_function<void(void*)>>;

--- a/include/sdbus-c++/TypeTraits.h
+++ b/include/sdbus-c++/TypeTraits.h
@@ -74,14 +74,10 @@ namespace sdbus {
 namespace sdbus {
 
     // Callbacks from sdbus-c++
-    // Server-side vtable entries: looked up through a const vtable, so invocation is const.
-    // Handlers should be pure w.r.t. their own state (capture shared state by ref/shared_ptr).
-    using method_callback = std::move_only_function<void(MethodCall msg) const>;
-    using property_set_callback = std::move_only_function<void(PropertySetCall msg) const>;
-    using property_get_callback = std::move_only_function<void(PropertyGetReply& reply) const>;
-
-    // Client-side reactive handlers: stored non-const, stateful captures are permitted
-    // (counters, rolling averages, debouncers).
+    // Repeatable server-side and client-side callbacks
+    using method_callback = std::move_only_function<void(MethodCall msg)>;
+    using property_set_callback = std::move_only_function<void(PropertySetCall msg)>;
+    using property_get_callback = std::move_only_function<void(PropertyGetReply& reply)>;
     using signal_handler = std::move_only_function<void(Signal signal)>;
     using message_handler = std::move_only_function<void(Message msg)>;
 

--- a/include/sdbus-c++/VTableItems.h
+++ b/include/sdbus-c++/VTableItems.h
@@ -38,14 +38,14 @@ namespace sdbus {
 
     struct MethodVTableItem
     {
-        template <typename Function> MethodVTableItem& implementedAs(Function&& callback);
-        MethodVTableItem& withInputParamNames(std::vector<std::string> names);
-        template <typename... String> MethodVTableItem& withInputParamNames(String... names);
-        MethodVTableItem& withOutputParamNames(std::vector<std::string> names);
-        template <typename... String> MethodVTableItem& withOutputParamNames(String... names);
-        MethodVTableItem& markAsDeprecated();
-        MethodVTableItem& markAsPrivileged();
-        MethodVTableItem& withNoReply();
+        template <typename Function> MethodVTableItem&& implementedAs(Function&& callback) &&;
+        MethodVTableItem&& withInputParamNames(std::vector<std::string> names) &&;
+        template <typename... String> MethodVTableItem&& withInputParamNames(String... names) &&;
+        MethodVTableItem&& withOutputParamNames(std::vector<std::string> names) &&;
+        template <typename... String> MethodVTableItem&& withOutputParamNames(String... names) &&;
+        MethodVTableItem&& markAsDeprecated() &&;
+        MethodVTableItem&& markAsPrivileged() &&;
+        MethodVTableItem&& withNoReply() &&;
 
         MethodName name;
         Signature inputSignature;
@@ -61,10 +61,10 @@ namespace sdbus {
 
     struct SignalVTableItem
     {
-        template <typename... Args> SignalVTableItem& withParameters();
-        template <typename... Args> SignalVTableItem& withParameters(std::vector<std::string> names);
-        template <typename... Args, typename... String> SignalVTableItem& withParameters(String... names);
-        SignalVTableItem& markAsDeprecated();
+        template <typename... Args> SignalVTableItem&& withParameters() &&;
+        template <typename... Args> SignalVTableItem&& withParameters(std::vector<std::string> names) &&;
+        template <typename... Args, typename... String> SignalVTableItem&& withParameters(String... names) &&;
+        SignalVTableItem&& markAsDeprecated() &&;
 
         SignalName name;
         Signature signature;
@@ -77,11 +77,11 @@ namespace sdbus {
 
     struct PropertyVTableItem
     {
-        template <typename Function> PropertyVTableItem& withGetter(Function&& callback);
-        template <typename Function> PropertyVTableItem& withSetter(Function&& callback);
-        PropertyVTableItem& markAsDeprecated();
-        PropertyVTableItem& markAsPrivileged();
-        PropertyVTableItem& withUpdateBehavior(Flags::PropertyUpdateBehaviorFlags behavior);
+        template <typename Function> PropertyVTableItem&& withGetter(Function&& callback) &&;
+        template <typename Function> PropertyVTableItem&& withSetter(Function&& callback) &&;
+        PropertyVTableItem&& markAsDeprecated() &&;
+        PropertyVTableItem&& markAsPrivileged() &&;
+        PropertyVTableItem&& withUpdateBehavior(Flags::PropertyUpdateBehaviorFlags behavior) &&;
 
         PropertyName name;
         Signature signature;
@@ -95,10 +95,10 @@ namespace sdbus {
 
     struct InterfaceFlagsVTableItem
     {
-        InterfaceFlagsVTableItem& markAsDeprecated();
-        InterfaceFlagsVTableItem& markAsPrivileged();
-        InterfaceFlagsVTableItem& withNoReplyMethods();
-        InterfaceFlagsVTableItem& withPropertyUpdateBehavior(Flags::PropertyUpdateBehaviorFlags behavior);
+        InterfaceFlagsVTableItem&& markAsDeprecated() &&;
+        InterfaceFlagsVTableItem&& markAsPrivileged() &&;
+        InterfaceFlagsVTableItem&& withNoReplyMethods() &&;
+        InterfaceFlagsVTableItem&& withPropertyUpdateBehavior(Flags::PropertyUpdateBehaviorFlags behavior) &&;
 
         Flags flags;
     };

--- a/include/sdbus-c++/VTableItems.inl
+++ b/include/sdbus-c++/VTableItems.inl
@@ -44,7 +44,7 @@ namespace sdbus {
     {
         inputSignature = signature_of_function_input_arguments_v<Function>;
         outputSignature = signature_of_function_output_arguments_v<Function>;
-        callbackHandler = [callback = std::forward<Function>(callback)](MethodCall call)
+        callbackHandler = [callback = std::forward<Function>(callback)](MethodCall call) mutable
         {
             // Create a tuple of callback input arguments' types, which will be used
             // as a storage for the argument values deserialized from the message.
@@ -194,7 +194,7 @@ namespace sdbus {
         if (signature.empty())
             signature = signature_of_function_output_arguments_v<Function>;
 
-        getter = [callback = std::forward<Function>(callback)](PropertyGetReply& reply)
+        getter = [callback = std::forward<Function>(callback)](PropertyGetReply& reply) mutable
         {
             // Get the propety value and serialize it into the pre-constructed reply message
             reply << callback();
@@ -212,7 +212,7 @@ namespace sdbus {
         if (signature.empty())
             signature = signature_of_function_input_arguments_v<Function>;
 
-        setter = [callback = std::forward<Function>(callback)](PropertySetCall call)
+        setter = [callback = std::forward<Function>(callback)](PropertySetCall call) mutable
         {
             // Default-construct property value
             using property_type = function_argument_t<Function, 0>;

--- a/include/sdbus-c++/VTableItems.inl
+++ b/include/sdbus-c++/VTableItems.inl
@@ -40,7 +40,7 @@ namespace sdbus {
     /*** -------------------- ***/
 
     template <typename Function>
-    MethodVTableItem& MethodVTableItem::implementedAs(Function&& callback)
+    MethodVTableItem&& MethodVTableItem::implementedAs(Function&& callback) &&
     {
         inputSignature = signature_of_function_input_arguments_v<Function>;
         outputSignature = signature_of_function_output_arguments_v<Function>;
@@ -71,58 +71,58 @@ namespace sdbus {
             }
         };
 
-        return *this;
+        return std::move(*this);
     }
 
-    inline MethodVTableItem& MethodVTableItem::withInputParamNames(std::vector<std::string> names)
+    inline MethodVTableItem&& MethodVTableItem::withInputParamNames(std::vector<std::string> names) &&
     {
         inputParamNames = std::move(names);
 
-        return *this;
+        return std::move(*this);
     }
 
     template <typename... String>
-    inline MethodVTableItem& MethodVTableItem::withInputParamNames(String... names)
+    inline MethodVTableItem&& MethodVTableItem::withInputParamNames(String... names) &&
     {
         static_assert(std::conjunction_v<std::is_convertible<String, std::string>...>, "Parameter names must be (convertible to) strings");
 
-        return withInputParamNames({names...});
+        return std::move(*this).withInputParamNames({names...});
     }
 
-    inline MethodVTableItem& MethodVTableItem::withOutputParamNames(std::vector<std::string> names)
+    inline MethodVTableItem&& MethodVTableItem::withOutputParamNames(std::vector<std::string> names) &&
     {
         outputParamNames = std::move(names);
 
-        return *this;
+        return std::move(*this);
     }
 
     template <typename... String>
-    inline MethodVTableItem& MethodVTableItem::withOutputParamNames(String... names)
+    inline MethodVTableItem&& MethodVTableItem::withOutputParamNames(String... names) &&
     {
         static_assert(std::conjunction_v<std::is_convertible<String, std::string>...>, "Parameter names must be (convertible to) strings");
 
-        return withOutputParamNames({names...});
+        return std::move(*this).withOutputParamNames({names...});
     }
 
-    inline MethodVTableItem& MethodVTableItem::markAsDeprecated()
+    inline MethodVTableItem&& MethodVTableItem::markAsDeprecated() &&
     {
         flags.set(Flags::DEPRECATED);
 
-        return *this;
+        return std::move(*this);
     }
 
-    inline MethodVTableItem& MethodVTableItem::markAsPrivileged()
+    inline MethodVTableItem&& MethodVTableItem::markAsPrivileged() &&
     {
         flags.set(Flags::PRIVILEGED);
 
-        return *this;
+        return std::move(*this);
     }
 
-    inline MethodVTableItem& MethodVTableItem::withNoReply()
+    inline MethodVTableItem&& MethodVTableItem::withNoReply() &&
     {
         flags.set(Flags::METHOD_NO_REPLY);
 
-        return *this;
+        return std::move(*this);
     }
 
     inline MethodVTableItem registerMethod(MethodName methodName)
@@ -140,35 +140,35 @@ namespace sdbus {
     /*** -------------------- ***/
 
     template <typename... Args>
-    inline SignalVTableItem& SignalVTableItem::withParameters()
+    inline SignalVTableItem&& SignalVTableItem::withParameters() &&
     {
         signature = signature_of_function_input_arguments_v<void(Args...)>;
 
-        return *this;
+        return std::move(*this);
     }
 
     template <typename... Args>
-    inline SignalVTableItem& SignalVTableItem::withParameters(std::vector<std::string> names)
+    inline SignalVTableItem&& SignalVTableItem::withParameters(std::vector<std::string> names) &&
     {
         paramNames = std::move(names);
 
-        return withParameters<Args...>();
+        return std::move(*this).template withParameters<Args...>();
     }
 
     template <typename... Args, typename... String>
-    inline SignalVTableItem& SignalVTableItem::withParameters(String... names)
+    inline SignalVTableItem&& SignalVTableItem::withParameters(String... names) &&
     {
         static_assert(std::conjunction_v<std::is_convertible<String, std::string>...>, "Parameter names must be (convertible to) strings");
         static_assert(sizeof...(Args) == sizeof...(String), "Numbers of signal parameters and their names don't match");
 
-        return withParameters<Args...>({names...});
+        return std::move(*this).template withParameters<Args...>({names...});
     }
 
-    inline SignalVTableItem& SignalVTableItem::markAsDeprecated()
+    inline SignalVTableItem&& SignalVTableItem::markAsDeprecated() &&
     {
         flags.set(Flags::DEPRECATED);
 
-        return *this;
+        return std::move(*this);
     }
 
     inline SignalVTableItem registerSignal(SignalName signalName)
@@ -186,7 +186,7 @@ namespace sdbus {
     /*** -------------------- ***/
 
     template <typename Function>
-    inline PropertyVTableItem& PropertyVTableItem::withGetter(Function&& callback)
+    inline PropertyVTableItem&& PropertyVTableItem::withGetter(Function&& callback) &&
     {
         static_assert(function_argument_count_v<Function> == 0, "Property getter function must not take any arguments");
         static_assert(!std::is_void_v<function_result_t<Function>>, "Property getter function must return property value");
@@ -200,11 +200,11 @@ namespace sdbus {
             reply << callback();
         };
 
-        return *this;
+        return std::move(*this);
     }
 
     template <typename Function>
-    inline PropertyVTableItem& PropertyVTableItem::withSetter(Function&& callback)
+    inline PropertyVTableItem&& PropertyVTableItem::withSetter(Function&& callback) &&
     {
         static_assert(function_argument_count_v<Function> == 1, "Property setter function must take one parameter - the property value");
         static_assert(std::is_void_v<function_result_t<Function>>, "Property setter function must not return any value");
@@ -225,28 +225,28 @@ namespace sdbus {
             callback(property);
         };
 
-        return *this;
+        return std::move(*this);
     }
 
-    inline PropertyVTableItem& PropertyVTableItem::markAsDeprecated()
+    inline PropertyVTableItem&& PropertyVTableItem::markAsDeprecated() &&
     {
         flags.set(Flags::DEPRECATED);
 
-        return *this;
+        return std::move(*this);
     }
 
-    inline PropertyVTableItem& PropertyVTableItem::markAsPrivileged()
+    inline PropertyVTableItem&& PropertyVTableItem::markAsPrivileged() &&
     {
         flags.set(Flags::PRIVILEGED);
 
-        return *this;
+        return std::move(*this);
     }
 
-    inline PropertyVTableItem& PropertyVTableItem::withUpdateBehavior(Flags::PropertyUpdateBehaviorFlags behavior)
+    inline PropertyVTableItem&& PropertyVTableItem::withUpdateBehavior(Flags::PropertyUpdateBehaviorFlags behavior) &&
     {
         flags.set(behavior);
 
-        return *this;
+        return std::move(*this);
     }
 
     inline PropertyVTableItem registerProperty(PropertyName propertyName)
@@ -263,32 +263,32 @@ namespace sdbus {
     /*** Interface Flags VTable Item ***/
     /*** --------------------------- ***/
 
-    inline InterfaceFlagsVTableItem& InterfaceFlagsVTableItem::markAsDeprecated()
+    inline InterfaceFlagsVTableItem&& InterfaceFlagsVTableItem::markAsDeprecated() &&
     {
         flags.set(Flags::DEPRECATED);
 
-        return *this;
+        return std::move(*this);
     }
 
-    inline InterfaceFlagsVTableItem& InterfaceFlagsVTableItem::markAsPrivileged()
+    inline InterfaceFlagsVTableItem&& InterfaceFlagsVTableItem::markAsPrivileged() &&
     {
         flags.set(Flags::PRIVILEGED);
 
-        return *this;
+        return std::move(*this);
     }
 
-    inline InterfaceFlagsVTableItem& InterfaceFlagsVTableItem::withNoReplyMethods()
+    inline InterfaceFlagsVTableItem&& InterfaceFlagsVTableItem::withNoReplyMethods() &&
     {
         flags.set(Flags::METHOD_NO_REPLY);
 
-        return *this;
+        return std::move(*this);
     }
 
-    inline InterfaceFlagsVTableItem& InterfaceFlagsVTableItem::withPropertyUpdateBehavior(Flags::PropertyUpdateBehaviorFlags behavior)
+    inline InterfaceFlagsVTableItem&& InterfaceFlagsVTableItem::withPropertyUpdateBehavior(Flags::PropertyUpdateBehaviorFlags behavior) &&
     {
         flags.set(behavior);
 
-        return *this;
+        return std::move(*this);
     }
 
     inline InterfaceFlagsVTableItem setInterfaceFlags()

--- a/src/Connection.cpp
+++ b/src/Connection.cpp
@@ -58,9 +58,9 @@
 
 namespace sdbus::internal {
 
-Connection::Connection(std::unique_ptr<ISdBus>&& interface, const BusFactory& busFactory)
+Connection::Connection(std::unique_ptr<ISdBus>&& interface, BusFactory&& busFactory)
     : sdbus_(std::move(interface))
-    , bus_(openBus(busFactory))
+    , bus_(openBus(std::move(busFactory)))
 {
     assert(sdbus_ != nullptr);
 }
@@ -739,7 +739,7 @@ sd_bus_message* Connection::createErrorReplyMessage(sd_bus_message* sdbusMsg, co
     return sdbusErrorReply;
 }
 
-Connection::BusPtr Connection::openBus(const BusFactory& busFactory)
+Connection::BusPtr Connection::openBus(BusFactory&& busFactory)
 {
     sd_bus* bus{};
     const int r = busFactory(&bus);

--- a/src/Connection.cpp
+++ b/src/Connection.cpp
@@ -238,12 +238,12 @@ uint64_t Connection::getMethodCallTimeout() const
     return timeout;
 }
 
-void Connection::addMatch(const std::string& match, message_handler callback)
+void Connection::addMatch(const std::string& match, message_handler&& callback)
 {
     floatingMatchRules_.push_back(addMatch(match, std::move(callback), return_slot));
 }
 
-Slot Connection::addMatch(const std::string& match, message_handler callback, return_slot_t)
+Slot Connection::addMatch(const std::string& match, message_handler&& callback, return_slot_t)
 {
     SDBUS_THROW_ERROR_IF(!callback, "Invalid match callback handler provided", EINVAL);
 
@@ -258,14 +258,14 @@ Slot Connection::addMatch(const std::string& match, message_handler callback, re
     return {matchInfo.release(), [](void *ptr){ delete static_cast<MatchInfo*>(ptr); }}; // NOLINT(cppcoreguidelines-owning-memory)
 }
 
-void Connection::addMatchAsync(const std::string& match, message_handler callback, message_handler installCallback)
+void Connection::addMatchAsync(const std::string& match, message_handler&& callback, match_install_handler&& installCallback)
 {
     floatingMatchRules_.push_back(addMatchAsync(match, std::move(callback), std::move(installCallback), return_slot));
 }
 
 Slot Connection::addMatchAsync( const std::string& match
-                              , message_handler callback
-                              , message_handler installCallback
+                              , message_handler&& callback
+                              , match_install_handler&& installCallback
                               , return_slot_t )
 {
     SDBUS_THROW_ERROR_IF(!callback, "Invalid match callback handler provided", EINVAL);
@@ -920,7 +920,7 @@ int Connection::sdbus_match_install_callback(sd_bus_message *sdbusMessage, void 
 
     auto message = Message::Factory::create<PlainMessage>(sdbusMessage, &matchInfo->connection);
 
-    auto ok = invokeHandlerAndCatchErrors([&](){ matchInfo->installCallback(std::move(message)); }, retError);
+    auto ok = invokeHandlerAndCatchErrors([&](){ std::move(matchInfo->installCallback)(std::move(message)); }, retError);
 
     return ok ? 0 : -1;
 }

--- a/src/Connection.cpp
+++ b/src/Connection.cpp
@@ -742,7 +742,7 @@ sd_bus_message* Connection::createErrorReplyMessage(sd_bus_message* sdbusMsg, co
 Connection::BusPtr Connection::openBus(BusFactory&& busFactory)
 {
     sd_bus* bus{};
-    const int r = busFactory(&bus);
+    const int r = std::move(busFactory)(&bus);
     SDBUS_THROW_ERROR_IF(r < 0, "Failed to open bus", -r);
 
     BusPtr busPtr{bus, [this](sd_bus* bus){ return sdbus_->sd_bus_flush_close_unref(bus); }};

--- a/src/Connection.h
+++ b/src/Connection.h
@@ -181,11 +181,11 @@ namespace sdbus::internal {
         sd_bus_message* createErrorReplyMessage(sd_bus_message* sdbusMsg, const Error& error) override;
 
     private:
-        using BusFactory = std::move_only_function<int(sd_bus**)>;
+        using BusFactory = std::move_only_function<int(sd_bus**) &&>;
         using BusPtr = std::unique_ptr<sd_bus, std::move_only_function<sd_bus*(sd_bus*)>>;
         Connection(std::unique_ptr<ISdBus>&& interface, BusFactory&& busFactory);
 
-        BusPtr openBus(std::move_only_function<int(sd_bus**)>&& busFactory);
+        BusPtr openBus(BusFactory&& busFactory);
         BusPtr openPseudoBus();
         void finishHandshake(sd_bus* bus);
         bool waitForNextEvent();
@@ -233,8 +233,8 @@ namespace sdbus::internal {
 
         struct MatchInfo
         {
-            message_handler&& callback;
-            match_install_handler&& installCallback;
+            message_handler callback;
+            match_install_handler installCallback;
             Connection& connection; // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
             Slot slot;
         };

--- a/src/Connection.h
+++ b/src/Connection.h
@@ -181,11 +181,11 @@ namespace sdbus::internal {
         sd_bus_message* createErrorReplyMessage(sd_bus_message* sdbusMsg, const Error& error) override;
 
     private:
-        using BusFactory = std::function<int(sd_bus**)>;
+        using BusFactory = std::move_only_function<int(sd_bus**)>;
         using BusPtr = std::unique_ptr<sd_bus, std::function<sd_bus*(sd_bus*)>>;
-        Connection(std::unique_ptr<ISdBus>&& interface, const BusFactory& busFactory);
+        Connection(std::unique_ptr<ISdBus>&& interface, BusFactory&& busFactory);
 
-        BusPtr openBus(const std::function<int(sd_bus**)>& busFactory);
+        BusPtr openBus(std::move_only_function<int(sd_bus**)>&& busFactory);
         BusPtr openPseudoBus();
         void finishHandshake(sd_bus* bus);
         bool waitForNextEvent();

--- a/src/Connection.h
+++ b/src/Connection.h
@@ -111,12 +111,12 @@ namespace sdbus::internal {
         void setMethodCallTimeout(uint64_t timeout) override;
         [[nodiscard]] uint64_t getMethodCallTimeout() const override;
 
-        void addMatch(const std::string& match, message_handler callback) override;
-        [[nodiscard]] Slot addMatch(const std::string& match, message_handler callback, return_slot_t) override;
-        void addMatchAsync(const std::string& match, message_handler callback, message_handler installCallback) override;
+        void addMatch(const std::string& match, message_handler&& callback) override;
+        [[nodiscard]] Slot addMatch(const std::string& match, message_handler&& callback, return_slot_t) override;
+        void addMatchAsync(const std::string& match, message_handler&& callback, match_install_handler&& installCallback) override;
         [[nodiscard]] Slot addMatchAsync( const std::string& match
-                                        , message_handler callback
-                                        , message_handler installCallback
+                                        , message_handler&& callback
+                                        , match_install_handler&& installCallback
                                         , return_slot_t ) override;
 
         void attachSdEventLoop(sd_event *event, int priority) override;
@@ -233,8 +233,8 @@ namespace sdbus::internal {
 
         struct MatchInfo
         {
-            message_handler callback;
-            message_handler installCallback;
+            message_handler&& callback;
+            match_install_handler&& installCallback;
             Connection& connection; // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
             Slot slot;
         };

--- a/src/Connection.h
+++ b/src/Connection.h
@@ -182,7 +182,7 @@ namespace sdbus::internal {
 
     private:
         using BusFactory = std::move_only_function<int(sd_bus**)>;
-        using BusPtr = std::unique_ptr<sd_bus, std::function<sd_bus*(sd_bus*)>>;
+        using BusPtr = std::unique_ptr<sd_bus, std::move_only_function<sd_bus*(sd_bus*)>>;
         Connection(std::unique_ptr<ISdBus>&& interface, BusFactory&& busFactory);
 
         BusPtr openBus(std::move_only_function<int(sd_bus**)>&& busFactory);

--- a/src/Object.cpp
+++ b/src/Object.cpp
@@ -300,7 +300,7 @@ void Object::finalizeSdBusVTable(std::vector<sd_bus_vtable>& vtable)
     vtable.push_back(createSdBusVTableEndItem());
 }
 
-const Object::VTable::MethodItem* Object::findMethod(const VTable& vtable, std::string_view methodName)
+Object::VTable::MethodItem* Object::findMethod(VTable& vtable, std::string_view methodName)
 {
     auto it = std::lower_bound(vtable.methods.begin(), vtable.methods.end(), methodName, [](const auto& methodItem, const auto& methodName)
     {
@@ -310,7 +310,7 @@ const Object::VTable::MethodItem* Object::findMethod(const VTable& vtable, std::
     return it != vtable.methods.end() && it->name == methodName ? &*it : nullptr;
 }
 
-const Object::VTable::PropertyItem* Object::findProperty(const VTable& vtable, std::string_view propertyName)
+Object::VTable::PropertyItem* Object::findProperty(VTable& vtable, std::string_view propertyName)
 {
     auto it = std::lower_bound(vtable.properties.begin(), vtable.properties.end(), propertyName, [](const auto& propertyItem, const auto& propertyName)
     {
@@ -336,7 +336,7 @@ int Object::sdbus_method_callback(sd_bus_message *sdbusMessage, void *userData, 
 
     auto message = Message::Factory::create<MethodCall>(sdbusMessage, &vtable->object->connection_);
 
-    const auto* methodItem = findMethod(*vtable, message.getMemberName());
+    auto* methodItem = findMethod(*vtable, message.getMemberName());
     assert(methodItem != nullptr);
     assert(methodItem->callback);
 
@@ -357,7 +357,7 @@ int Object::sdbus_property_get_callback( sd_bus */*bus*/
     assert(vtable != nullptr);
     assert(vtable->object != nullptr);
 
-    const auto* propertyItem = findProperty(*vtable, property);
+    auto* propertyItem = findProperty(*vtable, property);
     assert(propertyItem != nullptr);
 
     // Getter may be empty - the case of "write-only" property
@@ -369,7 +369,7 @@ int Object::sdbus_property_get_callback( sd_bus */*bus*/
 
     auto reply = Message::Factory::create<PropertyGetReply>(sdbusReply, &vtable->object->connection_);
 
-    auto ok = invokeHandlerAndCatchErrors([&](){ propertyItem->getCallback(reply); }, retError);
+    auto ok = invokeHandlerAndCatchErrors([&] { propertyItem->getCallback(reply); }, retError);
 
     return ok ? 1 : -1;
 }
@@ -386,7 +386,7 @@ int Object::sdbus_property_set_callback( sd_bus */*bus*/
     assert(vtable != nullptr);
     assert(vtable->object != nullptr);
 
-    const auto* propertyItem = findProperty(*vtable, property);
+    auto* propertyItem = findProperty(*vtable, property);
     assert(propertyItem != nullptr);
     assert(propertyItem->setCallback);
 

--- a/src/Object.cpp
+++ b/src/Object.cpp
@@ -340,7 +340,7 @@ int Object::sdbus_method_callback(sd_bus_message *sdbusMessage, void *userData, 
     assert(methodItem != nullptr);
     assert(methodItem->callback);
 
-    auto ok = invokeHandlerAndCatchErrors([&] mutable { methodItem->callback(std::move(message)); }, retError);
+    auto ok = invokeHandlerAndCatchErrors([&] { methodItem->callback(std::move(message)); }, retError);
 
     return ok ? 1 : -1;
 }
@@ -392,7 +392,7 @@ int Object::sdbus_property_set_callback( sd_bus */*bus*/
 
     auto value = Message::Factory::create<PropertySetCall>(sdbusValue, &vtable->object->connection_);
 
-    auto ok = invokeHandlerAndCatchErrors([&] mutable { propertyItem->setCallback(std::move(value)); }, retError);
+    auto ok = invokeHandlerAndCatchErrors([&] { propertyItem->setCallback(std::move(value)); }, retError);
 
     return ok ? 1 : -1;
 }

--- a/src/Object.cpp
+++ b/src/Object.cpp
@@ -340,7 +340,7 @@ int Object::sdbus_method_callback(sd_bus_message *sdbusMessage, void *userData, 
     assert(methodItem != nullptr);
     assert(methodItem->callback);
 
-    auto ok = invokeHandlerAndCatchErrors([&](){ methodItem->callback(std::move(message)); }, retError);
+    auto ok = invokeHandlerAndCatchErrors([&] mutable { methodItem->callback(std::move(message)); }, retError);
 
     return ok ? 1 : -1;
 }
@@ -392,7 +392,7 @@ int Object::sdbus_property_set_callback( sd_bus */*bus*/
 
     auto value = Message::Factory::create<PropertySetCall>(sdbusValue, &vtable->object->connection_);
 
-    auto ok = invokeHandlerAndCatchErrors([&](){ propertyItem->setCallback(std::move(value)); }, retError);
+    auto ok = invokeHandlerAndCatchErrors([&] mutable { propertyItem->setCallback(std::move(value)); }, retError);
 
     return ok ? 1 : -1;
 }

--- a/src/Object.h
+++ b/src/Object.h
@@ -145,8 +145,8 @@ namespace sdbus::internal {
         static void writePropertyRecordToSdBusVTable(const VTable::PropertyItem& property, std::vector<sd_bus_vtable>& vtable);
         static void finalizeSdBusVTable(std::vector<sd_bus_vtable>& vtable);
 
-        static const VTable::MethodItem* findMethod(const VTable& vtable, std::string_view methodName);
-        static const VTable::PropertyItem* findProperty(const VTable& vtable, std::string_view propertyName);
+        static VTable::MethodItem* findMethod(VTable& vtable, std::string_view methodName);
+        static VTable::PropertyItem* findProperty(VTable& vtable, std::string_view propertyName);
 
         static std::string paramNamesToString(const std::vector<std::string>& paramNames);
 

--- a/src/Proxy.cpp
+++ b/src/Proxy.cpp
@@ -166,15 +166,15 @@ std::future<MethodReply> Proxy::callMethodAsync(const MethodCall& message, with_
 
 std::future<MethodReply> Proxy::callMethodAsync(const MethodCall& message, uint64_t timeout, with_future_t)
 {
-    auto promise = std::make_shared<std::promise<MethodReply>>();
-    auto future = promise->get_future();
+    std::promise<MethodReply> promise;
+    auto future = promise.get_future();
 
-    async_reply_handler asyncReplyCallback = [promise = std::move(promise)](MethodReply reply, std::optional<Error> error) noexcept
+    async_reply_handler asyncReplyCallback = [promise = std::move(promise)](MethodReply reply, std::optional<Error> error) mutable noexcept
     {
         if (!error)
-            promise->set_value(std::move(reply));
+            promise.set_value(std::move(reply));
         else
-            promise->set_exception(std::make_exception_ptr(*std::move(error)));
+            promise.set_exception(std::make_exception_ptr(*std::move(error)));
     };
 
     (void)Proxy::callMethodAsync(message, std::move(asyncReplyCallback), timeout);

--- a/src/Proxy.cpp
+++ b/src/Proxy.cpp
@@ -117,17 +117,17 @@ MethodReply Proxy::callMethod(const MethodCall& message, uint64_t timeout)
     return message.send(timeout);
 }
 
-PendingAsyncCall Proxy::callMethodAsync(const MethodCall& message, async_reply_handler asyncReplyCallback)
+PendingAsyncCall Proxy::callMethodAsync(const MethodCall& message, async_reply_handler&& asyncReplyCallback)
 {
     return Proxy::callMethodAsync(message, std::move(asyncReplyCallback), /*timeout*/ 0);
 }
 
-Slot Proxy::callMethodAsync(const MethodCall& message, async_reply_handler asyncReplyCallback, return_slot_t)
+Slot Proxy::callMethodAsync(const MethodCall& message, async_reply_handler&& asyncReplyCallback, return_slot_t)
 {
     return Proxy::callMethodAsync(message, std::move(asyncReplyCallback), /*timeout*/ 0, return_slot);
 }
 
-PendingAsyncCall Proxy::callMethodAsync(const MethodCall& message, async_reply_handler asyncReplyCallback, uint64_t timeout)
+PendingAsyncCall Proxy::callMethodAsync(const MethodCall& message, async_reply_handler&& asyncReplyCallback, uint64_t timeout)
 {
     SDBUS_THROW_ERROR_IF(!message.isValid(), "Invalid async method call message provided", EINVAL);
 
@@ -145,7 +145,7 @@ PendingAsyncCall Proxy::callMethodAsync(const MethodCall& message, async_reply_h
     return PendingAsyncCall{asyncCallInfoWeakPtr};
 }
 
-Slot Proxy::callMethodAsync(const MethodCall& message, async_reply_handler asyncReplyCallback, uint64_t timeout, return_slot_t)
+Slot Proxy::callMethodAsync(const MethodCall& message, async_reply_handler&& asyncReplyCallback, uint64_t timeout, return_slot_t)
 {
     SDBUS_THROW_ERROR_IF(!message.isValid(), "Invalid async method call message provided", EINVAL);
 
@@ -209,14 +209,14 @@ Awaitable<MethodReply> Proxy::callMethodAsync(const MethodCall& message, uint64_
 
 void Proxy::registerSignalHandler( const InterfaceName& interfaceName
                                  , const SignalName& signalName
-                                 , signal_handler signalHandler )
+                                 , signal_handler&& signalHandler )
 {
     Proxy::registerSignalHandler(interfaceName.c_str(), signalName.c_str(), std::move(signalHandler));
 }
 
 void Proxy::registerSignalHandler( const char* interfaceName
                                  , const char* signalName
-                                 , signal_handler signalHandler )
+                                 , signal_handler&& signalHandler )
 {
     auto slot = Proxy::registerSignalHandler(interfaceName, signalName, std::move(signalHandler), return_slot);
 
@@ -225,7 +225,7 @@ void Proxy::registerSignalHandler( const char* interfaceName
 
 Slot Proxy::registerSignalHandler( const InterfaceName& interfaceName
                                  , const SignalName& signalName
-                                 , signal_handler signalHandler
+                                 , signal_handler&& signalHandler
                                  , return_slot_t )
 {
     return Proxy::registerSignalHandler(interfaceName.c_str(), signalName.c_str(), std::move(signalHandler), return_slot);
@@ -233,7 +233,7 @@ Slot Proxy::registerSignalHandler( const InterfaceName& interfaceName
 
 Slot Proxy::registerSignalHandler( const char* interfaceName
                                  , const char* signalName
-                                 , signal_handler signalHandler
+                                 , signal_handler&& signalHandler
                                  , return_slot_t )
 {
     SDBUS_CHECK_INTERFACE_NAME(interfaceName);
@@ -296,12 +296,12 @@ int Proxy::sdbus_async_reply_handler(sd_bus_message *sdbusMessage, void *userDat
         const auto* error = sd_bus_message_get_error(sdbusMessage);
         if (error == nullptr)
         {
-            asyncCallInfo->callback(std::move(message), {});
+            std::move(asyncCallInfo->callback)(std::move(message), {});
         }
         else
         {
             Error exception(Error::Name{error->name}, error->message);
-            asyncCallInfo->callback(std::move(message), std::move(exception));
+            std::move(asyncCallInfo->callback)(std::move(message), std::move(exception));
         }
     }, retError);
 

--- a/src/Proxy.h
+++ b/src/Proxy.h
@@ -104,7 +104,7 @@ namespace sdbus::internal {
 
         friend PendingAsyncCall;
 
-        std::unique_ptr<IConnection, std::function<void(IConnection*)>> connection_;
+        std::unique_ptr<IConnection, std::move_only_function<void(IConnection*)>> connection_;
         ServiceName destination_;
         ObjectPath objectPath_;
 

--- a/src/Proxy.h
+++ b/src/Proxy.h
@@ -60,15 +60,15 @@ namespace sdbus::internal {
         [[nodiscard]] MethodCall createMethodCall(const char* interfaceName, const char* methodName) const override;
         MethodReply callMethod(const MethodCall& message) override;
         MethodReply callMethod(const MethodCall& message, uint64_t timeout) override;
-        PendingAsyncCall callMethodAsync(const MethodCall& message, async_reply_handler asyncReplyCallback) override;
+        PendingAsyncCall callMethodAsync(const MethodCall& message, async_reply_handler&& asyncReplyCallback) override;
         Slot callMethodAsync( const MethodCall& message
-                            , async_reply_handler asyncReplyCallback
+                            , async_reply_handler&& asyncReplyCallback
                             , return_slot_t ) override;
         PendingAsyncCall callMethodAsync( const MethodCall& message
-                                        , async_reply_handler asyncReplyCallback
+                                        , async_reply_handler&& asyncReplyCallback
                                         , uint64_t timeout ) override;
         Slot callMethodAsync( const MethodCall& message
-                            , async_reply_handler asyncReplyCallback
+                            , async_reply_handler&& asyncReplyCallback
                             , uint64_t timeout
                             , return_slot_t ) override;
         std::future<MethodReply> callMethodAsync(const MethodCall& message, with_future_t) override;
@@ -80,17 +80,17 @@ namespace sdbus::internal {
 
         void registerSignalHandler( const InterfaceName& interfaceName
                                   , const SignalName& signalName
-                                  , signal_handler signalHandler ) override;
+                                  , signal_handler&& signalHandler ) override;
         void registerSignalHandler( const char* interfaceName
                                   , const char* signalName
-                                  , signal_handler signalHandler ) override;
+                                  , signal_handler&& signalHandler ) override;
         Slot registerSignalHandler( const InterfaceName& interfaceName
                                   , const SignalName& signalName
-                                  , signal_handler signalHandler
+                                  , signal_handler&& signalHandler
                                   , return_slot_t ) override;
         Slot registerSignalHandler( const char* interfaceName
                                   , const char* signalName
-                                  , signal_handler signalHandler
+                                  , signal_handler&& signalHandler
                                   , return_slot_t ) override;
         void unregister() override;
 

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -57,7 +57,7 @@
 namespace sdbus::internal {
 
     template <typename Callable>
-    bool invokeHandlerAndCatchErrors(Callable callable, sd_bus_error *retError)
+    bool invokeHandlerAndCatchErrors(const Callable& callable, sd_bus_error *retError)
     {
         try
         {

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -57,11 +57,11 @@
 namespace sdbus::internal {
 
     template <typename Callable>
-    bool invokeHandlerAndCatchErrors(const Callable& callable, sd_bus_error *retError)
+    bool invokeHandlerAndCatchErrors(Callable&& callable, sd_bus_error *retError)
     {
         try
         {
-            callable();
+            std::forward<Callable>(callable)();
         }
         catch (const Error& e)
         {

--- a/tests/integrationtests/DBusMethodsTests.cpp
+++ b/tests/integrationtests/DBusMethodsTests.cpp
@@ -36,6 +36,7 @@
 #include <memory>
 #include <string>
 #include <chrono>
+#include <utility>
 #include <vector>
 #include <variant>
 

--- a/tests/integrationtests/DBusMethodsTests.cpp
+++ b/tests/integrationtests/DBusMethodsTests.cpp
@@ -36,7 +36,6 @@
 #include <memory>
 #include <string>
 #include <chrono>
-#include <utility>
 #include <vector>
 #include <variant>
 

--- a/tests/integrationtests/DBusMethodsTests.cpp
+++ b/tests/integrationtests/DBusMethodsTests.cpp
@@ -350,10 +350,10 @@ TYPED_TEST(SdbusTestObject, CanRegisterAdditionalVTableDynamicallyAtAnyTime)
 {
     auto& object = this->m_adaptor->getObject();
     sdbus::InterfaceName const interfaceName{"org.sdbuscpp.integrationtests2"};
-    auto vtableSlot = object.addVTable( interfaceName
-                                      , { sdbus::registerMethod("add").implementedAs([](const double& lhs, const double& rhs){ return lhs + rhs; })
-                                        , sdbus::registerMethod("subtract").implementedAs([](const int& lhs, const int& rhs){ return lhs - rhs; }) }
-                                      , sdbus::return_slot );
+    std::vector<sdbus::VTableItem> vtable;
+    vtable.emplace_back(sdbus::registerMethod("add").implementedAs([](const double& lhs, const double& rhs){ return lhs + rhs; }));
+    vtable.emplace_back(sdbus::registerMethod("subtract").implementedAs([](const int& lhs, const int& rhs){ return lhs - rhs; }));
+    auto vtableSlot = object.addVTable(interfaceName, std::move(vtable), sdbus::return_slot);
 
     // The new remote vtable is registered as long as we keep vtableSlot, so remote method calls now should pass
     auto proxy = sdbus::createLightWeightProxy(SERVICE_NAME, OBJECT_PATH);
@@ -368,10 +368,10 @@ TYPED_TEST(SdbusTestObject, CanUnregisterAdditionallyRegisteredVTableAtAnyTime)
     auto& object = this->m_adaptor->getObject();
     sdbus::InterfaceName const interfaceName{"org.sdbuscpp.integrationtests2"};
 
-    auto vtableSlot = object.addVTable( interfaceName
-                                      , { sdbus::registerMethod("add").implementedAs([](const double& lhs, const double& rhs){ return lhs + rhs; })
-                                        , sdbus::registerMethod("subtract").implementedAs([](const int& lhs, const int& rhs){ return lhs - rhs; }) }
-                                      , sdbus::return_slot );
+    std::vector<sdbus::VTableItem> vtable;
+    vtable.emplace_back(sdbus::registerMethod("add").implementedAs([](const double& lhs, const double& rhs){ return lhs + rhs; }));
+    vtable.emplace_back(sdbus::registerMethod("subtract").implementedAs([](const int& lhs, const int& rhs){ return lhs - rhs; }));
+    auto vtableSlot = object.addVTable(interfaceName, std::move(vtable), sdbus::return_slot);
     vtableSlot.reset(); // Letting the slot go means letting go the associated vtable registration
 
     // No such remote D-Bus method under given interface exists anymore...

--- a/tests/integrationtests/DBusMethodsTests.cpp
+++ b/tests/integrationtests/DBusMethodsTests.cpp
@@ -351,10 +351,9 @@ TYPED_TEST(SdbusTestObject, CanRegisterAdditionalVTableDynamicallyAtAnyTime)
 {
     auto& object = this->m_adaptor->getObject();
     sdbus::InterfaceName const interfaceName{"org.sdbuscpp.integrationtests2"};
-    std::vector<sdbus::VTableItem> vtable;
-    vtable.emplace_back(sdbus::registerMethod("add").implementedAs([](const double& lhs, const double& rhs){ return lhs + rhs; }));
-    vtable.emplace_back(sdbus::registerMethod("subtract").implementedAs([](const int& lhs, const int& rhs){ return lhs - rhs; }));
-    auto vtableSlot = object.addVTable(interfaceName, std::move(vtable), sdbus::return_slot);
+    auto vtableSlot = object.addVTable( sdbus::registerMethod("add").implementedAs([](const double& lhs, const double& rhs){ return lhs + rhs; })
+                                      , sdbus::registerMethod("subtract").implementedAs([](const int& lhs, const int& rhs){ return lhs - rhs; })
+                                      ).forInterface(interfaceName, sdbus::return_slot);
 
     // The new remote vtable is registered as long as we keep vtableSlot, so remote method calls now should pass
     auto proxy = sdbus::createLightWeightProxy(SERVICE_NAME, OBJECT_PATH);
@@ -368,11 +367,10 @@ TYPED_TEST(SdbusTestObject, CanUnregisterAdditionallyRegisteredVTableAtAnyTime)
 {
     auto& object = this->m_adaptor->getObject();
     sdbus::InterfaceName const interfaceName{"org.sdbuscpp.integrationtests2"};
+    auto vtableSlot = object.addVTable( sdbus::registerMethod("add").implementedAs([](const double& lhs, const double& rhs){ return lhs + rhs; })
+                                      , sdbus::registerMethod("subtract").implementedAs([](const int& lhs, const int& rhs){ return lhs - rhs; })
+                                      ).forInterface(interfaceName, sdbus::return_slot);
 
-    std::vector<sdbus::VTableItem> vtable;
-    vtable.emplace_back(sdbus::registerMethod("add").implementedAs([](const double& lhs, const double& rhs){ return lhs + rhs; }));
-    vtable.emplace_back(sdbus::registerMethod("subtract").implementedAs([](const int& lhs, const int& rhs){ return lhs - rhs; }));
-    auto vtableSlot = object.addVTable(interfaceName, std::move(vtable), sdbus::return_slot);
     vtableSlot.reset(); // Letting the slot go means letting go the associated vtable registration
 
     // No such remote D-Bus method under given interface exists anymore...


### PR DESCRIPTION
This PR:

- bumps c++-version to 23
- uses `std::move_only_function` for one-shot callbacks
- sprinkles some `mutable` for lambdas moving captures out
- disabled clang-format

The lambdas made mutable were for different reasons. In a few spots, there were lambdas capturing something and then using `std::move()` to move the capture out on invocation. That only works correctly if the lambdas is mutable, Without mutable, the capture is `const` and you'll get a `const T&&`, which is not what you want.

Not all callbacks are converted to `std::move_only_function` either. I only did that for "one-shot callbacks". In contrast to `std::function`, the invocation operator of `std::move_only_function` is not const-qualified. It may change internal state (and not be safe for repeated invocation).

Clang-format I have disabled because there were no formatting rules, causing default rules to be automatically applied whenever I save a file. I do think it could be a good idea to settle on a particular formatting at some point.

Note that I didn't change any of the tests. That's not necessary, because it's OK to move an `std::function` into an `std::move_only_function` (but not the other way around). This shows that the changes are an _ABI-break_ but not an _API-break_.