### PR TITLE
fix: prevent ambiguous call by calling signal handler with std::nullopt

### DIFF
--- a/docs/using-sdbus-c++.md
+++ b/docs/using-sdbus-c++.md
@@ -611,10 +611,10 @@ We recommend that sdbus-c++ users prefer the convenience API to the lower level,
 
 > **_Note_:** By default, signal callback handlers are not invoked (i.e., the signal is silently dropped) if there is a signal signature mismatch. If you want to be informed of such situations, you can add `std::optional<sdbus::Error>` parameter to the beginning of your signal callback handler's parameter list. When sdbus-c++ invokes the handler, it will set this argument either to be empty (in normal cases), or to carry a corresponding `sdbus::Error` object (in case of deserialization failures, like type mismatches). An example of a handler with the signature (`int`) different from the real signal contents (`string`):
 > ```c++
->     void onConcatenated(std::optional<sdbus::Error> e, int wrongParameter)
+>     void onConcatenated(std::optional<sdbus::Error> err, int wrongParameter)
 >     {
->         assert(e.has_value());
->         assert(e->getMessage() == "Failed to deserialize a int32 value");
+>         assert(err.has_value());
+>         assert(err->getMessage() == "Failed to deserialize a int32 value");
 >     }
 > ```
 > Signature mismatch in signal handlers is probably the most common reason why signals are not received in the client, while we can see them on the bus with `dbus-monitor`. Use `std::optional<sdbus::Error>`-based callback variant and inspect the error to check if that's the cause of your problems.

--- a/include/sdbus-c++/ConvenienceApiClasses.inl
+++ b/include/sdbus-c++/ConvenienceApiClasses.inl
@@ -462,7 +462,7 @@ namespace sdbus {
                 }
 
                 // Invoke callback with no error and input arguments from the tuple.
