### PR TITLE
ci: fix ctest run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
     - name: verify
       run: |
         sudo cmake --build _build --target install
-        ctest --output-on-failure
+        ctest --output-on-failure --test-dir _build
     - name: pack
       if: matrix.build == 'shared-libsystemd'
       run: |


### PR DESCRIPTION
There was a bug which caused no tests to be run in the CI jobs.