### PR TITLE
Allow custom callbacks in proxy generator

### DIFF
--- a/docs/using-sdbus-c++.md
+++ b/docs/using-sdbus-c++.md
@@ -1310,13 +1310,17 @@ sdbus-c++-xml2cpp can generate C++ code for client-side async methods. We just n
 </node>
 ```
 
-An asynchronous method can be generated as a callback-based method, `std::future`-based method, or C++20 awaitable-based method. This can optionally be customized through an additional `org.freedesktop.DBus.Method.Async.ClientImpl` annotation. Its supported values are `callback`, `future` and `awaitable`. The default behavior is callback-based method.
+An asynchronous method can be generated as a callback-based method, `std::future`-based method, or C++20 awaitable-based method. This can optionally be customized through an additional `org.freedesktop.DBus.Method.Async.ClientImpl` annotation. Its supported values are `callback`, `direct-callback`, `future` and `awaitable`. The default behavior is callback-based method.
 
 #### Generating callback-based async methods
 
 For each client-side async method, a corresponding `on<MethodName>Reply` pure virtual function, where `<MethodName>` is the capitalized D-Bus method name, is generated in the generated proxy class. This function is the callback invoked when the D-Bus method reply arrives, and must be provided a body by overriding it in the implementation class.
 
-So in the specific example above, the tool will generate a `Concatenator_proxy` class similar to one shown in a [dedicated section above](#concatenator-client-glueh), with the difference that it will also generate an additional `virtual void onConcatenateReply(std::optional<sdbus::Error> error, const std::string& concatenatedString);` method, which we shall override in the derived `ConcatenatorProxy`.
+So in the specific example above, the tool will generate a `Concatenator_proxy` class similar to one shown in a [dedicated section above](#concatenator-client-glueh), with the difference that it will also generate an additional `virtual void onConcatenateReply(const std::string& concatenatedString, std::optional<sdbus::Error> error);` method, which we shall override in the derived `ConcatenatorProxy`.
+
+#### Generating direct callback-based async methods
+
+An additional callback parameter is added to the function signature. The callback is called when the D-Bus method reply arrives. The callback can be any generic callable that takes the method output arguments (`const std::string&` in this example), followed by the parameter of type `std::optional<sdbus::Error> error`.
 
 #### Generating std::future-based async methods
 

--- a/tools/xml2cpp-codegen/ProxyGenerator.cpp
+++ b/tools/xml2cpp-codegen/ProxyGenerator.cpp
@@ -246,7 +246,7 @@ std::tuple<std::string, std::string> ProxyGenerator::processMethods(const Nodes&
         if (asyncImpl.has_value() && *asyncImpl == AsyncImpl::DirectCallback)
         {
             definitionSS << tab << "template <typename F>" << endl
-                << tab << realRetType << " " << nameSafe << "(" << inArgTypeStr << (not inArgTypeStr.empty() ? ", " : "") << "F && callback" << ")" << endl
+                << tab << realRetType << " " << nameSafe << "(" << inArgTypeStr << (not inArgTypeStr.empty() ? ", " : "") << "F&& callback" << ")" << endl
                 << tab << "{" << endl;
         }
         else
@@ -343,7 +343,7 @@ std::tuple<std::string, std::string> ProxyGenerator::processSignals(const Nodes&
                 ".call([this](" << argTypeStr << ")"
                 "{ this->on" << nameBigFirst << "(" << argStr << "); });" << endl;
 
-        declarationSS << tab << "virtual void on" << nameBigFirst << "(" << argTypeStr << ") {};" << endl;
+        declarationSS << tab << "virtual void on" << nameBigFirst << "(" << argTypeStr << ") {}" << endl;
     }
 
     return std::make_tuple(registrationSS.str(), declarationSS.str());
@@ -425,7 +425,7 @@ std::tuple<std::string, std::string> ProxyGenerator::processProperties(const Nod
             if (asyncImplGet.has_value() && asyncImplGet.value() == AsyncImpl::DirectCallback)
             {
                 propertySS << tab << "template <typename F>" << endl
-                    << tab << realRetType << " " << propertyNameSafe << "(F && callback)" << endl;
+                    << tab << realRetType << " " << propertyNameSafe << "(F&& callback)" << endl;
             }
             else
             {
@@ -493,7 +493,7 @@ std::tuple<std::string, std::string> ProxyGenerator::processProperties(const Nod
             if (asyncImplSet.has_value() && asyncImplSet.value() == AsyncImpl::DirectCallback)
             {
                 propertySS << tab << "template <typename F>" << endl
-                    << tab << realRetType << " " << propertyNameSafe << "(" << propertyTypeArg << (not propertyTypeArg.empty() ? ", " : "") << "F && callback)" << endl;
+                    << tab << realRetType << " " << propertyNameSafe << "(" << propertyTypeArg << (not propertyTypeArg.empty() ? ", " : "") << "F&& callback)" << endl;
             }
             else
             {

--- a/tools/xml2cpp-codegen/ProxyGenerator.cpp
+++ b/tools/xml2cpp-codegen/ProxyGenerator.cpp
@@ -43,7 +43,7 @@ using sdbuscpp::xml::Node;
 using sdbuscpp::xml::Nodes;
 
 // Possible implementation backends of async methods
-enum class AsyncImpl { Callback, Future, Awaitable };
+enum class AsyncImpl { Callback, Future, Awaitable, DirectCallback };
 
 /**
  * Generate proxy code - client glue
@@ -178,9 +178,16 @@ std::tuple<std::string, std::string> ProxyGenerator::processMethods(const Nodes&
             {
                 if (annotationName == "org.freedesktop.DBus.Method.Async"
                      && (annotationValue == "client" || annotationValue == "clientserver" || annotationValue == "client-server"))
-                    asyncImpl = AsyncImpl::Callback; // Default to callback
+                {
+                    if (not asyncImpl.has_value())
+                    {
+                        asyncImpl = AsyncImpl::Callback; // Default to callback
+                    }
+                }
                 else if (annotationName == "org.freedesktop.DBus.Method.Async.ClientImpl" && annotationValue == "callback")
                     asyncImpl = AsyncImpl::Callback;
+                else if (annotationName == "org.freedesktop.DBus.Method.Async.ClientImpl" && annotationValue == "direct-callback")
+                    asyncImpl = AsyncImpl::DirectCallback;
                 else if (annotationName == "org.freedesktop.DBus.Method.Async.ClientImpl" && (annotationValue == "future" || annotationValue == "std::future"))
                     asyncImpl = AsyncImpl::Future;
                 else if (annotationName == "org.freedesktop.DBus.Method.Async.ClientImpl" && (annotationValue == "awaitable" || annotationValue == "coroutine"))
@@ -236,8 +243,17 @@ std::tuple<std::string, std::string> ProxyGenerator::processMethods(const Nodes&
             realRetType = retType;
         }
 
-        definitionSS << tab << realRetType << " " << nameSafe << "(" << inArgTypeStr << ")" << endl
+        if (asyncImpl.has_value() && *asyncImpl == AsyncImpl::DirectCallback)
+        {
+            definitionSS << tab << "template <typename F>" << endl
+                << tab << realRetType << " " << nameSafe << "(" << inArgTypeStr << (not inArgTypeStr.empty() ? ", " : "") << "F && callback" << ")" << endl
                 << tab << "{" << endl;
+        }
+        else
+        {
+            definitionSS << tab << realRetType << " " << nameSafe << "(" << inArgTypeStr << ")" << endl
+                    << tab << "{" << endl;
+        }
 
         if (!timeoutValue.empty())
         {
@@ -276,6 +292,10 @@ std::tuple<std::string, std::string> ProxyGenerator::processMethods(const Nodes&
             else if (*asyncImpl == AsyncImpl::Awaitable)
             {
                 definitionSS << ".getResultAsAwaitable<" << retTypeBare << ">()";
+            }
+            else if (*asyncImpl == AsyncImpl::DirectCallback)
+            {
+                definitionSS << ".uponReplyInvoke(std::forward<F>(callback))";
             }
             else // Callback
             {
@@ -323,7 +343,7 @@ std::tuple<std::string, std::string> ProxyGenerator::processSignals(const Nodes&
                 ".call([this](" << argTypeStr << ")"
                 "{ this->on" << nameBigFirst << "(" << argStr << "); });" << endl;
 
-        declarationSS << tab << "virtual void on" << nameBigFirst << "(" << argTypeStr << ") = 0;" << endl;
+        declarationSS << tab << "virtual void on" << nameBigFirst << "(" << argTypeStr << ") {};" << endl;
     }
 
     return std::make_tuple(registrationSS.str(), declarationSS.str());
@@ -353,17 +373,31 @@ std::tuple<std::string, std::string> ProxyGenerator::processProperties(const Nod
             const auto annotationValue = annotation->get("value");
 
             if (annotationName == "org.freedesktop.DBus.Property.Get.Async" && annotationValue == "client") // Server-side not supported (may be in the future)
-                asyncImplGet = AsyncImpl::Callback; // Default to callback
+            {
+                if (not asyncImplGet.has_value())
+                {
+                    asyncImplGet = AsyncImpl::Callback; // Default to callback
+                }
+            }
             else if (annotationName == "org.freedesktop.DBus.Property.Get.Async.ClientImpl" && annotationValue == "callback")
                 asyncImplGet = AsyncImpl::Callback;
+            else if (annotationName == "org.freedesktop.DBus.Property.Get.Async.ClientImpl" && annotationValue == "direct-callback")
+                asyncImplGet = AsyncImpl::DirectCallback;
             else if (annotationName == "org.freedesktop.DBus.Property.Get.Async.ClientImpl" && (annotationValue == "future" || annotationValue == "std::future"))
                 asyncImplGet = AsyncImpl::Future;
             else if (annotationName == "org.freedesktop.DBus.Property.Get.Async.ClientImpl" && (annotationValue == "awaitable" || annotationValue == "coroutine"))
                 asyncImplGet = AsyncImpl::Awaitable;
             else if (annotationName == "org.freedesktop.DBus.Property.Set.Async" && annotationValue == "client") // Server-side not supported (may be in the future)
-                asyncImplSet = AsyncImpl::Callback; // Default to callback
+            {
+                if (not asyncImplSet.has_value())
+                {
+                    asyncImplSet = AsyncImpl::Callback; // Default to callback
+                }
+            }
             else if (annotationName == "org.freedesktop.DBus.Property.Set.Async.ClientImpl" && annotationValue == "callback")
                 asyncImplSet = AsyncImpl::Callback;
+            else if (annotationName == "org.freedesktop.DBus.Property.Set.Async.ClientImpl" && annotationValue == "direct-callback")
+                asyncImplSet = AsyncImpl::DirectCallback;
             else if (annotationName == "org.freedesktop.DBus.Property.Set.Async.ClientImpl" && (annotationValue == "future" || annotationValue == "std::future"))
                 asyncImplSet = AsyncImpl::Future;
             else if (annotationName == "org.freedesktop.DBus.Property.Set.Async.ClientImpl" && (annotationValue == "awaitable" || annotationValue == "coroutine"))
@@ -388,10 +422,20 @@ std::tuple<std::string, std::string> ProxyGenerator::processProperties(const Nod
                 realRetType = propertyType;
             }
 
-            propertySS << tab << realRetType << " " << propertyNameSafe << "()" << endl
-                    << tab << "{" << endl;
+            if (asyncImplGet.has_value() && asyncImplGet.value() == AsyncImpl::DirectCallback)
+            {
+                propertySS << tab << "template <typename F>" << endl
+                    << tab << realRetType << " " << propertyNameSafe << "(F && callback)" << endl;
+            }
+            else
+            {
+                propertySS << tab << realRetType << " " << propertyNameSafe << "()" << endl;
+            }
+
+            propertySS << tab << "{" << endl;
             propertySS << tab << tab << "return m_proxy.getProperty" << (asyncImplGet.has_value() ? "Async" : "") << "(\"" << propertyName << "\")"
                             ".onInterface(INTERFACE_NAME)";
+
             if (!asyncImplGet.has_value())
             {
                 propertySS << ".get<" << realRetType << ">()";
@@ -408,6 +452,10 @@ std::tuple<std::string, std::string> ProxyGenerator::processProperties(const Nod
                 else if (*asyncImplGet == AsyncImpl::Awaitable)
                 {
                     propertySS << ".getResultAsAwaitable()";
+                }
+                else if (*asyncImplGet == AsyncImpl::DirectCallback)
+                {
+                    propertySS << ".uponReplyInvoke(std::forward<F>(callback))";
                 }
                 else // Callback
                 {
@@ -442,8 +490,17 @@ std::tuple<std::string, std::string> ProxyGenerator::processProperties(const Nod
                 realRetType = "void";
             }
 
-            propertySS << tab << realRetType << " " << propertyNameSafe << "(" << propertyTypeArg << ")" << endl
-                       << tab << "{" << endl;
+            if (asyncImplSet.has_value() && asyncImplSet.value() == AsyncImpl::DirectCallback)
+            {
+                propertySS << tab << "template <typename F>" << endl
+                    << tab << realRetType << " " << propertyNameSafe << "(" << propertyTypeArg << (not propertyTypeArg.empty() ? ", " : "") << "F && callback)" << endl;
+            }
+            else
+            {
+                propertySS << tab << realRetType << " " << propertyNameSafe << "(" << propertyTypeArg << ")" << endl;
+            }
+
+            propertySS << tab << "{" << endl;
             propertySS << tab << tab << (asyncImplSet.has_value() ? "return " : "") << "m_proxy.setProperty" << (asyncImplSet.has_value() ? "Async" : "")
                        << "(\"" << propertyName << "\")"
                             ".onInterface(INTERFACE_NAME)"
@@ -461,6 +518,10 @@ std::tuple<std::string, std::string> ProxyGenerator::processProperties(const Nod
                 else if (*asyncImplSet == AsyncImpl::Awaitable)
                 {
                     propertySS << ".getResultAsAwaitable()";
+                }
+                else if (*asyncImplSet == AsyncImpl::DirectCallback)
+                {
+                    propertySS << ".uponReplyInvoke(std::forward<T>(callback))";
                 }
                 else // Callback
                 {


### PR DESCRIPTION
Adds new value `direct-callback` for annotation `org.freedesktop.DBus.Method.Async.ClientImpl`, which generates proxy method interfaces that accept custom callback as an argument.

This (in my opinion) is infinitely more convenient to use than standard `callback`-generated interfaces that require overriding virtual functions in a derived proxy class to implement a callback, which implies that we need to create a separate derived class for each separate access scenario of the interface.

This change also adds empty default implementation to the signal handlers, removing the need to implement them, in case you don't use them.