-                sdbus::apply(callback, {}, signalArgs);
+                sdbus::apply(callback, std::nullopt, signalArgs);
             }
             else
             {

--- a/include/sdbus-c++/ConvenienceApiClasses.inl
+++ b/include/sdbus-c++/ConvenienceApiClasses.inl
@@ -317,11 +317,11 @@ namespace sdbus {
                 {
                     reply >> args;
                 }
-                catch (const Error& e)
+                catch (const Error& err)
                 {
                     // Pass message deserialization exceptions to the client via callback error parameter,
                     // instead of propagating them up the message loop call stack.
-                    sdbus::apply(callback, e, args);
+                    sdbus::apply(callback, err, args);
                     return;
                 }
             }
@@ -453,11 +453,11 @@ namespace sdbus {
                 {
                     signal >> signalArgs;
                 }
-                catch (const Error& e)
+                catch (const Error& err)
                 {
                     // Pass message deserialization exceptions to the client via callback error parameter,
                     // instead of propagating them up the message loop call stack.
-                    sdbus::apply(callback, e, signalArgs);
+                    sdbus::apply(callback, err, signalArgs);
                     return;
                 }
 

--- a/tests/integrationtests/DBusSignalsTests.cpp
+++ b/tests/integrationtests/DBusSignalsTests.cpp
@@ -114,6 +114,14 @@ TYPED_TEST(SdbusTestObject, EmitsSignalWithoutRegistrationSuccessfully)
     ASSERT_THAT(this->m_proxy->m_signatureFromSignal["platform"], Eq(sdbus::Signature{"av"}));
 }
 
+TYPED_TEST(SdbusTestObject, EmitsSignalWithErrorAndTypeMismatchSuccessfully)
+{
+    this->m_adaptor->emitSignalWithErrorAndTypeMismatch();
+
+    ASSERT_TRUE(waitUntil(this->m_proxy->m_gotSignalWithTypeMismatch));
+    ASSERT_TRUE(this->m_proxy->m_errorFromSignal.has_value());
+}
+
 TYPED_TEST(SdbusTestObject, CanAccessAssociatedSignalMessageInSignalHandler)
 {
     this->m_adaptor->emitSimpleSignal();

--- a/tests/integrationtests/TestAdaptor.cpp
+++ b/tests/integrationtests/TestAdaptor.cpp
@@ -311,6 +311,11 @@ void TestAdaptor::emitSignalWithoutRegistration(const sdbus::Struct<std::string,
     getObject().emitSignal("signalWithoutRegistration").onInterface(sdbus::test::INTERFACE_NAME).withArguments(strct);
 }
 
+void TestAdaptor::emitSignalWithErrorAndTypeMismatch()
+{
+    getObject().emitSignal("signalWithErrorAndTypeMismatch").onInterface(sdbus::test::INTERFACE_NAME);
+}
+
 std::string TestAdaptor::getExpectedXmlApiDescription() 
 {
     return

--- a/tests/integrationtests/TestAdaptor.h
+++ b/tests/integrationtests/TestAdaptor.h
@@ -106,6 +106,7 @@ protected:
 
 public:
     void emitSignalWithoutRegistration(const sdbus::Struct<std::string, sdbus::Struct<sdbus::Signature>>& strct);
+    void emitSignalWithErrorAndTypeMismatch();
     static std::string getExpectedXmlApiDescription() ;
 
 private:

--- a/tests/integrationtests/TestProxy.cpp
+++ b/tests/integrationtests/TestProxy.cpp
@@ -45,7 +45,7 @@ TestProxy::TestProxy(ServiceName destination, ObjectPath objectPath)
     : ProxyInterfaces(std::move(destination), std::move(objectPath))
 {
     getProxy().uponSignal("signalWithoutRegistration").onInterface(sdbus::test::INTERFACE_NAME).call([this](const sdbus::Struct<std::string, sdbus::Struct<sdbus::Signature>>& strct){ this->onSignalWithoutRegistration(strct); });
-    getProxy().uponSignal("signalWithErrorAndTypeMismatch").onInterface(sdbus::test::INTERFACE_NAME).call([this](std::optional<sdbus::Error> e, int wrongParameter){ this->onSignalWithErrorAndTypeMismatch(e, wrongParameter); });
+    getProxy().uponSignal("signalWithErrorAndTypeMismatch").onInterface(sdbus::test::INTERFACE_NAME).call([this](std::optional<sdbus::Error> err, int wrongParameter){ this->onSignalWithErrorAndTypeMismatch(std::move(err), wrongParameter); });
 
     registerProxy();
 }
@@ -61,7 +61,7 @@ TestProxy::TestProxy(sdbus::IConnection& connection, ServiceName destination, Ob
     : ProxyInterfaces(connection, std::move(destination), std::move(objectPath))
 {
     getProxy().uponSignal("signalWithoutRegistration").onInterface(sdbus::test::INTERFACE_NAME).call([this](const sdbus::Struct<std::string, sdbus::Struct<sdbus::Signature>>& strct){ this->onSignalWithoutRegistration(strct); });
-    getProxy().uponSignal("signalWithErrorAndTypeMismatch").onInterface(sdbus::test::INTERFACE_NAME).call([this](std::optional<sdbus::Error> e, int wrongParameter){ this->onSignalWithErrorAndTypeMismatch(e, wrongParameter); });
+    getProxy().uponSignal("signalWithErrorAndTypeMismatch").onInterface(sdbus::test::INTERFACE_NAME).call([this](std::optional<sdbus::Error> err, int wrongParameter){ this->onSignalWithErrorAndTypeMismatch(std::move(err), wrongParameter); });
 
     registerProxy();
 }
@@ -98,9 +98,9 @@ void TestProxy::onSignalWithoutRegistration(const sdbus::Struct<std::string, sdb
     m_gotSignalWithSignature = true;
 }
 
-void TestProxy::onSignalWithErrorAndTypeMismatch(std::optional<sdbus::Error> e, [[maybe_unused]] int wrongParameter)
+void TestProxy::onSignalWithErrorAndTypeMismatch(std::optional<sdbus::Error> err, [[maybe_unused]] int wrongParameter)
 {
-    m_errorFromSignal = e;
+    m_errorFromSignal = std::move(err);
     m_gotSignalWithTypeMismatch = true;
 }
 

--- a/tests/integrationtests/TestProxy.cpp
+++ b/tests/integrationtests/TestProxy.cpp
@@ -45,6 +45,7 @@ TestProxy::TestProxy(ServiceName destination, ObjectPath objectPath)
     : ProxyInterfaces(std::move(destination), std::move(objectPath))
 {
     getProxy().uponSignal("signalWithoutRegistration").onInterface(sdbus::test::INTERFACE_NAME).call([this](const sdbus::Struct<std::string, sdbus::Struct<sdbus::Signature>>& strct){ this->onSignalWithoutRegistration(strct); });
+    getProxy().uponSignal("signalWithErrorAndTypeMismatch").onInterface(sdbus::test::INTERFACE_NAME).call([this](std::optional<sdbus::Error> e, int wrongParameter){ this->onSignalWithErrorAndTypeMismatch(e, wrongParameter); });
 
     registerProxy();
 }
@@ -60,6 +61,7 @@ TestProxy::TestProxy(sdbus::IConnection& connection, ServiceName destination, Ob
     : ProxyInterfaces(connection, std::move(destination), std::move(objectPath))
 {
     getProxy().uponSignal("signalWithoutRegistration").onInterface(sdbus::test::INTERFACE_NAME).call([this](const sdbus::Struct<std::string, sdbus::Struct<sdbus::Signature>>& strct){ this->onSignalWithoutRegistration(strct); });
+    getProxy().uponSignal("signalWithErrorAndTypeMismatch").onInterface(sdbus::test::INTERFACE_NAME).call([this](std::optional<sdbus::Error> e, int wrongParameter){ this->onSignalWithErrorAndTypeMismatch(e, wrongParameter); });
 
     registerProxy();
 }
@@ -94,6 +96,12 @@ void TestProxy::onSignalWithoutRegistration(const sdbus::Struct<std::string, sdb
     // Static cast to std::string is a workaround for gcc 11.4 false positive warning (which later gcc versions nor Clang emit)
     m_signatureFromSignal[std::get<0>(strct)] = static_cast<std::string>(std::get<0>(std::get<1>(strct)));
     m_gotSignalWithSignature = true;
+}
+
+void TestProxy::onSignalWithErrorAndTypeMismatch(std::optional<sdbus::Error> e, int wrongParameter)
+{
+    m_errorFromSignal = e;
+    m_gotSignalWithTypeMismatch = true;
 }
 
 void TestProxy::onDoOperationReply(uint32_t returnValue, std::optional<sdbus::Error> error) const

--- a/tests/integrationtests/TestProxy.cpp
+++ b/tests/integrationtests/TestProxy.cpp
@@ -98,7 +98,7 @@ void TestProxy::onSignalWithoutRegistration(const sdbus::Struct<std::string, sdb
     m_gotSignalWithSignature = true;
 }
 
-void TestProxy::onSignalWithErrorAndTypeMismatch(std::optional<sdbus::Error> e, int wrongParameter)
+void TestProxy::onSignalWithErrorAndTypeMismatch(std::optional<sdbus::Error> e, [[maybe_unused]] int wrongParameter)
 {
     m_errorFromSignal = e;
     m_gotSignalWithTypeMismatch = true;

--- a/tests/integrationtests/TestProxy.h
+++ b/tests/integrationtests/TestProxy.h
@@ -94,6 +94,7 @@ protected:
     void onSignalWithVariant(const sdbus::Variant& aVariant) override;
 
     void onSignalWithoutRegistration(const sdbus::Struct<std::string, sdbus::Struct<sdbus::Signature>>& strct);
+    void onSignalWithErrorAndTypeMismatch(std::optional<sdbus::Error> e, int wrongParameter);
     void onDoOperationReply(uint32_t returnValue, std::optional<sdbus::Error> error) const;
 
     // Signals of standard D-Bus interfaces
@@ -130,6 +131,8 @@ public:
     double m_variantFromSignal{};
     std::atomic<bool> m_gotSignalWithSignature{false};
     std::map<std::string, Signature> m_signatureFromSignal;
+    std::atomic<bool> m_gotSignalWithTypeMismatch{false};
+    std::optional<sdbus::Error> m_errorFromSignal;
 
     std::function<void(uint32_t res, std::optional<sdbus::Error> err)> m_DoOperationClientSideAsyncReplyHandler;
     std::function<void(const sdbus::InterfaceName&, const std::map<PropertyName, sdbus::Variant>&, const std::vector<PropertyName>&)> m_onPropertiesChangedHandler;

--- a/tests/integrationtests/TestProxy.h
+++ b/tests/integrationtests/TestProxy.h
@@ -94,7 +94,7 @@ protected:
     void onSignalWithVariant(const sdbus::Variant& aVariant) override;
 
     void onSignalWithoutRegistration(const sdbus::Struct<std::string, sdbus::Struct<sdbus::Signature>>& strct);
-    void onSignalWithErrorAndTypeMismatch(std::optional<sdbus::Error> e, int wrongParameter);
+    void onSignalWithErrorAndTypeMismatch(std::optional<sdbus::Error> err, int wrongParameter);
     void onDoOperationReply(uint32_t returnValue, std::optional<sdbus::Error> error) const;
 
     // Signals of standard D-Bus interfaces


### PR DESCRIPTION
This fixes the following compilation error:
```cpp
/sdbus-cpp/include/sdbus-c++/ConvenienceApiClasses.inl:465:29: error: call of overloaded ‘apply(const sdbus::test::TestProxy::TestProxy(sdbus::IConnection&, sdbus::ServiceName, sdbus::ObjectPath)::<lambda(std::optional<sdbus::Error>, int)>&, <brace-enclosed initializer list>, sdbus::tuple_of_function_input_arg_types_t<sdbus::test::TestProxy::TestProxy(sdbus::IConnection&, sdbus::ServiceName, sdbus::ObjectPath)::<lambda(std::optional<sdbus::Error>, int)> >&)’ is ambiguous
  465 |                 sdbus::apply(callback, {}, signalArgs);
      |                 ~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~
/sdbus-cpp/include/sdbus-c++/TypeTraits.h:682:30: note: candidate: ‘constexpr decltype(auto) sdbus::apply(Function&&, Result<Args ...>&&, Tuple&&) [with Function = const test::TestProxy::TestProxy(sdbus::IConnection&, sdbus::ServiceName, sdbus::ObjectPath)::<lambda(std::optional<Error>, int)>&; Tuple = std::tuple<int>&; Args = {}]’
  682 |     constexpr decltype(auto) apply(Function&& fun, Result<Args...>&& res, Tuple&& tuple)
      |                              ^~~~~
/sdbus-cpp/include/sdbus-c++/TypeTraits.h:693:20: note: candidate: ‘decltype(auto) sdbus::apply(Function&&, std::optional<Error>, Tuple&&) [with Function = const test::TestProxy::TestProxy(sdbus::IConnection&, sdbus::ServiceName, sdbus::ObjectPath)::<lambda(std::optional<Error>, int)>&; Tuple = std::tuple<int>&]’
  693 |     decltype(auto) apply(Function&& fun, std::optional<Error> err, Tuple&& tuple)
      |                    ^~~~~
```